### PR TITLE
refactoring all the common container code into nn.Container

### DIFF
--- a/Concat.lua
+++ b/Concat.lua
@@ -1,19 +1,9 @@
-local Concat, parent = torch.class('nn.Concat', 'nn.Module')
+local Concat, parent = torch.class('nn.Concat', 'nn.Container')
 
 function Concat:__init(dimension)
-   parent.__init(self)
-   self.modules = {}
+   parent.__init(self, dimension)
    self.size = torch.LongStorage()
    self.dimension = dimension
-end
-
-function Concat:add(module)
-   table.insert(self.modules, module)
-   return self
-end
-
-function Concat:get(index)
-   return self.modules[index]
 end
 
 function Concat:updateOutput(input)
@@ -81,58 +71,6 @@ function Concat:accUpdateGradParameters(input, gradOutput, lr)
           lr)
       offset = offset + currentOutput:size(self.dimension)
    end
-end
-
-function Concat:zeroGradParameters()
-   for _,module in ipairs(self.modules) do
-      module:zeroGradParameters()
-   end
-end
-
-function Concat:updateParameters(learningRate)
-   for _,module in ipairs(self.modules) do
-      module:updateParameters(learningRate)
-   end
-end
-
-function Concat:training()
-   for i=1,#self.modules do
-      self.modules[i]:training()
-   end
-end
-
-function Concat:evaluate()
-   for i=1,#self.modules do
-      self.modules[i]:evaluate()
-   end
-end
-
-function Concat:share(mlp,...)
-   for i=1,#self.modules do
-      self.modules[i]:share(mlp.modules[i],...);
-   end
-end
-
-function Concat:parameters()
-   local function tinsert(to, from)
-      if type(from) == 'table' then
-         for i=1,#from do
-            tinsert(to,from[i])
-         end
-      else
-         table.insert(to,from)
-      end
-   end
-   local w = {}
-   local gw = {}
-   for i=1,#self.modules do
-      local mw,mgw = self.modules[i]:parameters()
-      if mw then
-         tinsert(w,mw)
-         tinsert(gw,mgw)
-      end
-   end
-   return w,gw
 end
 
 function Concat:__tostring__()

--- a/Container.lua
+++ b/Container.lua
@@ -1,0 +1,80 @@
+-- This is code common to container modules, which are collections of
+-- smaller constituent modules like Parallel, Sequential, etc.
+local Container, parent =
+  torch.class('nn.Container', 'nn.Module')
+
+function Container:__init(...)
+    parent.__init(self, ...)
+    self.modules = {}
+end
+
+function Container:add(module)
+    table.insert(self.modules, module)
+    return self
+end
+
+function Container:get(index)
+    return self.modules[index]
+end
+
+function Container:size()
+    return #self.modules
+end
+
+function Container:zeroGradParameters()
+    for i=1,#self.modules do
+        self.modules[i]:zeroGradParameters()
+    end
+end
+
+function Container:updateParameters(learningRate)
+    for _,module in ipairs(self.modules) do
+        module:updateParameters(learningRate)
+    end
+end
+
+function Container:training()
+    for i=1,#self.modules do
+        self.modules[i]:training()
+    end
+end
+
+function Container:evaluate()
+    for i=1,#self.modules do
+        self.modules[i]:evaluate()
+    end
+end
+
+function Container:share(mlp, ...)
+    for i=1,#self.modules do
+        self.modules[i]:share(mlp.modules[i], ...);
+    end
+end
+
+function Container:reset(stdv)
+    for i=1,#self.modules do
+        self.modules[i]:reset(stdv)
+    end
+end
+
+function Container:parameters()
+    local function tinsert(to, from)
+        if type(from) == 'table' then
+            for i=1,#from do
+                tinsert(to,from[i])
+            end
+        else
+            table.insert(to,from)
+        end
+    end
+    local w = {}
+    local gw = {}
+    for i=1,#self.modules do
+        local mw,mgw = self.modules[i]:parameters()
+        if mw then
+            tinsert(w,mw)
+            tinsert(gw,mgw)
+        end
+    end
+    return w,gw
+end

--- a/Parallel.lua
+++ b/Parallel.lua
@@ -1,4 +1,4 @@
-local Parallel, parent = torch.class('nn.Parallel', 'nn.Module')
+local Parallel, parent = torch.class('nn.Parallel', 'nn.Container')
 
 function Parallel:__init(inputDimension,outputDimension)
    parent.__init(self)
@@ -6,15 +6,6 @@ function Parallel:__init(inputDimension,outputDimension)
    self.size = torch.LongStorage() 
    self.inputDimension = inputDimension
    self.outputDimension = outputDimension
-end
-
-function Parallel:add(module)
-   table.insert(self.modules, module)
-   return self
-end
-
-function Parallel:get(index)
-   return self.modules[index]
 end
 
 function Parallel:updateOutput(input)
@@ -99,36 +90,6 @@ function Parallel:accUpdateGradParameters(input, gradOutput, lr)
    end
 end
  
-function Parallel:zeroGradParameters()
-   for _,module in ipairs(self.modules) do
-      module:zeroGradParameters()
-   end
-end
-
-function Parallel:updateParameters(learningRate)
-   for _,module in ipairs(self.modules) do
-      module:updateParameters(learningRate)
-   end
-end
-
-function Parallel:training()
-   for i=1,#self.modules do
-      self.modules[i]:training()
-   end
-end
-
-function Parallel:evaluate()
-   for i=1,#self.modules do
-      self.modules[i]:evaluate()
-   end
-end
-
-function Parallel:share(mlp,...)
-   for i=1,#self.modules do
-      self.modules[i]:share(mlp.modules[i],...); 
-   end
-end
-
 function Parallel:parameters()
    local function tinsert(to, from)
       if type(from) == 'table' then

--- a/Sequential.lua
+++ b/Sequential.lua
@@ -1,9 +1,4 @@
-local Sequential, parent = torch.class('nn.Sequential', 'nn.Module')
-
-function Sequential:__init()
-   parent.__init(self)
-   self.modules = {}
-end
+local Sequential, _ = torch.class('nn.Sequential', 'nn.Container')
 
 function Sequential:add(module)
    if #self.modules == 0 then
@@ -22,14 +17,6 @@ function Sequential:insert(module, index)
    table.insert(self.modules, index, module)
    self.output = self.modules[#self.modules].output
    self.gradInput = self.modules[1].gradInput
-end
-
-function Sequential:size()
-   return #self.modules
-end
-
-function Sequential:get(index)
-   return self.modules[index]
 end
 
 function Sequential:updateOutput(input)
@@ -82,63 +69,6 @@ function Sequential:accUpdateGradParameters(input, gradOutput, lr)
    currentModule:accUpdateGradParameters(input, currentGradOutput, lr)
 end
 
-function Sequential:zeroGradParameters()
-  for i=1,#self.modules do
-     self.modules[i]:zeroGradParameters()
-  end
-end
-
-function Sequential:updateParameters(learningRate)
-   for i=1,#self.modules do
-      self.modules[i]:updateParameters(learningRate)
-   end
-end
-
-function Sequential:training()
-   for i=1,#self.modules do
-      self.modules[i]:training()
-   end
-end
-
-function Sequential:evaluate()
-   for i=1,#self.modules do
-      self.modules[i]:evaluate()
-   end
-end
-
-function Sequential:share(mlp,...)
-   for i=1,#self.modules do
-      self.modules[i]:share(mlp.modules[i],...); 
-   end
-end
-
-function Sequential:reset(stdv)
-   for i=1,#self.modules do
-      self.modules[i]:reset(stdv)
-   end
-end
-
-function Sequential:parameters()
-   local function tinsert(to, from)
-      if type(from) == 'table' then
-         for i=1,#from do
-            tinsert(to,from[i])
-         end
-      else
-         table.insert(to,from)
-      end
-   end
-   local w = {}
-   local gw = {}
-   for i=1,#self.modules do
-      local mw,mgw = self.modules[i]:parameters()
-      if mw then
-         tinsert(w,mw)
-         tinsert(gw,mgw)
-      end
-   end
-   return w,gw
-end
 
 function Sequential:__tostring__()
    local tab = '  '

--- a/init.lua
+++ b/init.lua
@@ -4,6 +4,7 @@ require('libnn')
 include('ErrorMessages.lua')
 include('Module.lua')
 
+include('Container.lua')
 include('Concat.lua')
 include('Parallel.lua')
 include('Sequential.lua')

--- a/test.lua
+++ b/test.lua
@@ -477,7 +477,7 @@ function nntest.WeightedEuclidean()
    local inj = math.random(13,5)
    local input = torch.Tensor(ini):zero()
    local module = nn.WeightedEuclidean(ini,inj)
-   
+
    local err = jac.testJacobian(module,input)
    mytester:assertlt(err,precision, 'error on state ')
 


### PR DESCRIPTION
nn.Container helps simplify the code for all of the container modules like nn.Parallel, nn.Concat, nn.Sequential etc.

This PR introduces nn.Container, and makes some of the existing container modules make it as the base class.
This change is fully backward-compatible in terms of serialization.
Reviewed by @andresy, authored by Keith Adams