### PR TITLE
small improvements in ConcatTable and ClassNLLCriterion

### DIFF
--- a/ClassNLLCriterion.lua
+++ b/ClassNLLCriterion.lua
@@ -10,6 +10,16 @@ function ClassNLLCriterion:__init(weights)
    end
 end
 
+
+function ClassNLLCriterion:__len()
+   if (self.weights) then
+      return #self.weights
+   else
+      return 0
+   end
+end
+
+
 function ClassNLLCriterion:updateOutput(input, target)
    if input:type() == 'torch.CudaTensor' and not self.weights then
       if input:dim() == 1 then


### PR DESCRIPTION
Corrects fprop in ConcatTable when model was saved with nilling (replacing all outputs with empyTensor)
corrects the behavior of who() in presence of ClassNLLCriterion
(I do not have trepl in my Windows installation)