### PR TITLE
SpatialConvolutionMM: fixed corruption on small padded tensors

### DIFF
--- a/generic/SpatialConvolutionMM.c
+++ b/generic/SpatialConvolutionMM.c
@@ -96,9 +96,13 @@ static void nn_(unfolded_copy)(THTensor *finput, THTensor *input,
              ix = 0 - padding + kw;
              lpad = fmaxf(0,padding-kw);
              rpad = fmaxf(0,padding-(kW-kw-1));
-             if (lpad > 0) memset(dst+y*outputWidth, 0, sizeof(real)*lpad);
-             memcpy(dst+y*outputWidth+lpad, src+iy*inputWidth+ix+lpad, sizeof(real)*(outputWidth-rpad-lpad));
-             if (rpad > 0) memset(dst+y*outputWidth + outputWidth - rpad, 0, sizeof(real)*rpad);
+             if (outputWidth-rpad-lpad <= 0) {
+                memset(dst+y*outputWidth, 0, sizeof(real)*outputWidth);
+             } else {
+                if (lpad > 0) memset(dst+y*outputWidth, 0, sizeof(real)*lpad);
+                memcpy(dst+y*outputWidth+lpad, src+iy*inputWidth+ix+lpad, sizeof(real)*(outputWidth-rpad-lpad));
+                if (rpad > 0) memset(dst+y*outputWidth + outputWidth - rpad, 0, sizeof(real)*rpad);
+             }
           }
           else{
             for (x=0; x<outputWidth; x++){


### PR DESCRIPTION
There is a bug in SpatialConvolutionMM when using padding and convolving tensors with filters which are larger than the input. For example, the following snippet produces a segfault:
```
require 'nn'
M = nn.SpatialConvolutionMM(4,4,5,5,1,1,2)
T = torch.Tensor(4,1,1):zero()
print(M(T))
```
My assumption is that the code on lines 104-110 should produce the same result as lines 96-101 when dW=1. Therefore the fix.