### PR TITLE
Added 2 calls to collect garbage for getParameters

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -241,7 +241,9 @@ function Module:getParameters()
 
    -- flatten parameters and gradients
    local flatParameters = flatten(parameters)
+   collectgarbage()
    local flatGradParameters = flatten(gradParameters)
+   collectgarbage()
 
    -- return new flat vector that contains all discrete parameters
    return flatParameters, flatGradParameters


### PR DESCRIPTION
These 2 calls of collectgarbage() can save a large chunk of temporary memory when calling getParameters(). It is particularly useful when working with GPUs on a model with large number of parameters, for which it would otherwise be impossible to even call getParameters() (out of memory cuda error).