### PR TITLE
Update StochasticGradient.lua

### DIFF
--- a/StochasticGradient.lua
+++ b/StochasticGradient.lua
@@ -7,6 +7,7 @@ function StochasticGradient:__init(module, criterion)
    self.shuffleIndices = true
    self.module = module
    self.criterion = criterion
+   self.verbose = true
 end
 
 function StochasticGradient:train(dataset)
@@ -41,16 +42,20 @@ function StochasticGradient:train(dataset)
          end
       end
 
+      currentError = currentError / dataset:size()
+
       if self.hookIteration then
-         self.hookIteration(self, iteration)
+         self.hookIteration(self, iteration, currentError)
       end
 
-      currentError = currentError / dataset:size()
-      print("# current error = " .. currentError)
+      if self.verbose then
+         print("# current error = " .. currentError)
+      end
       iteration = iteration + 1
       currentLearningRate = self.learningRate/(1+iteration*self.learningRateDecay)
       if self.maxIteration > 0 and iteration > self.maxIteration then
          print("# StochasticGradient: you have reached the maximum number of iterations")
+         print("# training error = " .. currentError)
          break
       end
    end


### PR DESCRIPTION
Added default `true` `self.verbose` which will keep outputting the "current error" at every iteration by default (but now it can be disabled)
Computed `currentError` before `hookIteration` so that it can be passed to the function (for printing error rate vs. iteration, for example)
Printed final "training error" (just in case we have disabled the `verbose` option)
