### PR TITLE
[Torch] Make Jacobian.testIO safe for concurrent runs

### DIFF
--- a/Jacobian.lua
+++ b/Jacobian.lua
@@ -170,17 +170,18 @@ function nn.Jacobian.testIO(module,input, minval, maxval)
    local bo = module.gradInput:clone()
 
    -- write module
-   local f = torch.DiskFile('tmp.bin','w'):binary()
+   local filename = os.tmpname()
+   local f = torch.DiskFile(filename, 'w'):binary()
    f:writeObject(module)
    f:close()
    -- read module
-   local m = torch.DiskFile('tmp.bin'):binary():readObject()
+   local m = torch.DiskFile(filename):binary():readObject()
    m:forward(input)
    m:zeroGradParameters()
    m:updateGradInput(input,go)
    m:accGradParameters(input,go)
    -- cleanup
-   os.remove('tmp.bin')
+   os.remove(filename)
 
    local fo2 = m.output:clone()
    local bo2 = m.gradInput:clone()


### PR DESCRIPTION
The current implementation has a file 'tmp.bin' for all instances.  This diff changes that to be a filename generated by `os.tmpname`.
