### PR TITLE
ClassNLLCriterion - adding classes weights input

### DIFF
--- a/ClassNLLCriterion.lua
+++ b/ClassNLLCriterion.lua
@@ -1,17 +1,27 @@
 local ClassNLLCriterion, parent = torch.class('nn.ClassNLLCriterion', 'nn.Criterion')
 
-function ClassNLLCriterion:__init()
+function ClassNLLCriterion:__init(weights)
    parent.__init(self)
    self.sizeAverage = true
+   if weights then
+       self.weights = weights
+   end
 end
 
 function ClassNLLCriterion:updateOutput(input, target)
    if input:dim() == 1 then
       self.output = -input[target]
+      if self.weights then
+          self.output = self.output*self.weights[target]
+      end
    elseif input:dim() == 2 then
       local output = 0
       for i=1,target:size(1) do
-         output = output - input[i][target[i]]
+         if self.weights then
+            output = output - input[i][target[i]]*self.weights[target[i]]
+         else
+            output = output - input[i][target[i]]
+         end
       end
       if self.sizeAverage then
          output = output / target:size(1)
@@ -29,16 +39,20 @@ function ClassNLLCriterion:updateGradInput(input, target)
 
   if input:dim() == 1 then
       self.gradInput[target] = -1
+      if self.weights then
+          self.gradInput[target] = self.gradInput[target]*self.weights[target]
+      end
   else
       local z = -1
       if self.sizeAverage then
          z = z / target:size(1)
       end
-      local gradInput = self.gradInput
       for i=1,target:size(1) do
-         gradInput[i][target[i]] = z
+          self.gradInput[i][target[i]] = z
+         if self.weights then
+             self.gradInput[i][target[i]] = self.gradInput[i][target[i]]*self.weights[target[i]]
+         end
       end
    end
-
    return self.gradInput
 end


### PR DESCRIPTION
Adding class weights is relevant when you have unbalanced training set, adding custom weights can help in these cases.

Example for input weights -

 --- compute frequency for each class
class_freqs = torch.Tensor(nLabels):fill(0)
for iImage = 1,trainData:size() do
   label = trainData.labels[iImage]
   class_freqs[label] = class_freqs[label] + 1
end

--- each class weight is inverse proportional to the number of samples in the class
class_weights = torch.Tensor(nLabels):fill(0)
for iLabel = 1,nLabels do
   class_weights[iLabel] = 1 / class_freqs[iLabel]
end
class_weights = class_weights / class_weights:sum()
