### PR TITLE
fixed Power.lua

### DIFF
--- a/Power.lua
+++ b/Power.lua
@@ -15,7 +15,10 @@ function Power:updateOutput(input)
 end
 
 function Power:updateGradInput(input, gradOutput)
+   self.buffer = self.buffer or input.new()
+   self.buffer:resizeAs(input):copy(input)
+   self.buffer:pow(self.pow - 1)
    self.gradInput:resizeAs(input):copy(gradOutput)
-   self.gradInput:cmul(self.output):cdiv(input):mul(self.pow)
+   self.gradInput:cmul(self.buffer):mul(self.pow)
    return self.gradInput
 end


### PR DESCRIPTION
The previous version won't support inputs which contain 0s due to the fact it was dividing by the input. This version solves this problem.