### PR TITLE
Adding classes weights to ClassNLLCriterion

### DIFF
--- a/ClassNLLCriterion.lua
+++ b/ClassNLLCriterion.lua
@@ -1,17 +1,28 @@
 local ClassNLLCriterion, parent = torch.class('nn.ClassNLLCriterion', 'nn.Criterion')
 
-function ClassNLLCriterion:__init()
+function ClassNLLCriterion:__init(weights)
    parent.__init(self)
    self.sizeAverage = true
+   if weights then
+       assert(weights:dim() == 1, "weights input should be 1-D Tensor")          
+       self.weights = weights
+   end
 end
 
 function ClassNLLCriterion:updateOutput(input, target)
    if input:dim() == 1 then
       self.output = -input[target]
+      if self.weights then
+          self.output = self.output*self.weights[target]
+      end
    elseif input:dim() == 2 then
       local output = 0
       for i=1,target:size(1) do
-         output = output - input[i][target[i]]
+         if self.weights then
+            output = output - input[i][target[i]]*self.weights[target[i]]
+         else
+            output = output - input[i][target[i]]
+         end
       end
       if self.sizeAverage then
          output = output / target:size(1)
@@ -29,16 +40,20 @@ function ClassNLLCriterion:updateGradInput(input, target)
 
   if input:dim() == 1 then
       self.gradInput[target] = -1
+      if self.weights then
+          self.gradInput[target] = self.gradInput[target]*self.weights[target]
+      end
   else
       local z = -1
       if self.sizeAverage then
          z = z / target:size(1)
       end
-      local gradInput = self.gradInput
       for i=1,target:size(1) do
-         gradInput[i][target[i]] = z
+          self.gradInput[i][target[i]] = z
+         if self.weights then
+             self.gradInput[i][target[i]] = self.gradInput[i][target[i]]*self.weights[target[i]]
+         end
       end
    end
-
    return self.gradInput
 end

--- a/doc/criterion.md
+++ b/doc/criterion.md
@@ -72,16 +72,19 @@ criterion.sizeAverage = false
 ## ClassNLLCriterion ##
 
 ```lua
-criterion = ClassNLLCriterion()
+criterion = ClassNLLCriterion(weights)
 ```
 
 The negative log likelihood criterion. It is useful to train a classication
-problem with `n` classes. The `input` given through a `forward()` is
+problem with `n` classes. 
+If provided, the optional argument `weights` should be a 1D Tensor assigning weight to each of the classes. This is particularly useful when you have an unbalanced training set.
+
+The `input` given through a `forward()` is
 expected to contain _log-probabilities_ of each class: `input` has to be a
-1D tensor of size `n`. Obtaining log-probabilities in a neural network is
+1D tensor of size `n`. 
+Obtaining log-probabilities in a neural network is
 easily achieved by adding a [LogSoftMax](#nn.LogSoftMax) layer in the last
 layer of your neural network.
-
 This criterion expect a class index (1 to the number of class) as `target`
 when calling [forward(input, target)](#nn.CriterionForward) and
 [backward(input, target)](#nn.CriterionBackward).
@@ -90,7 +93,10 @@ The loss can be described as:
 ```lua
 loss(x, class) = forward(x, class) = -x[class]
 ```
-
+or in the case of the `weights` argument being specified:
+```lua
+loss(x, class) = forward(x, class) = -weights[class]*x[class]
+```
 The following is a code fragment showing how to make a gradient step 
 given an input `x`, a desired output `y` (an integer `1` to `n`, 
 in this case `n` = `2` classes), 

--- a/test/test.lua
+++ b/test/test.lua
@@ -512,6 +512,22 @@ function nntest.DistKLDivCriterion()
    criterionJacobianTest1D(cri, input, target)
 end
 
+function nntest.ClassNLLCriterion()
+   local numLabels = math.random(5,10)	
+   local input = torch.rand(numLabels)
+   local target = math.random(1,numLabels)	
+
+   -- default ClassNLLCriterion
+   local cri = nn.ClassNLLCriterion()
+   criterionJacobianTest1D(cri, input, target)
+
+   -- ClassNLLCriterion with weights
+   local weights = torch.rand(numLabels)
+   weights = weights / weights:sum()
+   cri = nn.ClassNLLCriterion(weights)
+   criterionJacobianTest1D(cri, input, target)
+end
+
 function nntest.LogSigmoid()
    local ini = math.random(10,20)
    local inj = math.random(10,20)


### PR DESCRIPTION
(Sorry for my mistake but this request should replace my previous one. Now i put my changes in specific branch for that topic - balanceNLL)

Adding class weights is relevant when you have unbalanced training set, adding custom weights can help in these cases.

Example for input weights -

--- compute frequency for each class
class_freqs = torch.Tensor(nLabels):fill(0)
for iImage = 1,trainData:size() do
label = trainData.labels[iImage]
class_freqs[label] = class_freqs[label] + 1
end

--- each class weight is inverse proportional to the number of samples in the class
class_weights = torch.Tensor(nLabels):fill(0)
for iLabel = 1,nLabels do
class_weights[iLabel] = 1 / class_freqs[iLabel]
end
class_weights = class_weights / class_weights:sum()
