### PR TITLE
Fixed SpatialAveragePooling - added division by filter size

### DIFF
--- a/generic/SpatialAveragePooling.c
+++ b/generic/SpatialAveragePooling.c
@@ -83,7 +83,7 @@ static int nn_(SpatialAveragePooling_updateOutput)(lua_State *L)
             ptr_input += inputWidth; /* next input line */
           }
           /* Update output */
-          *ptr_output++ += sum;
+          *ptr_output++ += sum/kW/kH;
         }
       }
     }
@@ -163,7 +163,7 @@ static int nn_(SpatialAveragePooling_updateGradInput)(lua_State *L)
           for(ky = 0; ky < kH; ky++)
           {
             for(kx = 0; kx < kW; kx++)
-              ptr_gradInput[kx] += z;
+              ptr_gradInput[kx] += z/kW/kH;
             ptr_gradInput += inputWidth;
           }
         }

--- a/test.lua
+++ b/test.lua
@@ -1706,7 +1706,7 @@ function nntest.SpatialAveragePooling()
    mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
    
    local sap = nn.SpatialSubSampling(from, ki, kj, si, sj)
-   sap.weight:fill(1.0)
+   sap.weight:fill(1.0/ki/kj)
    sap.bias:fill(0.0)
    
    local output = module:forward(input)
@@ -1737,7 +1737,7 @@ function nntest.SpatialAveragePooling()
    mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err (Batch) ')
    
    local sap = nn.SpatialSubSampling(from, ki, kj, si, sj)
-   sap.weight:fill(1.0)
+   sap.weight:fill(1.0/ki/kj)
    sap.bias:fill(0.0)
    
    local output = module:forward(input)


### PR DESCRIPTION
SpatialAveragePooling layer only summed the filters without dividing by filter size, the following code failed:
```lua
require 'nn'
require 'cudnn'
a = torch.rand(1,1,2,2):fill(1)
l = nn.SpatialAveragePooling(2,2)
b = l:forward(a)

a2 = torch.rand(1,1,2,2):fill(1):cuda()
l2 = cudnn.SpatialAveragePooling(2,2):cuda()
b2 = l:forward(a)

assert(b==b2)
```
Fixed both forward and backward.
