### PR TITLE
Module:sharedClone()

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -1,5 +1,8 @@
 local Module = torch.class('nn.Module')
 
+Module.__parameters__ = {'weight', 'bias'}
+Module.__gradParameters__ = {'gradWeight', 'gradBias'}
+
 function Module:__init()
    self.gradInput = torch.Tensor()
    self.output = torch.Tensor()
@@ -312,4 +315,74 @@ function Module:listModules()
    end
    return modules
 end
+
+-- clone the Module while sharing parameters or gradParameters
+function Module:sharedClone(shareParams, shareGradParams)
+   shareParams = (shareParams == nil) and true or shareParams
+   shareGradParams = (shareGradParams == nil) and true or shareGradParams
+   assert(shareParams or shareGradParams, "can only share parameters or gradParameters")
+   
+   local moduleClones, modules
+   if self.modules then
+      moduleClones = {}
+      for i,module in ipairs(self.modules) do
+         moduleClones[i] = module:sharedClone(shareParams, shareGradParams)
+      end
+      modules = self.modules
+      self.modules = nil -- to prevent recloning
+   end
+   
+   local params, pointers = {}, {}
+   if shareParams then
+      for i,paramName in ipairs(self.__parameters__) do
+         local param = self[paramName]
+         if param then
+            params[paramName] = param
+            self[paramName] = nil
+            if param:storage() then
+               pointers[torch.pointer(param:storage():data())] = true
+            end
+         end
+      end
+   end
+   
+   if shareGradParams then
+      for i,paramName in ipairs(self.__gradParameters__) do
+         local gradParam = self[paramName]
+         if gradParam then
+            params[paramName] = gradParam
+            self[paramName] = nil
+            if gradParam:storage() then
+               pointers[torch.pointer(gradParam:storage():data())] = true
+            end
+         end
+      end
+   end
+   
+   -- find all the tensors that share storage with the shared params
+   for name, param in pairs(self) do
+      if torch.isTensor(param) and param:storage() then
+         if pointers[torch.pointer(param:storage():data())] then
+            params[paramName] = param
+            self[paramName] = nil
+         end
+      end
+   end
+   
+   -- clone everything but parameters and/or gradients
+   local clone = self:clone()
+   
+   for paramName, param in pairs(params) do
+      assert(self[paramName] == nil)
+      self[paramName] = param
+      clone[paramName] = param.new():set(param)
+   end
+   
+   if moduleClones then
+      assert(self.modules == nil)
+      self.modules = modules
+      clone.modules = moduleClones
+   end
+   return clone
+end           
 

--- a/test.lua
+++ b/test.lua
@@ -2347,6 +2347,71 @@ function nntest.Module_listModules()
    end   
 end
 
+function nntest.Module_sharedClone()
+
+   local function test(mlp, name)
+      mlp:zeroGradParameters()
+      local clone = mlp:clone()
+      clone:share(mlp,"weight","bias","gradWeight","gradBias")
+      
+      local mlp2 = mlp:clone() -- not shared with mlp
+      local clone2 = mlp2:sharedClone(true, true)
+      
+      local input = torch.randn(2,3)
+      local gradOutput = torch.randn(2,4)
+      
+      local output = mlp:forward(input)
+      local gradInput = mlp:backward(input, gradOutput)
+      local output4 = clone:forward(input)
+      local gradInput4 = clone:backward(input, gradOutput)
+      
+      mytester:assertTensorEq(output, output4, 0.00001, name.." updateOutput")
+      mytester:assertTensorEq(gradInput, gradInput4, 0.00001, name.." updateGradInput")
+      
+      local output2 = clone2:forward(input)
+      local gradInput2 = clone2:backward(input, gradOutput)
+      
+      mytester:assertTensorEq(output, output2, 0.00001, name.." updateOutput")
+      mytester:assertTensorEq(gradInput, gradInput2, 0.00001, name.." updateGradInput")
+      
+      local output3 = mlp2:forward(input)
+      local gradInput3 = mlp2:backward(input, gradOutput)
+      
+      mlp:updateParameters(0.1)
+      mlp2:updateParameters(0.1)
+      
+      mytester:assertTensorEq(output3, output2, 0.00001, name.." updateOutput")
+      mytester:assertTensorEq(gradInput3, gradInput2, 0.00001, name.." updateGradInput")
+      
+      local params, gradParams = mlp:parameters()
+      local params4, gradParams4 = clone:parameters()
+      local params2, gradParams2 = clone2:parameters()
+      local params3, gradParams3 = mlp2:parameters()
+      
+      mytester:assert(#params == #params2, name.." num params err")
+      mytester:assert(#params3 == #params2, name.." num params err")
+      mytester:assert(#gradParams == #gradParams2, name.." num gradParams err")
+      mytester:assert(#gradParams == #gradParams3, name.." num gradParams err")
+      
+      for i,param in ipairs(params) do
+         mytester:assertTensorEq(param, params2[i], 0.00001, name.." params2 err "..i)
+         mytester:assertTensorEq(param, params4[i], 0.00001, name.." params4 err "..i)
+         mytester:assertTensorEq(param, params3[i], 0.00001, name.." params3 err "..i)
+         mytester:assertTensorEq(gradParams[i], gradParams2[i], 0.00001, name.." gradParams2 err "..i)
+         mytester:assertTensorEq(gradParams[i], gradParams4[i], 0.00001, name.." gradParams4 err "..i)
+         mytester:assertTensorEq(gradParams[i], gradParams3[i], 0.00001, name.." gradParams3 err "..i)
+      end
+   end
+   
+   test(nn.Linear(3,4), 'linear')
+   local mlp = nn.Sequential()
+   mlp:add(nn.Linear(3,7))
+   mlp:add(nn.Tanh())
+   mlp:add(nn.Euclidean(7,4))
+   mlp:add(nn.LogSoftMax())
+   test(mlp, 'sequential')
+end
+
 function nntest.PairwiseDistance()
    -- Note: testJacobian doesn't support table inputs, and rather than re-write
    -- it so that it does, I'll just use a split table module on the input.


### PR DESCRIPTION
This PR adds Module:sharedClone(). 

With this PR, the common pattern of:
```lua
clone = mlp:clone() -- this copies all the parameters and gradParameters
clone:share(mlp,"weight","gradWeight","bias","gradBias") -- this deletes and replaces them with mlp's
```
will become the more memory efficient:
```lua
clone = mlp:sharedClone()
```

And because each sub-module can override static variables `__parameters__` and `__gradParameters__`. You can call huge structures of Modules with different parameters names and still expect them to correctly be shared.

Not sure this will make it into nn. So I will only work on the doc when this gets approval. If you would like this method to be usable for attributes other than parameters/gradParameters, I could make this method `Module:sharedParamClone(bool shareGradParams)` and make it call `Module:sharedClone(...)` where `...` is the attributes like : `weight, bias, etc.`. 