### PR TITLE
empty addBuffer fix

### DIFF
--- a/Linear.lua
+++ b/Linear.lua
@@ -41,7 +41,7 @@ function Linear:updateOutput(input)
       local nframe = input:size(1)
       local nunit = self.bias:size(1)
       self.output:resize(nframe, nunit)
-      if not self.addBuffer or self.addBuffer:size(1) ~= nframe then
+      if not self.addBuffer or self.addBuffer:nElement() ~= nframe then
          self.addBuffer = input.new(nframe):fill(1)
       end
       if nunit == 1 then


### PR DESCRIPTION
This PR fixes a bug where the Linear.addBuffer is empty. This happens when using some of the torch-utils tools where non parameter buffers are resized to zero when saved to disk, and then reloaded. 

Not sure this is a good reason to make the PR, but in any case, it fixes the bug.