### PR TITLE
Removed redundant multiplication from Threshold.c

### DIFF
--- a/generic/Threshold.c
+++ b/generic/Threshold.c
@@ -24,10 +24,10 @@ static int nn_(Threshold_updateGradInput)(lua_State *L)
   THTensor *gradInput = luaT_getfieldcheckudata(L, 1, "gradInput", torch_Tensor);
 
   THTensor_(resizeAs)(gradInput, input);
-  TH_TENSOR_APPLY3(real, gradInput, real, gradOutput, real, input,      \
-                   if ((*input_data) > threshold) *gradInput_data = 1;  \
-                   else *gradInput_data = 0;                            \
-                   *gradInput_data = (*gradOutput_data) * (*gradInput_data););
+  TH_TENSOR_APPLY3(real, gradInput, real, gradOutput, real, input,       \
+     if ((*input_data) > threshold) *gradInput_data = *gradOutput_data;  \
+     else *gradInput_data = 0;);                                         \
+  
   return 1;
 }
 


### PR DESCRIPTION
This is a REALLY small one.  I would like to change Threshold so that it doesn't perform a multiplication.

The real reason I want this change is because I want to share gradOutputs across convolution and threshold modules...  So the memory location for gradInput and gradOutput are the same (to save memory).  For the old code this wont work because the gradOutput gets set to 1: losing the previous value.

Note that the cunn implementation does not do this multiply.  I'm not sure why the logic was written this way in the first place.
