### PR TITLE
Corrected BCECriterion test

### DIFF
--- a/test/test.lua
+++ b/test/test.lua
@@ -477,8 +477,9 @@ function nntest.WeightedMSECriterion()
 end
 
 function nntest.BCECriterion()
-   local input = torch.rand(100)
-   local target = input:clone():add(torch.rand(100))
+   local eps = 1e-2
+   local input = torch.rand(100)*(1-eps) + eps/2
+   local target = torch.rand(100)*(1-eps) + eps/2
    local cri = nn.BCECriterion()
    criterionJacobianTest1D(cri, input, target)
 end


### PR DESCRIPTION
Changed test so that 
a) both input and target have entries lying between 0 and 1
b) both input and target have entries at least 0.01 away from 0 / 1. This is needed to make this test stable - it otherwise fails frequently depending on random initialisation (the numerical approximation of the gradient of log(x) and log(1-x) diverges from the actual values near x=0 and x=1)
