### PR TITLE
nn.Recurrent

### DIFF
--- a/ParallelTable.lua
+++ b/ParallelTable.lua
@@ -40,16 +40,11 @@ function ParallelTable:__tostring__()
    local line = '\n'
    local next = '  |`-> '
    local ext = '  |    '
-   local extlast = '       '
    local last = '   ... -> '
    local str = torch.type(self)
    str = str .. ' {' .. line .. tab .. 'input'
    for i=1,#self.modules do
-      if i == self.modules then
-         str = str .. line .. tab .. next .. '(' .. i .. '): ' .. tostring(self.modules[i]):gsub(line, line .. tab .. extlast)
-      else
-         str = str .. line .. tab .. next .. '(' .. i .. '): ' .. tostring(self.modules[i]):gsub(line, line .. tab .. ext)
-      end
+      str = str .. line .. tab .. next .. '(' .. i .. '): ' .. tostring(self.modules[i]):gsub(line, line .. tab .. ext)
    end
    str = str .. line .. tab .. last .. 'output'
    str = str .. line .. '}'

--- a/Recurrent.lua
+++ b/Recurrent.lua
@@ -1,0 +1,529 @@
+------------------------------------------------------------------------
+--[[ Recurrent ]]--
+-- Ref. A.: http://goo.gl/vtVGkO (Mikolov et al.)
+-- B. http://goo.gl/hu1Lqm
+-- Processes the sequence one timestep (forward/backward) at a time. 
+-- A call to backward only keeps a log of the gradOutputs and scales.
+-- Back-Propagation Through Time (BPTT) is done when updateParameters
+-- is called. The Module keeps a list of all previous representations 
+-- (Module.outputs), including intermediate ones for BPTT.
+-- To use this module with batches, we suggest using different 
+-- sequences of the same size within a batch and calling 
+-- updateParameters() at the end of the Sequence. 
+-- Note that this container won't work with modules that use more than the
+-- output attribute to keep track of their internal state between 
+-- forward and backward. For example, you cannot nest Recurrent Modules.
+-- (This could be alleviated by added Module:getState/setState methods.)
+------------------------------------------------------------------------
+local Recurrent, parent = torch.class('nn.Recurrent', 'nn.Container')
+
+function Recurrent:__init(start, input, feedback, transfer, rho, merge)
+   parent.__init(self)
+   
+   local ts = torch.type(start)
+   if ts == 'torch.LongTensor' or ts == 'number' then
+      start = nn.Add(start)
+   end
+   
+   self.startModule = start
+   self.inputModule = input
+   self.feedbackModule = feedback
+   self.transferModule = transfer or nn.Sigmoid()
+   self.mergeModule = merge or nn.CAddTable()
+   self.rho = rho or 5
+   
+   -- used for the first step 
+   self.initialModule = nn.Sequential()
+   self.initialModule:add(self.inputModule)
+   self.initialModule:add(self.startModule)
+   self.initialModule:add(self.transferModule)
+   
+   -- used for the other steps (steps > 1)
+   local parallelModule = nn.ParallelTable()
+   parallelModule:add(self.inputModule)
+   parallelModule:add(self.feedbackModule)
+   self.recurrentModule = nn.Sequential()
+   self.recurrentModule:add(parallelModule)
+   self.recurrentModule:add(self.mergeModule)
+   self.recurrentModule:add(self.transferModule)
+   
+   self.modules = {self.startModule, self.inputModule, self.feedbackModule, self.transferModule, self.mergeModule}
+   
+   self.initialOutputs = {}
+   self.initialGradInputs = {}
+   self.recurrentOutputs = {}
+   self.recurrentGradInputs = {}
+   
+   self.fastBackward = true
+   self.copyInputs = true
+   
+   self.inputs = {}
+   self.outputs = {}
+   self.gradOutputs = {}
+   self.scales = {}
+   
+   self.gradParametersAccumulated = false
+   self.step = 1
+   
+   self:reset()
+end
+
+local function recursiveClone(t)
+   local clone
+   if torch.type(t) == 'table' then
+      clone = {}
+      for i = 1, #t do
+         clone[i] = recursiveClone(t[i])
+      end
+   else
+      if torch.typename(t) and 
+        torch.typename(t):find('torch%..+Tensor') then
+         clone = t:clone()
+      end
+   end
+   return clone
+end
+
+function Recurrent:updateOutput(input)
+   -- output(t) = transfer(feedback(output_(t-1)) + input(input_(t)))
+   local output
+   if self.step == 1 then
+      -- set/save the output states
+      local modules = self.initialModule:listModules()
+      for i,modula in ipairs(modules) do
+         local output_ = self.initialOutputs[i] or recursiveClone(modula.output)
+         modula.output = output_
+      end
+      output = self.initialModule:updateOutput(input)
+      for i,modula in ipairs(modules) do
+         self.initialOutputs[i]  = modula.output
+      end
+   else
+      if self.train ~= false then
+         -- set/save the output states
+         local modules = self.recurrentModule:listModules()
+         self:recycle()
+         local recurrentOutputs = self.recurrentOutputs[self.step]
+         if not recurrentOutputs then
+            recurrentOutputs = {}
+            self.recurrentOutputs[self.step] = recurrentOutputs
+         end
+         for i,modula in ipairs(modules) do
+            local output_ = recurrentOutputs[i] or recursiveClone(modula.output)
+            modula.output = output_
+         end
+          -- self.output is the previous output of this module
+         output = self.recurrentModule:updateOutput{input, self.output}
+         for i,modula in ipairs(modules) do
+            recurrentOutputs[i]  = modula.output
+         end
+      else
+         -- self.output is the previous output of this module
+         output = self.recurrentModule:updateOutput{input, self.output}
+      end
+   end
+   
+   if self.train ~= false then
+      local input_ = self.inputs[self.step]
+      if not input_ then
+         input_ = input.new()
+         self.inputs[self.step] = input_
+      end
+      if self.copyInputs then
+         input_:resizeAs(input):copy(input)
+      else
+         input_:set(input)
+      end
+   end
+   
+   self.outputs[self.step] = output
+   self.output:set(output)
+   self.step = self.step + 1
+   self.gradParametersAccumulated = false
+   return self.output
+end
+
+function Recurrent:updateGradInput(input, gradOutput)
+   -- Back-Propagate Through Time (BPTT) happens in updateParameters()
+   -- for now we just keep a list of the gradOutputs
+   local gradOutput_ = self.gradOutputs[self.step-1] 
+   if not gradOutput_ then
+      gradOutput_ = recursiveClone(gradOutput)
+      self.gradOutputs[self.step-1] = gradOutput_
+   end
+   gradOutput_:resizeAs(gradOutput):copy(gradOutput)
+end
+
+function Recurrent:accGradParameters(input, gradOutput, scale)
+   -- Back-Propagate Through Time (BPTT) happens in updateParameters()
+   -- for now we just keep a list of the scales
+   self.scales[self.step-1] = scale
+end
+
+-- not to be confused with the hit movie Back to the Future
+function Recurrent:backwardThroughTime()
+   assert(self.step > 1, "expecting at least one updateOutput")
+   local rho = math.min(self.rho, self.step-1)
+   local stop = self.step - rho
+   if self.fastBackward then
+      local gradInput
+      for step=self.step-1,math.max(stop, 2),-1 do
+         -- set the output/gradOutput states of current Module
+         local modules = self.recurrentModule:listModules()
+         local recurrentOutputs = self.recurrentOutputs[step]
+         local recurrentGradInputs = self.recurrentGradInputs[step]
+         if not recurrentGradInputs then
+            recurrentGradInputs = {}
+            self.recurrentGradInputs[step] = recurrentGradInputs
+         end
+         for i,modula in ipairs(modules) do
+            local output, gradInput = modula.output, modula.gradInput
+            local output_ = recurrentOutputs[i]
+            local gradInput_ = recurrentGradInputs[i] or recursiveClone(gradInput)
+            assert(output_, "backwardThroughTime should be preceded by updateOutput")
+            assert(gradInput_, "missing gradInput")
+            modula.output = output_
+            modula.gradInput = gradInput_
+         end
+         
+         -- backward propagate through this step
+         local input = self.inputs[step]
+         local output = self.outputs[step-1]
+         local gradOutput = self.gradOutputs[step]
+         if gradInput then
+            gradOutput:add(gradInput)
+         end
+         local scale = self.scales[step]
+         
+         gradInput = self.recurrentModule:backward({input, output}, gradOutput, scale/rho)[2]
+         for i,modula in ipairs(modules) do
+            recurrentGradInputs[i] = modula.gradInput
+         end
+      end
+      
+      if stop <= 1 then
+         -- set the output/gradOutput states of initialModule
+         local modules = self.initialModule:listModules()
+         for i,modula in ipairs(modules) do
+            local output, gradInput = modula.output, modula.gradInput
+            local output_ = self.initialOutputs[i]
+            local gradInput_ = self.initialGradInputs[i] or recursiveClone(gradInput)
+            modula.output = output_
+            modula.gradInput = gradInput_
+         end
+         
+         -- backward propagate through first step
+         local input = self.inputs[1]
+         local gradOutput = self.gradOutputs[1]
+         if gradInput then
+            gradOutput:add(gradInput)
+         end
+         local scale = self.scales[1]
+         gradInput = self.initialModule:backward(input, gradOutput, scale/rho)
+         
+         for i,modula in ipairs(modules) do
+            self.initialGradInputs[i] = modula.gradInput
+         end
+         
+         -- startModule's gradParams shouldn't be step-averaged
+         -- as it is used only once. So un-step-average it
+         local params, gradParams = self.startModule:parameters()
+         if gradParams then
+            for i,gradParam in ipairs(gradParams) do
+               gradParam:mul(rho)
+            end
+         end
+         
+         self.gradParametersAccumulated = true
+         return gradInput
+      end
+   else
+      local gradInput = self:updateGradInputThroughTime()
+      self:accGradParametersThroughTime()
+      return gradInput
+   end
+end
+
+function Recurrent:backwardUpdateThroughTime(learningRate)
+   local gradInput = self:updateGradInputThroughTime()
+   self:accUpdateGradParametersThroughTime(learningRate)
+   return gradInput
+end
+
+function Recurrent:updateGradInputThroughTime()
+   assert(self.step > 1, "expecting at least one updateOutput")
+   local gradInput
+   local rho = math.min(self.rho, self.step-1)
+   local stop = self.step - rho
+   for step=self.step-1,math.max(stop,2),-1 do
+      -- set the output/gradOutput states of current Module
+      local modules = self.recurrentModule:listModules()
+      local recurrentOutputs = self.recurrentOutputs[step]
+      local recurrentGradInputs = self.recurrentGradInputs[step]
+      if not recurrentGradInputs then
+         recurrentGradInputs = {}
+         self.recurrentGradInputs[step] = recurrentGradInputs
+      end
+      for i,modula in ipairs(modules) do
+         local output, gradInput = modula.output, modula.gradInput
+         local output_ = recurrentOutputs[i]
+         local gradInput_ = recurrentGradInputs[i] or recursiveClone(gradInput)
+         assert(output_, "updateGradInputThroughTime should be preceded by updateOutput")
+         modula.output = output_
+         modula.gradInput = gradInput_
+      end
+      
+      -- backward propagate through this step
+      local input = self.inputs[step]
+      local output = self.outputs[step-1]
+      local gradOutput = self.gradOutputs[step]
+      if gradInput then
+         gradOutput:add(gradInput)
+      end
+      gradInput = self.recurrentModule:updateGradInput({input, output}, gradOutput)[2]
+      for i,modula in ipairs(modules) do
+         recurrentGradInputs[i] = modula.gradInput
+      end
+   end
+   
+   if stop <= 1 then
+      -- set the output/gradOutput states of initialModule
+      local modules = self.initialModule:listModules()
+      for i,modula in ipairs(modules) do
+         local output, gradInput = modula.output, modula.gradInput
+         local output_ = self.initialOutputs[i]
+         local gradInput_ = self.initialGradInputs[i] or recursiveClone(gradInput)
+         modula.output = output_
+         modula.gradInput = gradInput_
+      end
+      
+      -- backward propagate through first step
+      local input = self.inputs[1]
+      local gradOutput = self.gradOutputs[1]
+      if gradInput then
+         gradOutput:add(gradInput)
+      end
+      gradInput = self.initialModule:updateGradInput(input, gradOutput)
+      
+      for i,modula in ipairs(modules) do
+         self.initialGradInputs[i] = modula.gradInput
+      end
+   end
+   
+   return gradInput
+end
+
+function Recurrent:accGradParametersThroughTime()
+   local rho = math.min(self.rho, self.step-1)
+   local stop = self.step - rho
+   for step=self.step-1,math.max(stop,2),-1 do
+      -- set the output/gradOutput states of current Module
+      local modules = self.recurrentModule:listModules()
+      local recurrentOutputs = self.recurrentOutputs[step]
+      local recurrentGradInputs = self.recurrentGradInputs[step]
+      
+      for i,modula in ipairs(modules) do
+         local output, gradInput = modula.output, modula.gradInput
+         local output_ = recurrentOutputs[i]
+         local gradInput_ = recurrentGradInputs[i]
+         assert(output_, "accGradParametersThroughTime should be preceded by updateOutput")
+         assert(gradInput_, "accGradParametersThroughTime should be preceded by updateGradInputThroughTime")
+         modula.output = output_
+         modula.gradInput = gradInput_
+      end
+      
+      -- backward propagate through this step
+      local input = self.inputs[step]
+      local output = self.outputs[step-1]
+      local gradOutput = self.gradOutputs[step]
+
+      local scale = self.scales[step]
+      self.recurrentModule:accGradParameters({input, output}, gradOutput, scale/rho)
+      
+   end
+   
+   if stop <= 1 then
+      -- set the output/gradOutput states of initialModule
+      local modules = self.initialModule:listModules()
+      for i,modula in ipairs(modules) do
+         local output, gradInput = modula.output, modula.gradInput
+         local output_ = self.initialOutputs[i]
+         local gradInput_ = self.initialGradInputs[i] 
+         modula.output = output_
+         modula.gradInput = gradInput_
+      end
+         
+      -- backward propagate through first step
+      local input = self.inputs[1]
+      local gradOutput = self.gradOutputs[1]
+      local scale = self.scales[1]
+      self.initialModule:accGradParameters(input, gradOutput, scale/rho)
+      
+      -- startModule's gradParams shouldn't be step-averaged
+      -- as it is used only once. So un-step-average it
+      local params, gradParams = self.startModule:parameters()
+      if gradParams then
+         for i,gradParam in ipairs(gradParams) do
+            gradParam:mul(rho)
+         end
+      end
+   end
+   
+   self.gradParametersAccumulated = true
+   return gradInput
+end
+
+function Recurrent:accUpdateGradParametersThroughTime(lr)
+   local rho = math.min(self.rho, self.step-1)
+   local stop = self.step - rho
+   for step=self.step-1,math.max(stop,2),-1 do
+      -- set the output/gradOutput states of current Module
+      local modules = self.recurrentModule:listModules()
+      local recurrentOutputs = self.recurrentOutputs[step]
+      local recurrentGradInputs = self.recurrentGradInputs[step]
+      
+      for i,modula in ipairs(modules) do
+         local output, gradInput = modula.output, modula.gradInput
+         local output_ = recurrentOutputs[i]
+         local gradInput_ = recurrentGradInputs[i]
+         assert(output_, "accGradParametersThroughTime should be preceded by updateOutput")
+         assert(gradInput_, "accGradParametersThroughTime should be preceded by updateGradInputThroughTime")
+         modula.output = output_
+         modula.gradInput = gradInput_
+      end
+      
+      -- backward propagate through this step
+      local input = self.inputs[step]
+      local output = self.outputs[step-1]
+      local gradOutput = self.gradOutputs[step]
+
+      local scale = self.scales[step]
+      self.recurrentModule:accUpdateGradParameters({input, output}, gradOutput, lr*scale/rho)
+   end
+   
+   if stop <= 1 then
+      -- set the output/gradOutput states of initialModule
+      local modules = self.initialModule:listModules()
+      for i,modula in ipairs(modules) do
+         local output, gradInput = modula.output, modula.gradInput
+         local output_ = self.initialOutputs[i]
+         local gradInput_ = self.initialGradInputs[i] 
+         modula.output = output_
+         modula.gradInput = gradInput_
+      end
+      
+      -- backward propagate through first step
+      local input = self.inputs[1]
+      local gradOutput = self.gradOutputs[1]
+      local scale = self.scales[1]
+      self.inputModule:accUpdateGradParameters(input, self.startModule.gradInput, lr*scale/rho)
+      -- startModule's gradParams shouldn't be step-averaged as it is used only once.
+      self.startModule:accUpdateGradParameters(self.inputModule.output, self.transferModule.gradInput, lr*scale)
+   end
+   
+   return gradInput
+end
+
+function Recurrent:updateParameters(learningRate)
+   if self.gradParametersAccumulated then
+      for i=1,#self.modules do
+         self.modules[i]:updateParameters(learningRate)
+      end
+   else
+      self:backwardUpdateThroughTime(learningRate)
+   end
+end
+
+-- goes hand in hand with the next method : forget()
+function Recurrent:recycle()
+   -- +1 is to skip initialModule
+   if self.step > self.rho + 1 then
+      assert(self.recurrentOutputs[self.step] == nil)
+      assert(self.recurrentOutputs[self.step-self.rho] ~= nil)
+      self.recurrentOutputs[self.step] = self.recurrentOutputs[self.step-self.rho]
+      self.recurrentGradInputs[self.step] = self.recurrentGradInputs[self.step-self.rho]
+      self.recurrentOutputs[self.step-self.rho] = nil
+      self.recurrentGradInputs[self.step-self.rho] = nil
+      -- need to keep rho+1 of these
+      self.outputs[self.step] = self.outputs[self.step-self.rho-1] 
+      self.outputs[self.step-self.rho-1] = nil
+   end
+   if self.step > self.rho then
+      assert(self.inputs[self.step] == nil)
+      assert(self.inputs[self.step-self.rho] ~= nil)
+      self.inputs[self.step] = self.inputs[self.step-self.rho] 
+      self.gradOutputs[self.step] = self.gradOutputs[self.step-self.rho] 
+      self.inputs[self.step-self.rho] = nil
+      self.gradOutputs[self.step-self.rho] = nil
+      self.scales[self.step-self.rho] = nil
+   end
+end
+
+function Recurrent:forget()
+
+   if self.train ~= false then
+      -- bring all states back to the start of the sequence buffers
+      local lastStep = self.step - 1
+      
+      if lastStep > self.rho + 1 then
+         local i = 2
+         for step = lastStep-self.rho+1,lastStep do
+            self.recurrentOutputs[i] = self.recurrentOutputs[step]
+            self.recurrentGradInputs[i] = self.recurrentGradInputs[step]
+            self.recurrentOutputs[step] = nil
+            self.recurrentGradInputs[step] = nil
+            -- we keep rho+1 of these : outputs[k]=outputs[k+rho+1]
+            self.outputs[i-1] = self.outputs[step]
+            self.outputs[step] = nil
+            i = i + 1
+         end
+         
+      end
+      
+      if lastStep > self.rho then
+         local i = 1
+         for step = lastStep-self.rho+1,lastStep do
+            self.inputs[i] = self.inputs[step]
+            self.gradOutputs[i] = self.gradOutputs[step]
+            self.inputs[step] = nil
+            self.gradOutputs[step] = nil
+            self.scales[step] = nil
+            i = i + 1
+         end
+
+      end
+   end
+   
+   -- forget the past inputs; restart from first step
+   self.step = 1
+end
+
+function Recurrent:__tostring__()
+   local tab = '  '
+   local line = '\n'
+   local next = ' -> '
+   local str = torch.type(self)
+   str = str .. ' {' .. line .. tab .. '[{input(t), output(t-1)}'
+   for i=1,3 do
+      str = str .. next .. '(' .. i .. ')'
+   end
+   str = str .. next .. 'output(t)]'
+   
+   local tab = '  '
+   local line = '\n  '
+   local next = '  |`-> '
+   local ext = '  |    '
+   local last = '   ... -> '
+   str = str .. line ..  '(1): ' .. ' {' .. line .. tab .. 'input(t)'
+   str = str .. line .. tab .. next .. '(t==0): ' .. tostring(self.startModule):gsub('\n', '\n' .. tab .. ext)
+   str = str .. line .. tab .. next .. '(t~=0): ' .. tostring(self.inputModule):gsub('\n', '\n' .. tab .. ext)
+   str = str .. line .. tab .. 'output(t-1)'
+   str = str .. line .. tab .. next .. tostring(self.feedbackModule):gsub('\n', line .. tab .. ext)
+   local tab = '  '
+   local line = '\n'
+   local next = ' -> '
+   str = str .. line .. tab .. '(' .. 2 .. '): ' .. tostring(self.mergeModule):gsub(line, line .. tab)
+   str = str .. line .. tab .. '(' .. 3 .. '): ' .. tostring(self.transferModule):gsub(line, line .. tab)
+   str = str .. line .. '}'
+   return str
+end

--- a/doc/containers.md
+++ b/doc/containers.md
@@ -5,7 +5,8 @@ Complex neural networks are easily built using container classes:
    * [Sequential](#nn.Sequential) : plugs layers in a feed-forward fully connected manner ;
    * [Parallel](#nn.Parallel) : applies its `ith` child module to the  `ith` slice of the input Tensor ;
    * [Concat](#nn.Concat) : concatenates in one layer several modules along dimension `dim` ;
-     * [DepthConcat](#nn.DepthConcat) : like Concat, but adds zero-padding when non-`dim` sizes don't match;
+     * [DepthConcat](#nn.DepthConcat) : like Concat, but adds zero-padding when non-`dim` sizes don't match ;
+   * [Recurrent](#nn.Recurrent) : for  Recurrent Neural Networks (RNN).
  
 See also the [Table Containers](#nn.TableContainers) for manipulating tables of [Tensors](https://github.com/torch/torch7/blob/master/doc/tensor.md).
 
@@ -230,6 +231,109 @@ This is inevitable when the component
 module output tensors non-`dim` sizes aren't all odd or even. 
 Such that in order to keep the mappings aligned, one need 
 only ensure that these be all odd (or even).
+
+<a name='nn.Recurrent'/>
+### Recurrent ###
+References :
+ * A. [Sutsekever Thesis Sec. 2.5 and 2.8](http://www.cs.utoronto.ca/~ilya/pubs/ilya_sutskever_phd_thesis.pdf)
+ * B. [Mikolov Thesis Sec. 3.2 and 3.3](http://www.fit.vutbr.cz/~imikolov/rnnlm/thesis.pdf)
+ * C. [RNN and Backpropagation Guide](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.3.9311&rep=rep1&type=pdf)
+
+A [composite Module](https://github.com/torch/nn/blob/master/doc/containers.md#containers) for implementing Recurrent Neural Networks (RNN), excluding the output layer. 
+
+The `nn.Recurrent(start, input, feedback, [transfer, rho, merge])` constructor takes 5 arguments:
+ * `start` : the size of the output (excluding the batch dimension), or a Module that will be inserted between the `input` Module and `transfer` module during the first step of the propagation. When `start` is a size (a number or `torch.LongTensor`), then this *start* Module will be initialized as `nn.Add(start)` (see Ref. A).
+ * `input` : a Module that processes input Tensors (or Tables). Output must be of same size as `start` (or its output in the case of a `start` Module), and same size as the output of the `feedback` Module.
+ * `feedback` : a Module that feedbacks the previous output Tensor (or Tables) up to the `transfer` Module.
+ * `transfer` : a non-linear Module used to process the element-wise sum of the `input` and `feedback` module outputs, or in the case of the first step, the output of the *start* Module.
+ * `rho` : the maximum amount of backpropagation steps to take back in time. Limits the number of previous steps kept in memory. Due to the vanishing gradients effect, references A and B recommend `rho = 5` (or lower). Defaults to 5.
+ * `merge` : a [table Module](https://github.com/torch/nn/blob/master/doc/table.md#table-layers) that merges the outputs of the `input` and `feedback` Module before being forwarded through the `transfer` Module.
+ 
+An RNN is used to process a sequence of inputs. 
+Each step in the sequence should be propagated via its own call to `forward` (and `backward`), 
+one `input` (and `gradOutput`) at a time. 
+Each call to `forward` keeps a log of the intermediate states (the `input` and many `Module.outputs`) 
+and increments the `step` attribute by 1. 
+A call to `backward` doesn't result in a `gradInput`. It only keeps a log of the current `gradOutput` and `scale`.
+Back-Propagation Through Time (BPTT) is done when the `updateParameters` or `backwardThroughTime` method
+is called. The `step` attribute is only reset to 1 when a call to the `forget` method is made. 
+In which case, the Module is ready to process the next sequence (or batch thereof).
+Note that the longer the sequence, the more memory that will be required to store all the 
+`output` and `gradInput` states (one for each time step). 
+
+To use this module with batches, we suggest using different 
+sequences of the same size within a batch and calling `updateParameters` 
+every `rho` steps and `forget` at the end of the Sequence. 
+
+Note that calling the `evaluate` method turns off long-term memory; 
+the RNN will only remember the previous output. This allows the RNN 
+to handle long sequences without allocating any additional memory.
+
+Example :
+```lua
+require 'nn'
+
+batchSize = 8
+rho = 5
+hiddenSize = 10
+nIndex = 10000
+-- RNN
+r = nn.Recurrent(
+   hiddenSize, nn.LookupTable(nIndex, hiddenSize), 
+   nn.Linear(hiddenSize, hiddenSize), nn.Sigmoid(), 
+   rho
+)
+
+rnn = nn.Sequential()
+rnn:add(r)
+rnn:add(nn.Linear(hiddenSize, nIndex))
+rnn:add(nn.LogSoftMax())
+
+criterion = nn.ClassNLLCriterion()
+
+-- dummy dataset (task is to predict next item, given previous)
+sequence = torch.randperm(nIndex)
+
+offsets = {}
+for i=1,batchSize do
+   table.insert(offsets, math.ceil(math.random()*batchSize))
+end
+offsets = torch.LongTensor(offsets)
+
+lr = 0.1
+updateInterval = 4
+i = 1
+while true do
+   -- a batch of inputs
+   local input = sequence:index(1, offsets)
+   local output = rnn:forward(input)
+   -- incement indices
+   offsets:add(1)
+   for j=1,batchSize do
+      if offsets[j] > nIndex then
+         offsets[j] = 1
+      end
+   end
+   local target = sequence:index(1, offsets)
+   local err = criterion:forward(output, target)
+   local gradOutput = criterion:backward(output, target)
+   -- the Recurrent layer is memorizing its gradOutputs (up to memSize)
+   rnn:backward(input, gradOutput)
+   
+   i = i + 1
+   -- note that updateInterval < rho
+   if i % updateInterval then
+      -- backpropagates through time (BPTT) :
+      -- 1. backward through feedback and input layers,
+      -- 2. updates parameters
+      r:updateParameters(lr)
+   end
+end
+```
+
+Note that this won't work with `input` and `feedback` modules that use more than their
+`output` attribute to keep track of their internal state between 
+calls to `forward` and `backward`.
 
 <a name="nn.TableContainers"/>
 ## Table Containers ##

--- a/init.lua
+++ b/init.lua
@@ -9,6 +9,7 @@ include('Concat.lua')
 include('Parallel.lua')
 include('Sequential.lua')
 include('DepthConcat.lua')
+include('Recurrent.lua')
 
 include('Linear.lua')
 include('SparseLinear.lua')


### PR DESCRIPTION
This PR provides the Recurrent module that can be used to build RNNs. Depends on #158 (for listModules). Includes docs and unit tests.

I also removed redundant lines from `ParallelTable:__tostring__` where `(i == self.modules)` is never true.