### PR TITLE
Kl divergence

### DIFF
--- a/DistKLDivCriterion.lua
+++ b/DistKLDivCriterion.lua
@@ -1,64 +1,14 @@
 local DistKLDivCriterion, parent = torch.class('nn.DistKLDivCriterion', 'nn.Criterion')
 
-local epsilon = 1e-100
-
 function DistKLDivCriterion:__init()
    parent.__init(self)
    self.sizeAverage = true
 end
 
 function DistKLDivCriterion:updateOutput(input, target)
-   local log = math.log
-   if input:dim() == 1 then
-      self.output = 0
-      for i = 1,input:size(1) do
-         local acc = 0
-         if target[i] > 0 then
-            acc = target[i] * (log(target[i]) - input[i])
-         end
-         self.output = self.output + acc
-      end
-   elseif input:dim() == 2 then
-      self.output = 0
-      for i=1,target:size(1) do
-         local tar = target[i]
-         local inp = input[i]
-         for i = 1,inp:size(1) do
-            local acc = 0
-            if tar[i] > epsilon then
-               acc = tar[i] * (log(tar[i]) - inp[i])
-            end
-            self.output = self.output + acc
-         end
-      end
-      if self.sizeAverage then
-         self.output = self.output / target:size(1)
-      end
-   else
-      error('matrix or vector expected')
-   end
-   return self.output
+   return input.nn.DistKLDivCriterion_updateOutput(self, input, target)  
 end
 
 function DistKLDivCriterion:updateGradInput(input, target)
-   local gradInput = self.gradInput
-   gradInput:resizeAs(input)
-
-   if input:dim() == 1 then
-      for i = 1,input:size(1) do
-         gradInput[i] = -target[i]
-      end
-   else
-      for i=1,target:size(1) do
-         local tar = target[i]
-         for i = 1,tar:size(1) do
-            gradInput[i] = -tar[i]
-         end
-      end
-      if self.sizeAverage then
-         gradInput:div(target:size(1))
-      end
-   end
-
-   return self.gradInput
+   return input.nn.DistKLDivCriterion_updateGradInput(self, input, target)
 end

--- a/doc/criterion.md
+++ b/doc/criterion.md
@@ -107,6 +107,29 @@ function gradUpdate(mlp,x,y,learningRate)
 end
 ```
 
+<a name="nn.DistKLDivCriterion"/>
+## DistKLDivCriterion ##
+
+```lua
+criterion = DistKLDivCriterion()
+```
+
+Kullback–Leibler divergence criterion.  KL divergence is a useful distance 
+measure for continuous distributions and is often useful when performance
+direct regression over the space of (discretely sampled) continuous output 
+distributions.  As with ClassNLLCriterion, the `input` given through a 
+`forward()` is expected to contain _log-probabilities_, however unlike
+ClassNLLCriterion, `input` is not restricted to a 1D vector.
+
+This criterion expect a `target` tensor of the same size as the `input`
+tensor when calling [forward(input, target)](#nn.CriterionForward) and
+[backward(input, target)](#nn.CriterionBackward).
+
+The loss can be described as:
+```lua
+loss(x, target) = sum_{all i}(target_i * (log(target_i) - x_i))
+```
+
 <a name="nn.BCECriterion"/>
 ## BCECriterion ##
 ```lua

--- a/generic/DistKLDivCriterion.c
+++ b/generic/DistKLDivCriterion.c
@@ -1,0 +1,53 @@
+#ifndef TH_GENERIC_FILE
+#define TH_GENERIC_FILE "generic/DistKLDivCriterion.c"
+#else
+
+static int nn_(DistKLDivCriterion_updateOutput)(lua_State *L)
+{
+  THTensor *input = luaT_checkudata(L, 2, torch_Tensor);  
+  THTensor *target = luaT_checkudata(L, 3, torch_Tensor);  
+  int sizeAverage = luaT_getfieldcheckboolean(L, 1, "sizeAverage");
+  real sum;
+
+  sum = 0;
+  TH_TENSOR_APPLY2(real, input, real, target,
+                   sum += *target_data > 0 ? *target_data * (log(*target_data) - *input_data) : 0;)
+
+  if(sizeAverage)
+    sum /= THTensor_(nElement)(input);
+
+  lua_pushnumber(L, sum);
+  lua_setfield(L, 1, "output");
+
+  lua_pushnumber(L, sum);
+  return 1;
+}
+
+static int nn_(DistKLDivCriterion_updateGradInput)(lua_State *L)
+{
+  THTensor *input = luaT_checkudata(L, 2, torch_Tensor);
+  THTensor *target = luaT_checkudata(L, 3, torch_Tensor);
+  int sizeAverage = luaT_getfieldcheckboolean(L, 1, "sizeAverage");
+  THTensor *gradInput = luaT_getfieldcheckudata(L, 1, "gradInput", torch_Tensor);
+  real norm = (sizeAverage ? 1./((real)THTensor_(nElement)(input)) : 1.);
+
+  THTensor_(resizeAs)(gradInput, input);
+  TH_TENSOR_APPLY3(real, gradInput, real, input, real, target,
+                   *gradInput_data = *target_data > 0 ? norm * (-*target_data) : 0;)
+  return 1;
+}
+
+static const struct luaL_Reg nn_(DistKLDivCriterion__) [] = {
+  {"DistKLDivCriterion_updateOutput", nn_(DistKLDivCriterion_updateOutput)},
+  {"DistKLDivCriterion_updateGradInput", nn_(DistKLDivCriterion_updateGradInput)},
+  {NULL, NULL}
+};
+
+static void nn_(DistKLDivCriterion_init)(lua_State *L)
+{
+  luaT_pushmetatable(L, torch_Tensor);
+  luaT_registeratname(L, nn_(DistKLDivCriterion__), "nn");
+  lua_pop(L,1);
+}
+
+#endif

--- a/init.c
+++ b/init.c
@@ -59,6 +59,9 @@
 #include "generic/AbsCriterion.c"
 #include "THGenerateFloatTypes.h"
 
+#include "generic/DistKLDivCriterion.c"
+#include "THGenerateFloatTypes.h"
+
 #include "generic/SparseLinear.c"
 #include "THGenerateFloatTypes.h"
 
@@ -127,6 +130,7 @@ int luaopen_libnn(lua_State *L)
   nn_FloatLogSoftMax_init(L);
   nn_FloatMSECriterion_init(L);
   nn_FloatAbsCriterion_init(L);
+  nn_FloatDistKLDivCriterion_init(L);
   nn_FloatLogSigmoid_init(L);
   nn_FloatSigmoid_init(L);
   nn_FloatSoftMax_init(L);
@@ -163,6 +167,7 @@ int luaopen_libnn(lua_State *L)
   nn_DoubleLogSoftMax_init(L);
   nn_DoubleMSECriterion_init(L);
   nn_DoubleAbsCriterion_init(L);
+  nn_DoubleDistKLDivCriterion_init(L);
   nn_DoubleLogSigmoid_init(L);
   nn_DoubleSigmoid_init(L);
   nn_DoubleSoftMax_init(L);

--- a/test/test.lua
+++ b/test/test.lua
@@ -498,6 +498,15 @@ function nntest.BCECriterion()
    criterionJacobianTest1D(cri, input, target)
 end
 
+function nntest.DistKLDivCriterion()
+   local input = torch.rand(100)
+   local target = input:clone():add(torch.rand(100))
+   local cri = nn.DistKLDivCriterion(true)  -- sizeAverage = true
+   criterionJacobianTest1D(cri, input, target)
+   cri = nn.DistKLDivCriterion(false)  -- sizeAverage = false
+   criterionJacobianTest1D(cri, input, target)
+end
+
 function nntest.LogSigmoid()
    local ini = math.random(10,20)
    local inj = math.random(10,20)


### PR DESCRIPTION
Added a C implementation of KL divergence.   Note that the behaviour when sizeAverage = true has changed slightly...  Actually, I think the BPROP was wrong when input:dim() > 1 and sizeAverage == true.  This is now fixed and it's behaviour is more in line with the MSECriterion.

In addition to be much faster, the input size is now arbitrary (works for any dimension input).

I will upload a CUDA version to cunn as well.
