### PR TITLE
Give better error messages when trying to use the wrong kind of Tensor.

### DIFF
--- a/ErrorMessages.lua
+++ b/ErrorMessages.lua
@@ -1,0 +1,19 @@
+
+local mt = {
+  __index = function(table, key)
+    error("nn."..key.." is only supported for Float or Double Tensors.")
+  end
+}
+
+local tensors = {
+  torch.ByteTensor,
+  torch.CharTensor,
+  torch.ShortTensor,
+  torch.IntTensor,
+  torch.LongTensor,
+}
+
+for _, t in ipairs(tensors) do
+  t.nn = {}
+  setmetatable(t.nn, mt)
+end

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,7 @@
 require('torch')
 require('libnn')
 
+include('ErrorMessages.lua')
 include('Module.lua')
 
 include('Concat.lua')


### PR DESCRIPTION
This patches gives better error messages when using the wrong kind of Tensor for the parts of nn written in C.

```
require 'nn'
local t = torch.ByteTensor(5)
local layer = nn.SpatialConvolution(1,1,1,1) -- Args don't matter here.
layer:forward(t)
```

Currently, the error is:

```
attempt to index field 'nn' (a nil value)
```

Instead you get this:

```
nn.SpatialConvolution_updateOutput is only supported for Float or Double Tensors.
```
