### PR TITLE
changed precison threshold for LogSoftmax test

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -472,7 +472,7 @@ function nntest.LogSoftmax()
    local module = nn.LogSoftMax()
 
    local err = jac.testJacobian(module,input)
-   mytester:assertlt(err,3*expprecision, 'error on state ')
+   mytester:assertlt(err,1e-3, 'error on state ')
 
    local ferr,berr = jac.testIO(module,input)
    mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err ')


### PR DESCRIPTION
The previous threshold was insufficient and the test occasionally failed. I ran it a large number of times (~1e5) and the actual error reached ~ 2x1e-4, so I propose 3*1e-10 as the new safer threshold.
