### PR TITLE
new Copy constructor arguments

### DIFF
--- a/Copy.lua
+++ b/Copy.lua
@@ -1,14 +1,16 @@
 local Copy, parent = torch.class('nn.Copy', 'nn.Module')
 
-function Copy:__init(intype, outtype)
+function Copy:__init(intype, outtype, forceCopy, dontCast)
    intype = intype or torch.Tensor.__typename
    outtype = outtype or torch.Tensor.__typename
+   
+   self.dontCast = dontCast
 
    parent.__init(self)
    self.gradInput = torch.getmetatable(intype).new()
    self.output = torch.getmetatable(outtype).new()
 
-   if intype == outtype then
+   if (not forceCopy) and intype == outtype then
 
       self.updateOutput = function(self, input)
                         self.output = input
@@ -30,4 +32,11 @@ end
 function Copy:updateGradInput(input, gradOutput)
    self.gradInput:resize(gradOutput:size()):copy(gradOutput)
    return self.gradInput
+end
+
+function Copy:type(type)
+   if type and self.dontCopy then
+      return self
+   end
+   return parent.type(self, type)
 end

--- a/doc/simple.md
+++ b/doc/simple.md
@@ -468,11 +468,15 @@ end
 <a name="nn.Copy"/>
 ## Copy ##
 
-`module` = `Copy(inputType,outputType)`
+`module` = `Copy(inputType,outputType,[forceCopy,dontCast])`
 
 This layer copies the input to output with type casting from input
-type from `inputType` to `outputType`.
-
+type from `inputType` to `outputType`. Unless `forceCopy` is true, when
+the first two arguments are the same, the input isn't copied, only transfered
+as the output. The default `forceCopy` is false. 
+When `dontCast` is true, a call to `nn.Copy:type(type)` will not cast
+the module's `output` and `gradInput` Tensors to the new type. The default 
+is false.
 
 <a name="nn.Narrow"/>
 ## Narrow ##

--- a/test.lua
+++ b/test.lua
@@ -2181,6 +2181,20 @@ function nntest.MulConstant()
   mytester:assertlt(err, precision, 'bprop error ')
 end
 
+function nntest.Copy()
+   local input = torch.randn(3,4):double()
+   local c = nn.Copy('torch.DoubleTensor', 'torch.FloatTensor')
+   local output = c:forward(input)
+   mytester:assert(torch.type(output) == 'torch.FloatTensor', 'copy forward type err')
+   mytester:assertTensorEq(output, input:float(), 0.000001, 'copy forward value err')
+   local gradInput = c:backward(input, output)
+   mytester:assert(torch.type(gradInput) == 'torch.DoubleTensor', 'copy backward type err')
+   mytester:assertTensorEq(gradInput, input, 0.000001, 'copy backward value err')
+   c.dontCast = true
+   c:double()
+   mytester:assert(torch.type(output) == 'torch.FloatTensor', 'copy forward type err')
+end
+
 function nntest.JoinTable()
    local tensor = torch.rand(3,4,5)
    local input = {tensor, tensor}


### PR DESCRIPTION
Hi,

This PR adds two optional arguments to nn.Copy (see doc for explanation). Also adds a nn.Copy unit test.