### PR TITLE
Add minibatch support for nn.JoinTable and nn.SplitTable

### DIFF
--- a/JoinTable.lua
+++ b/JoinTable.lua
@@ -1,18 +1,11 @@
 local JoinTable, parent = torch.class('nn.JoinTable', 'nn.Module')
 
-function JoinTable:__init(dimension)
+function JoinTable:__init(dimension, nInputDims)
    parent.__init(self)
    self.size = torch.LongStorage()
    self.dimension = dimension
    self.gradInput = {}
-   self.nInputDims = nil
-end 
-
--- Sets the expected number of dimensions
--- in a non-minibatch input.
-function JoinTable:setNumInputDims(nInputDims)
    self.nInputDims = nInputDims
-   return self
 end
 
 function JoinTable:updateOutput(input) 
@@ -40,7 +33,6 @@ function JoinTable:updateOutput(input)
       offset = offset + currentOutput:size(dimension)
    end
    return self.output
-
 end
 
 function JoinTable:updateGradInput(input, gradOutput)

--- a/SplitTable.lua
+++ b/SplitTable.lua
@@ -1,17 +1,10 @@
 local SplitTable, parent = torch.class('nn.SplitTable', 'nn.Module')
 
-function SplitTable:__init(dimension)
+function SplitTable:__init(dimension, nInputDims)
    parent.__init(self)
    self.modules = {}
    self.dimension = dimension
-   self.nInputDims = nil
-end
-
--- Sets the expected number of dimensions
--- in a non-minibatch input.
-function SplitTable:setNumInputDims(nInputDims)
    self.nInputDims = nInputDims
-   return self
 end
 
 function SplitTable:updateOutput(input)

--- a/doc/table.md
+++ b/doc/table.md
@@ -93,12 +93,12 @@ which gives the output:
 <a name="nn.SplitTable"/>
 ## SplitTable ##
 
-`module` = `SplitTable(dimension)`
+`module` = `SplitTable(dimension, nInputDims)`
 
 Creates a module that takes a [Tensor](https://github.com/torch/torch7/blob/master/doc/tensor.md#tensor)
 as input and outputs several tables, splitting the Tensor along dimension `dimension`.
 
-The method `setNumInputDims` allows to specify the number of dimensions that
+The optional parameter `nInputDims` allows to specify the number of dimensions that
 this module will receive. This makes it possible to forward both minibatch and
 non-minibatch tensors through the same module.
 
@@ -168,8 +168,7 @@ gives the output:
 
 Example 3:
 ```lua
-mlp=nn.SplitTable(1)
-mlp:setNumInputDims(2)
+mlp=nn.SplitTable(1,2)
 pred=mlp:forward(torch.randn(2,4,3))
 for i,k in pairs(pred) do print(i,k); end
 pred=mlp:forward(torch.randn(4,3))
@@ -260,13 +259,13 @@ end
 <a name="nn.JoinTable"/>
 ## JoinTable ##
 
-`module` = `JoinTable(dimension)`
+`module` = `JoinTable(dimension, nInputDims)`
 
 Creates a module that takes a list of Tensors as input and outputs a 
 [Tensor](https://github.com/torch/torch7/blob/master/doc/tensor.md#tensor)
 by joining them together along dimension `dimension`.
 
-The method `setNumInputDims` allows to specify the number of dimensions that
+The optional parameter `nInputDims` allows to specify the number of dimensions that
 this module will receive. This makes it possible to forward both minibatch and
 non-minibatch tensors through the same module.
 
@@ -313,8 +312,7 @@ gives the output:
 
 Example 2:
 ```lua
-module = nn.JoinTable(2)
-module:setNumInputDims(2)
+module = nn.JoinTable(2,2)
 
 x=torch.randn(3,1)
 y=torch.randn(3,1)

--- a/test/test.lua
+++ b/test/test.lua
@@ -1804,8 +1804,7 @@ function nntest.JoinTable()
    local input = {tensor, tensor}
    local module
    for d = 1,tensor:dim()-1 do
-      module = nn.JoinTable(d)
-      module:setNumInputDims(2)
+      module = nn.JoinTable(d, 2)
       mytester:asserteq(module:forward(input):size(d+1), tensor:size(d+1)*2, "dimension " .. d)
    end
 end
@@ -1822,8 +1821,7 @@ function nntest.SplitTable()
    local input = torch.randn(3,4,5)
    local module
    for d = 1,input:dim()-1 do
-      module = nn.SplitTable(d)
-      module:setNumInputDims(2)
+      module = nn.SplitTable(d, 2)
       mytester:asserteq(#module:forward(input), input:size(d+1), "dimension " .. d)
    end
 end


### PR DESCRIPTION
The method `setNumInputDims` allows forwarding both minibatch and non-minibatch tensors through the same module.
If this method is not used, the behaviour of these modules is the same as before.
