### PR TITLE
CosineEmbeddingCriterion: zero grads below margin

### DIFF
--- a/CosineEmbeddingCriterion.lua
+++ b/CosineEmbeddingCriterion.lua
@@ -32,16 +32,18 @@ function CosineEmbeddingCriterion:updateGradInput(input, y)
    gw2:resizeAs(v1)
 
    gw1:zero()
-   gw1:add(1/(self.w2*self.w3), v2)
-   gw1:add(-self.w1/(self.w22*self.w2*self.w3), v1)
-   
    gw2:zero()
-   gw2:add(1/(self.w2*self.w3), v1)
-   gw2:add(-self.w1/(self.w32*self.w2*self.w3), v2)
 
+   if self.output > 0 then
+      gw1:add(1/(self.w2*self.w3), v2)
+      gw1:add(-self.w1/(self.w22*self.w2*self.w3), v1)
+
+      gw2:add(1/(self.w2*self.w3), v1)
+      gw2:add(-self.w1/(self.w32*self.w2*self.w3), v2)
+   end
    if y == 1 then
-      gw1 = -gw1
-      gw2 = -gw2
+      gw1:mul(-1)
+      gw2:mul(-1)
    end
    self.gradInput = {gw1, gw2}
    return self.gradInput

--- a/test.lua
+++ b/test.lua
@@ -3124,6 +3124,19 @@ function nntest.BatchMMTransposeBoth()
   end
 end
 
+function nntest.CosineEmbeddingCriterion()
+  local v1 = torch.Tensor{1, 0}
+  local v2 = torch.Tensor{0.5, math.sqrt(3)*0.5}
+
+  local crit = nn.CosineEmbeddingCriterion(0.6)
+  local output = crit:forward({v1, v2}, -1) -- must be called before backward
+  local grads = crit:backward({v1, v2}, -1)
+
+  local zero = torch.Tensor(2):zero()
+  equal(grads[1], zero, 'gradient should be zero')
+  equal(grads[2], zero, 'gradient should be zero')
+end
+
 mytester:add(nntest)
 
 if not nn then


### PR DESCRIPTION
For negative pairs (`y == - 1`) the margin was NOT taken into account when computing the gradients.

In other words `updateGradInput` did return non zero gradients when the cosine similarity was below the margin (e.g this is not the case with [L1HingeEmbeddingCriterion](https://github.com/torch/nn/blob/822a742/L1HingeEmbeddingCriterion.lua#L33-L35) which behaves properly).

I have included a tiny non regression test.