### PR TITLE
getParameters can return an empty tensor

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -177,6 +177,9 @@ function Module:getParameters()
    -- this function flattens arbitrary lists of parameters,
    -- even complex shared ones
    local function flatten(parameters)
+      if not parameters or #parameters == 0 then
+         return torch.Tensor()
+      end
       local Tensor = parameters[1].new
 
       local storages = {}


### PR DESCRIPTION
If `parameters()` is not defined or returns an empty table, the method `getParameters()` will return an empty tensor.
This piece of code reproduces the two problems (nil and empty table parameters):

```
print(nn.View(1):getParameters())
print(nn.Sequential():getParameters())
```
