### PR TITLE
Prevent sharing parameters between unrelated modules

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -93,6 +93,7 @@ function Module:share(mlp, ...)
    local arg = {...}
    for i,v in ipairs(arg) do
       if self[v] ~= nil then
+         assert(self[v]:isSameSizeAs(mlp[v]), 'Module: shared Tensor size does not match (' .. v .. ')')
          self[v]:set(mlp[v])
          self.accUpdateGradParameters = self.sharedAccUpdateGradParameters
          mlp.accUpdateGradParameters = mlp.sharedAccUpdateGradParameters


### PR DESCRIPTION
I'm proposing a safety check to prevent accidental sharing of parameters between e.g. convolutions of different sizes.