### PR TITLE
BatchReshape module

### DIFF
--- a/BatchReshape.lua
+++ b/BatchReshape.lua
@@ -1,0 +1,65 @@
+local BatchReshape, parent = torch.class('nn.BatchReshape', 'nn.Module')
+
+--- Reshape, using one dimension to hold the remains
+function BatchReshape:__init(...)
+   parent.__init(self)
+   local arg = {...}
+
+   self.size = torch.LongStorage()
+   self.index = arg[1]
+   table.remove(arg, 1)
+
+   local n = #arg
+   if n == 1 and torch.typename(arg[1]) == 'torch.LongStorage' then
+      self.size:resize(#arg[1]):copy(arg[1])
+   else
+      self.size:resize(n)
+      for i=1,n do
+         self.size[i] = arg[i]
+      end
+   end
+
+   self.sizeindex = self.size[self.index]
+   self.nelement = 1
+   for i=1,#self.size do
+      self.nelement = self.nelement * self.size[i]
+   end
+   
+   -- only used for non-contiguous input or gradOutput
+   self._input = torch.Tensor()
+   self._gradOutput = torch.Tensor()
+end
+
+function BatchReshape:updateOutput(input)
+   if not input:isContiguous() then
+      self._input:resizeAs(input)
+      self._input:copy(input)
+      input = self._input
+   end
+
+   -- Computes the number of elements in the input tensor
+   nelement = 1
+   for i=1,##input do
+      nelement = nelement * (#input)[i]
+   end
+
+   assert(nelement % self.nelement == 0, "The number of elements in target shape is not a multiple of the number of elements")
+
+   self.size[self.index] = self.sizeindex * (nelement / self.nelement)
+   self.output:view(input, self.size)
+
+   return self.output
+end
+
+function BatchReshape:updateGradInput(input, gradOutput)
+   if not gradOutput:isContiguous() then
+      self._gradOutput:resizeAs(gradOutput)
+      self._gradOutput:copy(gradOutput)
+      gradOutput = self._gradOutput
+   end
+   
+   self.gradInput:viewAs(gradOutput, input)
+   return self.gradInput
+end
+
+

--- a/doc/simple.md
+++ b/doc/simple.md
@@ -16,6 +16,7 @@ and providing affine transformations :
    * [Narrow](#nn.Narrow) : a [narrow](https://github.com/nicholas-leonard/torch7/blob/doc/doc/tensor.md#tensor-narrowdim-index-size) operation over a given dimension ;
    * [Replicate](#nn.Replicate) : [repeats](https://github.com/nicholas-leonard/torch7/blob/doc/doc/tensor.md#tensor-repeattensorsizes) input `n` times along its first dimension ;
    * [Reshape](#nn.Reshape) : a [reshape](https://github.com/torch/torch7/blob/master/doc/maths.md#res-torchreshaperes-x-m-n) of the inputs ;
+   * [BatchReshape](#nn.BatchReshape) : a reshape of the inputs, with one free dimension ;
    * [View](#nn.View) : a [view](https://github.com/nicholas-leonard/torch7/blob/doc/doc/tensor.md#result-viewresult-tensor-sizes) of the inputs ;
    * [Select](#nn.Select) : a [select](https://github.com/nicholas-leonard/torch7/blob/doc/doc/tensor.md#tensor-selectdim-index) over a given dimension ;
  * Modules that adapt mathematical Tensor methods :
@@ -593,6 +594,63 @@ Example:
  16
 [torch.Tensor of dimension 16]
 ```
+
+<a name="nn.BatchReshape"/>
+## Reshape ##
+
+`module` = `Reshape(index,  dimension1, dimension2, ... )`
+
+Reshapes an `nxpxqx..`  Tensor into a `dimension1xdimension2x...` Tensor,
+taking the elements column-wise. One dimension is "free", i.e. it will
+be adapted depending on the number of elements in the tensor.
+The first argument `index` sets the index of this dimension.
+
+Notice that the number of elements in the tensor should be a multiple of
+the number of elements dimension1 x dimension2 x ... 
+
+Example:
+```lua
+> x=torch.Tensor(4,4)
+> for i=1,4 do
+>  for j=1,4 do
+>   x[i][j]=(i-1)*4+j;
+>  end
+> end
+> print(x)
+
+  1   2   3   4
+  5   6   7   8
+  9  10  11  12
+ 13  14  15  16
+[torch.Tensor of dimension 4x4]
+
+> > print(nn.BatchReshape(1,2,2):forward(x))
+  1   2
+  3   4
+  5   6
+  7   8
+  9  10
+ 11  12
+ 13  14
+ 15  16
+[torch.DoubleTensor of dimension 8x2]
+
+                                                                      [0.0004s]
+> print(nn.BatchReshape(2,2,2):forward(x))
+  1   2   3   4   5   6   7   8
+  9  10  11  12  13  14  15  16
+[torch.DoubleTensor of dimension 2x8]
+```
+
+A typical example is to use it combined with convolutions, as for example:
+```
+model:add(nn.TemporalConvolution(size, outputFrameSize, kW, dW))
+model:add(nn.BatchReshape(1, nOutputFrame, outputFrameSize))
+model:add(nn.Linear(outputFrameSize, outputSize))
+model:add(nn.BatchReshape(1, 1, nOutputFrame, outputSize))
+```
+where the convolution outputs nOutputFrame frames per input sample, and we
+want a linear transformation of each frame before continuing the processing.
 
 <a name="nn.View"/>
 ## View ##

--- a/init.lua
+++ b/init.lua
@@ -10,6 +10,7 @@ include('Sequential.lua')
 
 include('Linear.lua')
 include('SparseLinear.lua')
+include('BatchReshape.lua')
 include('Reshape.lua')
 include('View.lua')
 include('Select.lua')

--- a/test/test.lua
+++ b/test/test.lua
@@ -2141,6 +2141,22 @@ function nntest.Reshape()
       "Error in minibatch nElement")
 end
 
+function nntest.BatchReshape()
+    function match(batchArgs, shapeX, shape) 
+        r = nn.BatchReshape(unpack(batchArgs))
+        x = torch.randn(unpack(shapeX))
+        y = r:forward(x)
+
+        mytester:assertTableEq(y:size():totable(), shape, "Error in forward")
+    end
+
+    match({1, 1,5,5}, {5, 5}, {1,5,5})
+    match({1, 1,5,5}, {5, 10}, {2,5,5})
+    match({1, 1,5,5}, {10, 10}, {4,5,5})
+
+    match({2, 1,5,5}, {10, 10}, {1,20,5})
+end
+
 -- Define a test for SpatialUpSamplingCuda
 function nntest.SpatialUpSamplingNearest()
   local scale = torch.random(2,4)


### PR DESCRIPTION
The reshape module does not allow to cope with the output of e.g. temporal convolution. For example, if I have a batch of size 25, and 50 output frames of dimension 10 that I would like to process through a linear module, there is no way to do so currently. With BatchReshape, this gives

```
> print(nn.BatchReshape(1, 50, 10):forward(torch.randn(25, 50, 10)):size())

 1250
   10
[torch.LongStorage of size 2]
```

we can then process them using any module that operate on batches with matrices, and then use it again to get back the initial batch:

```
> print(nn.BatchReshape(1, 1, 50, 10):forward(torch.randn(1250, 10)):size())

 25
 50
 10
[torch.LongStorage of size 3]
```
