### PR TITLE
ParallelCriterion

### DIFF
--- a/MultiCriterion.lua
+++ b/MultiCriterion.lua
@@ -30,3 +30,10 @@ function MultiCriterion:updateGradInput(input, target)
    end
    return self.gradInput
 end
+
+function MultiCriterion:type(type)
+   for i,criterion in ipairs(self.criterions) do
+      criterion:type(type)
+   end
+   return parent.type(self, type)
+end

--- a/ParallelCriterion.lua
+++ b/ParallelCriterion.lua
@@ -1,0 +1,52 @@
+local ParallelCriterion, parent = torch.class('nn.ParallelCriterion', 'nn.Criterion')
+
+function ParallelCriterion:__init(repeatTarget)
+   parent.__init(self)
+   self.criterions = {}
+   self.weights = {}
+   self.gradInput = {}
+   self.repeatTarget = repeatTarget
+end
+
+function ParallelCriterion:add(criterion, weight)
+   weight = weight or 1
+   table.insert(self.criterions, criterion)
+   table.insert(self.weights, weight)
+   return self
+end
+
+function ParallelCriterion:updateOutput(input, target)
+   self.output = 0
+   if not self.repeatTarget then
+      for i,criterion in ipairs(self.criterions) do
+         self.output = self.output + self.weights[i]*criterion:updateOutput(input[i],target[i])
+      end
+   else
+      for i,criterion in ipairs(self.criterions) do
+         self.output = self.output + self.weights[i]*criterion:updateOutput(input[i],target)
+      end
+   end
+   return self.output
+end
+
+function ParallelCriterion:updateGradInput(input, target)
+   if not self.repeatTarget then
+      for i,criterion in ipairs(self.criterions) do
+         self.gradInput[i] = input[i].new() or self.gradInput[i]
+         self.gradInput[i]:resizeAs(input[i]):zero()
+         self.gradInput[i]:add(self.weights[i], criterion:updateGradInput(input[i],target[i]))
+      end
+   else
+      for i,criterion in ipairs(self.criterions) do
+         self.gradInput[i] = input[i].new() or self.gradInput[i]
+         self.gradInput[i]:resizeAs(input[i]):zero()
+         self.gradInput[i]:add(self.weights[i], criterion:updateGradInput(input[i],target))
+      end
+   end
+   return self.gradInput
+end
+
+function ParallelCriterion:type(type)
+   self.gradInput = {}
+   return parent.type(self, type)
+end

--- a/init.lua
+++ b/init.lua
@@ -121,6 +121,7 @@ include('L1Penalty.lua')
 include('WeightedMSECriterion.lua')
 include('BCECriterion.lua')
 include('CrossEntropyCriterion.lua')
+include('ParallelCriterion.lua')
 
 include('StochasticGradient.lua')
 


### PR DESCRIPTION
This PR adds the ParallelCriterion (formerly [SuperCriterion](https://github.com/clementfarabet/lua---nnx/blob/master/SuperCriterion.lua)). It includes unit tests and doc. It also includes unit tests for the related MultiCriterion and some doc to differentiate the two. I changed the name to make it more consistent with the naming convention of Modules.