### PR TITLE
refactored nn.Linear into C/CUDA methods

### DIFF
--- a/Linear.lua
+++ b/Linear.lua
@@ -8,6 +8,7 @@ function Linear:__init(inputSize, outputSize)
    self.gradWeight = torch.Tensor(outputSize, inputSize)
    self.gradBias = torch.Tensor(outputSize)
    
+   self:setup()
    self:reset()
 end
 
@@ -30,69 +31,33 @@ function Linear:reset(stdv)
    end
 end
 
-function Linear:updateOutput(input)
-   if input:dim() == 1 then
-      self.output:resize(self.bias:size(1))
-      self.output:copy(self.bias)
-      self.output:addmv(1, self.weight, input)
-   elseif input:dim() == 2 then
-      local nframe = input:size(1)
-      local nunit = self.bias:size(1)
-
-      self.output:resize(nframe, nunit)
-      if nunit == 1 then
-         -- Special case to fix output size of 1 bug:
-         self.output:zero():add(self.bias[1])
-         self.output:select(2,1):addmv(1, input, self.weight:select(1,1))
-      else
-         self.output:zero():addr(1, input.new(nframe):fill(1), self.bias)
-         self.output:addmm(1, input, self.weight:t())
-      end
-   else
-      error('input must be vector or matrix')
+function Linear:setup()
+   -- for backwards compatibility
+   if not self.v2 then
+      self._ones = self.weight.new{1}
+      -- for cuda only
+      self.forceAsync = true
+      self._gradOutput = self.weight.new()
+      self._input = self.weight.new()
+      self.v2 = true
    end
+end
 
-   return self.output
+function Linear:updateOutput(input)
+   self:setup()
+   return input.nn.Linear_updateOutput(self, input)
 end
 
 function Linear:updateGradInput(input, gradOutput)
    if self.gradInput then
-
-      local nElement = self.gradInput:nElement()
-      self.gradInput:resizeAs(input)
-      if self.gradInput:nElement() ~= nElement then
-         self.gradInput:zero()
-      end
-      if input:dim() == 1 then
-         self.gradInput:addmv(0, 1, self.weight:t(), gradOutput)
-      elseif input:dim() == 2 then
-         self.gradInput:addmm(0, 1, gradOutput, self.weight)
-      end
-
-      return self.gradInput
+      self:setup()
+      return input.nn.Linear_updateGradInput(self, input, gradOutput)
    end
 end
 
 function Linear:accGradParameters(input, gradOutput, scale)
-   scale = scale or 1
-
-   if input:dim() == 1 then
-      self.gradWeight:addr(scale, gradOutput, input)
-      self.gradBias:add(scale, gradOutput)      
-   elseif input:dim() == 2 then
-      local nframe = input:size(1)
-      local nunit = self.bias:size(1)
-      
-      if nunit == 1 then
-         -- Special case to fix output size of 1 bug:
-         self.gradWeight:select(1,1):addmv(scale, input:t(), gradOutput:select(2,1))
-         self.gradBias:addmv(scale, gradOutput:t(), input.new(nframe):fill(1))
-      else
-         self.gradWeight:addmm(scale, gradOutput:t(), input)
-         self.gradBias:addmv(scale, gradOutput:t(), input.new(nframe):fill(1))
-      end
-   end
-
+   self:setup()
+   return input.nn.Linear_accGradParameters(self, input, gradOutput, scale)
 end
 
 -- we do not need to accumulate parameters when sharing

--- a/generic/Linear.c
+++ b/generic/Linear.c
@@ -1,0 +1,145 @@
+#ifndef TH_GENERIC_FILE
+#define TH_GENERIC_FILE "generic/Linear.c"
+#else
+
+static int nn_(Linear_updateOutput)(lua_State *L)
+{
+  THTensor *input = luaT_checkudata(L, 2, torch_Tensor);
+
+  THTensor *ones = luaT_getfieldcheckudata(L, 1, "_ones", torch_Tensor);
+  THTensor *weight = luaT_getfieldcheckudata(L, 1, "weight", torch_Tensor);
+  THTensor *bias = luaT_getfieldcheckudata(L, 1, "bias", torch_Tensor);
+  THTensor *output = luaT_getfieldcheckudata(L, 1, "output", torch_Tensor);
+
+  luaL_argcheck(L, input->nDimension == 1 || input->nDimension == 2, 2, "1D or 2D tensor expected");
+
+  if (input->nDimension == 1) 
+  {
+    luaL_argcheck(L, input->size[0] == weight->size[1], 2, "invalid number of input units (input:size(1))");
+    
+    THTensor_(resize1d)(output, bias->size[0]);
+    THTensor_(copy)(output, bias);
+    THTensor_(addmv)(output, 1, output, 1, weight, input);
+  }
+  else if ( input->nDimension == 2 ) 
+  {
+    long nframe = input->size[0];
+    long nunit = bias->size[0];
+    THTensor* weightT = THTensor_(newTranspose)(weight, 0, 1);
+    
+    luaL_argcheck(L, input->size[1] == weight->size[1], 2, "invalid number of input units (input:size(2))");
+
+    THTensor_(resize2d)(output, nframe, nunit);
+    if (ones->size[0] != nframe)
+    {
+      THTensor_(resize1d)(ones, nframe);
+      THTensor_(fill)(ones, 1);
+    }
+      
+    THTensor_(zero)(output);
+    THTensor_(addr)(output, 1, output, 1, ones, bias);
+    THTensor_(addmm)(output, 1, output, 1, input, weightT);
+    
+    THTensor_(free)(weightT);
+  }
+
+  return 1;
+}
+
+static int nn_(Linear_updateGradInput)(lua_State *L)
+{
+  THTensor *input = luaT_checkudata(L, 2, torch_Tensor);
+  THTensor *gradOutput = luaT_checkudata(L, 3, torch_Tensor);
+
+  THTensor *weight = luaT_getfieldcheckudata(L, 1, "weight", torch_Tensor);
+  THTensor *gradInput = luaT_getfieldcheckudata(L, 1, "gradInput", torch_Tensor);
+  
+  long nElement = THTensor_(nElement)(gradInput);
+  
+  luaL_argcheck(L, input->nDimension == 1 || input->nDimension == 2, 2, "1D or 2D tensor expected");
+  luaL_argcheck(L, gradOutput->nDimension == input->nDimension, 2, "input and gradOutput should have same number of dimensions");
+  
+  THTensor_(resizeAs)(gradInput, input);
+  if (THTensor_(nElement)(gradInput) != nElement)
+    THTensor_(zero)(gradInput);
+  
+  if (input->nDimension == 1) 
+  {
+    THTensor *weightT = THTensor_(newTranspose)(weight, 0, 1);
+    
+    luaL_argcheck(L, input->size[0] == weight->size[1], 2, "invalid number of input units (input:size(1))");
+    luaL_argcheck(L, gradOutput->size[0] == weight->size[0], 2, "invalid number of output units (gradOutput:size(1))");
+    
+    THTensor_(addmv)(gradInput, 0, gradInput, 1, weightT, gradOutput);
+    THTensor_(free)(weightT);
+  }
+  else
+  {
+    luaL_argcheck(L, input->size[1] == weight->size[1], 2, "invalid number of input units (input:size(2))");
+    luaL_argcheck(L, gradOutput->size[1] == weight->size[0], 2, "invalid number of output units (gradOutput:size(2))");
+    
+    THTensor_(addmm)(gradInput, 0, gradInput, 1, gradOutput, weight);
+  }
+  
+  return 1;
+}
+
+static int nn_(Linear_accGradParameters)(lua_State *L)
+{
+  THTensor *input = luaT_checkudata(L, 2, torch_Tensor);
+  THTensor *gradOutput = luaT_checkudata(L, 3, torch_Tensor);
+  real scale = luaL_optnumber(L, 4, 1);
+
+  THTensor *ones = luaT_getfieldcheckudata(L, 1, "_ones", torch_Tensor);
+  THTensor *gradWeight = luaT_getfieldcheckudata(L, 1, "gradWeight", torch_Tensor);
+  THTensor *gradBias = luaT_getfieldcheckudata(L, 1, "gradBias", torch_Tensor);
+  
+  luaL_argcheck(L, input->nDimension == 1 || input->nDimension == 2, 2, "1D or 2D tensor expected");
+  luaL_argcheck(L, gradOutput->nDimension == input->nDimension, 2, "input and gradOutput should have same number of dimensions");
+  
+  if (input->nDimension == 1) 
+  {
+    luaL_argcheck(L, input->size[0] == gradWeight->size[1], 2, "invalid number of input units (input:size(1))");
+    luaL_argcheck(L, gradOutput->size[0] == gradWeight->size[0], 2, "invalid number of output units (gradOutput:size(1))");
+    
+    THTensor_(addr)(gradWeight, 1, gradWeight, scale, gradOutput, input);
+    THTensor_(cadd)(gradBias, gradBias, scale, gradOutput);
+  }
+  else 
+  {
+    long nframe = input->size[0];
+    long nunit = gradBias->size[0];
+    THTensor* gradOutputT = THTensor_(newTranspose)(gradOutput, 0, 1);
+    
+    luaL_argcheck(L, input->size[1] == gradWeight->size[1], 2, "invalid number of input units (input:size(2))");
+    luaL_argcheck(L, gradOutput->size[1] == gradWeight->size[0], 2, "invalid number of output units (gradOutput:size(2))");
+
+    if (ones->size[0] != nframe)
+    {
+      THTensor_(resize1d)(ones, nframe);
+      THTensor_(fill)(ones, 1);
+    }
+    THTensor_(addmm)(gradWeight, 1, gradWeight, scale, gradOutputT, input);
+    THTensor_(addmv)(gradBias, 1, gradBias, scale, gradOutputT, ones);
+    
+    THTensor_(free)(gradOutputT);
+  }
+
+  return 0;
+}
+
+static const struct luaL_Reg nn_(Linear__) [] = {
+  {"Linear_updateOutput", nn_(Linear_updateOutput)},
+  {"Linear_updateGradInput", nn_(Linear_updateGradInput)},
+  {"Linear_accGradParameters", nn_(Linear_accGradParameters)},
+  {NULL, NULL}
+};
+
+static void nn_(Linear_init)(lua_State *L)
+{
+  luaT_pushmetatable(L, torch_Tensor);
+  luaT_registeratname(L, nn_(Linear__), "nn");
+  lua_pop(L,1);
+}
+
+#endif

--- a/init.c
+++ b/init.c
@@ -5,6 +5,9 @@
 #define torch_Tensor TH_CONCAT_STRING_3(torch.,Real,Tensor)
 #define nn_(NAME) TH_CONCAT_3(nn_, Real, NAME)
 
+#include "generic/Linear.c"
+#include "THGenerateFloatTypes.h"
+
 #include "generic/Square.c"
 #include "THGenerateFloatTypes.h"
 
@@ -124,6 +127,7 @@ int luaopen_libnn(lua_State *L)
   lua_pushvalue(L, -1);
   lua_setfield(L, LUA_GLOBALSINDEX, "nn");
 
+  nn_FloatLinear_init(L);
   nn_FloatMin_init(L);
   nn_FloatMax_init(L);
   nn_FloatExp_init(L);
@@ -162,6 +166,7 @@ int luaopen_libnn(lua_State *L)
   nn_FloatL1Cost_init(L);
   nn_FloatSpatialUpSamplingNearest_init(L);
 
+  nn_DoubleLinear_init(L);
   nn_DoubleMin_init(L);
   nn_DoubleMax_init(L);
   nn_DoubleExp_init(L);

--- a/test/test.lua
+++ b/test/test.lua
@@ -290,28 +290,28 @@ function nntest.Linear()
 
      -- 1D
      local err = jac.testJacobian(module,input)
-     mytester:assertlt(err,precision, 'error on state ')
+     mytester:assertlt(err,precision, 'error on state 1D '..inj)
 
      local err = jac.testJacobianParameters(module, input, module.weight, module.gradWeight)
-     mytester:assertlt(err,precision, 'error on weight ')
+     mytester:assertlt(err,precision, 'error on weight 1D '..inj)
 
      local err = jac.testJacobianParameters(module, input, module.bias, module.gradBias)
-     mytester:assertlt(err,precision, 'error on bias ')
+     mytester:assertlt(err,precision, 'error on bias 1D '..inj)
 
      local err = jac.testJacobianUpdateParameters(module, input, module.weight)
-     mytester:assertlt(err,precision, 'error on weight [direct update] ')
+     mytester:assertlt(err,precision, 'error on weight [direct update] 1D '..inj)
 
      local err = jac.testJacobianUpdateParameters(module, input, module.bias)
-     mytester:assertlt(err,precision, 'error on bias [direct update] ')
+     mytester:assertlt(err,precision, 'error on bias [direct update] 1D '..inj)
 
      for t,err in pairs(jac.testAllUpdate(module, input, 'weight', 'gradWeight')) do
         mytester:assertlt(err, precision, string.format(
-                           'error on weight [%s]', t))
+                           'error on weight [%s] 1D '..inj, t))
      end
 
      for t,err in pairs(jac.testAllUpdate(module, input, 'bias', 'gradBias')) do
         mytester:assertlt(err, precision, string.format(
-                           'error on bias [%s]', t))
+                           'error on bias [%s] 1D '..inj, t))
      end
 
      -- 2D
@@ -319,34 +319,34 @@ function nntest.Linear()
      local input = torch.Tensor(nframe, ini):zero()
 
      local err = jac.testJacobian(module,input)
-     mytester:assertlt(err,precision, 'error on state ')
+     mytester:assertlt(err,precision, 'error on state 2D '..inj)
 
      local err = jac.testJacobianParameters(module, input, module.weight, module.gradWeight)
-     mytester:assertlt(err,precision, 'error on weight ')
+     mytester:assertlt(err,precision, 'error on weight 2D '..inj)
 
      local err = jac.testJacobianParameters(module, input, module.bias, module.gradBias)
-     mytester:assertlt(err,precision, 'error on weight ')
+     mytester:assertlt(err,precision, 'error on weight 2D '..inj)
 
      local err = jac.testJacobianUpdateParameters(module, input, module.weight)
-     mytester:assertlt(err,precision, 'error on weight [direct update] ')
+     mytester:assertlt(err,precision, 'error on weight [direct update] 2D '..inj)
 
      local err = jac.testJacobianUpdateParameters(module, input, module.bias)
-     mytester:assertlt(err,precision, 'error on bias [direct update] ')
+     mytester:assertlt(err,precision, 'error on bias [direct update] 2D '..inj)
 
      for t,err in pairs(jac.testAllUpdate(module, input, 'weight', 'gradWeight')) do
         mytester:assertlt(err, precision, string.format(
-                           'error on weight [%s]', t))
+                           'error on weight [%s] 2D '..inj, t))
      end
 
      for t,err in pairs(jac.testAllUpdate(module, input, 'bias', 'gradBias')) do
         mytester:assertlt(err, precision, string.format(
-                           'error on bias [%s]', t))
+                           'error on bias [%s] 2D '..inj, t))
      end
 
      -- IO
      local ferr,berr = jac.testIO(module,input)
-     mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err ')
-     mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
+     mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err '..inj)
+     mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err '..inj)
   end  -- for ind, inj in pairs(inj_vals) do
 end
 


### PR DESCRIPTION
This PR was fun. It makes nn.Linear non-blocking. Includes unit tests. It should be backwards compatible for serialized modules. It refactors the nn.Linear Lua code into C/CUDA files such that we can do specific fixes for torch.CudaTensors and such.

fixes #77
depends on https://github.com/torch/cunn/pull/33
