### PR TITLE
SelectTable:type() must call Model:type()

### DIFF
--- a/SelectTable.lua
+++ b/SelectTable.lua
@@ -38,4 +38,5 @@ end
 
 function SelectTable:type(type)
    self.gradInput = {}
+   return parent.type(self, type)
 end


### PR DESCRIPTION
Model:type() is overriden:
```Lua
function SelectTable:type(type)
  self.gradInput = {}
end
```
However, SelectTable has other fields: output and _type, which should be changed by this function.
Proposed fix: add `return parent.type(self,type)` before the end of the function.
`parent:type(type)` doesn't work, because the `self` that is used in this call does not contain the attributes of SelectTable.
`return` has been added because it is done like this in the other :type() functions.