### PR TITLE
SpatialConvolutionMM: removed clearFlag, as it is not necessary anymore ...

### DIFF
--- a/generic/SpatialConvolutionMM.c
+++ b/generic/SpatialConvolutionMM.c
@@ -211,10 +211,6 @@ static int nn_(SpatialConvolutionMM_updateOutput)(lua_State *L)
     THTensor_(resize3d)(finput, T, kW*kH*nInputPlane, outputHeight*outputWidth);
     THTensor_(resize4d)(output, T, nOutputPlane, outputHeight, outputWidth);
 
-    THStorage_(clearFlag)(input->storage, TH_STORAGE_REFCOUNTED);
-    THStorage_(clearFlag)(output->storage, TH_STORAGE_REFCOUNTED);
-    THStorage_(clearFlag)(finput->storage, TH_STORAGE_REFCOUNTED);
-
 #pragma omp parallel for private(t)
     for(t = 0; t < T; t++)
     {
@@ -231,9 +227,6 @@ static int nn_(SpatialConvolutionMM_updateOutput)(lua_State *L)
       THTensor_(free)(output_t);
       THTensor_(free)(finput_t);
     }
-    THStorage_(setFlag)(input->storage, TH_STORAGE_REFCOUNTED);
-    THStorage_(setFlag)(output->storage, TH_STORAGE_REFCOUNTED);
-    THStorage_(setFlag)(finput->storage, TH_STORAGE_REFCOUNTED);
   }
 
   return 1;
@@ -285,10 +278,6 @@ static int nn_(SpatialConvolutionMM_updateGradInput)(lua_State *L)
     long T = input->size[0];
     long t;
 
-    THStorage_(clearFlag)(gradInput->storage, TH_STORAGE_REFCOUNTED);
-    THStorage_(clearFlag)(gradOutput->storage, TH_STORAGE_REFCOUNTED);
-    THStorage_(clearFlag)(fgradInput->storage, TH_STORAGE_REFCOUNTED);
-
 #pragma omp parallel for private(t)
     for(t = 0; t < T; t++)
     {
@@ -302,10 +291,6 @@ static int nn_(SpatialConvolutionMM_updateGradInput)(lua_State *L)
       THTensor_(free)(gradOutput_t);
       THTensor_(free)(fgradInput_t);
     }
-
-    THStorage_(setFlag)(gradInput->storage, TH_STORAGE_REFCOUNTED);
-    THStorage_(setFlag)(gradOutput->storage, TH_STORAGE_REFCOUNTED);
-    THStorage_(setFlag)(fgradInput->storage, TH_STORAGE_REFCOUNTED);
   }
 
   THTensor_(transpose)(weight, weight, 0, 1);


### PR DESCRIPTION
...(since atomic refcounting).

clearFlag is also harmful (not thread-safe) when forward/backward are called in several threads.