### PR TITLE
SelectTable can resize

### DIFF
--- a/SelectTable.lua
+++ b/SelectTable.lua
@@ -15,14 +15,14 @@ local function zeroTableCopy(t1, t2)
    for k, v in pairs(t2) do
       if (torch.type(v) == "table") then
          t1[k] = zeroTableCopy(t1[k] or {}, t2[k])
-      else]
+      else
          if not t1[k] then
             t1[k] = v:clone():zero()
          else
             local tensor = t1[k]
             if not tensor:isSameSizeAs(v) then
-               t[k]:resizeAs(v)
-               t[k]:zero()
+               t1[k]:resizeAs(v)
+               t1[k]:zero()
             end
          end
       end


### PR DESCRIPTION
depends on https://github.com/torch/cutorch/pull/33

fixes #50

``` lua
~/projects/nn$ th
> require 'nn'
true    
                                                                      [0.0150s] 
> st = nn.SelectTable(1)
                                                                      [0.0001s] 
> input = {torch.rand(1)}
                                                                      [0.0001s] 
> gradOutput = torch.rand(1)
                                                                      [0.0001s] 
> st:forward(input)
 0.7282
[torch.DoubleTensor of dimension 1]

                                                                      [0.0001s] 
> print(st:backward(input, gradOutput))
{
  1 : DoubleTensor - size: 1
}
                                                                      [0.0001s] 
> input = {torch.rand(1), torch.rand(1)}
                                                                      [0.0001s] 
> print(st:backward(input, gradOutput))
{
  1 : DoubleTensor - size: 1
  2 : DoubleTensor - size: 1
}
                                                                      [0.0003s] 
> input = {torch.rand(1), torch.rand(1,2), torch.rand(1)}
                                                                      [0.0003s] 
> print(st:backward(input, gradOutput))
{
  1 : DoubleTensor - size: 1
  2 : DoubleTensor - size: 1x2
  3 : DoubleTensor - size: 1
}
```

So now it works for mutable sizes.
