### PR TITLE
Fixed the recursive type call.

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -114,7 +114,7 @@ function Module:clone(...)
 end
 
 local function recursiveType(param, type_str)
-   if type(param) == 'table' then
+   if torch.type(param) == 'table' then
       for i = 1, #param do
          param[i] = recursiveType(param[i], type_str)
       end


### PR DESCRIPTION
OK, I had a feeling something would break :-(

On my development machine, `print(#nn.Sequential())` returns `0`.  However, I just found out that on another of our machines with a later torch install, the length operator was removed and it returns `nn.Sequential has no length operator`.  Chatting with Soumit it seems like this was due to the addition of lua 5.2 compatibility?

In any case, this means that my recursive function brakes on the newer torch commits.  I've switched to using @nicholas-leonard's type function.  My intention was to avoid recursing into sub-modules and to just recurse into nested tables of tensors (it seemed like the smallest behavioural change).
