### PR TITLE
updated ConcatTable so that it works with table inputs as well as tensors

### DIFF
--- a/ConcatTable.lua
+++ b/ConcatTable.lua
@@ -30,9 +30,32 @@ function ConcatTable:updateGradInput(input, gradOutput)
    for i,module in ipairs(self.modules) do
       local currentGradInput = module:updateGradInput(input, gradOutput[i])
       if i == 1 then
-         self.gradInput:resizeAs(currentGradInput):copy(currentGradInput)
+         if type(input) == 'table' then
+            assert(type(currentGradInput) == 'table', 
+              'currentGradInput is not a table!')
+            assert(#input == #currentGradInput, 
+              'table size mismatch')
+            -- gradInput is also a table
+            self.gradInput = {}
+            for j = 1, #currentGradInput do
+               self.gradInput[j] = currentGradInput[j]:clone()
+            end
+         else
+            -- gradInput is a tensor
+            self.gradInput:resizeAs(currentGradInput):copy(currentGradInput)
+         end
       else
-         self.gradInput:add(currentGradInput)
+         if type(input) == 'table' then
+            assert(type(currentGradInput) == 'table', 
+               'currentGradInput is not a table!')
+            assert(#input == #currentGradInput, 
+               'table size mismatch')
+            for j = 1, #self.gradInput do
+               self.gradInput[j]:add(currentGradInput[j])
+            end
+         else
+            self.gradInput:add(currentGradInput)
+         end
       end
    end
    return self.gradInput


### PR DESCRIPTION
OK, so this one might not be popular.  I see no reason why ConcatTable should fail when the input is a table...  The documentation does say:

"ConcatTable is a container module that applies each member module to the same input Tensor."

However, it's a pretty trivial code change to allow table inputs as well.  I've found lots of applications where I've run into this limitation.

The commit below is pretty simple and I added a unit test for concat table for all code branches.  Please let me know what you think.

FYI: I'm happy to get rid of the assert calls if you think the string comparison is too expensive.
