### PR TITLE
Adding Batch L2 Normalization Layer that L2 normalizes rows of input Tensor

### DIFF
--- a/L2Normalize.lua
+++ b/L2Normalize.lua
@@ -1,0 +1,40 @@
+
+--[[ 
+   This layer expects an [n x d] Tensor and normalizes each
+   row to have unit L2 norm.
+]]--
+local L2Normalize, parent = torch.class('nn.L2Normalize', 'nn.Module')
+function L2Normalize:__init()
+   parent.__init(self)
+end
+function L2Normalize:updateOutput(input)
+   assert(input:dim() == 2, 'only mini-batch supported (2D tensor), got '
+             .. input:dim() .. 'D tensor instead')
+   self.output:resizeAs(input)
+   local norms = torch.cmul(input,input):sum(2):sqrt()
+   self.output:copy(input):cdiv(norms:expandAs(input))
+   return self.output
+end
+
+function L2Normalize:updateGradInput(input, gradOutput)
+   assert(input:dim() == 2, 'only mini-batch supported')
+   assert(gradOutput:dim() == 2, 'only mini-batch supported')
+   local n = input:size(1) -- batch size
+   local d = input:size(2) -- dimensionality of vectors
+   
+   local sums = torch.sum(torch.cmul(input,input), 2):view(-1)
+   local divterms = torch.pow(sums,3/2)
+   -- compute diagonal term
+   local diag = torch.eye(d):typeAs(input):repeatTensor(n,1):view(n,d,d)
+                   :cmul(sums:view(n,1,1):expand(n,d,d))
+   -- compute cross term
+   local b1 = input:reshape(n,d,1)
+   local b2 = input:reshape(n,1,d)
+   local cross = - torch.bmm(b1,b2)
+   -- compute the local gradient of the L2 transformation
+   local dsum = torch.cdiv(diag + cross, divterms:view(n,1,1):expand(n,d,d))
+   -- chain the gradient
+   self.gradInput = torch.bmm(dsum, gradOutput:view(n,d,1))
+   return self.gradInput
+end
+

--- a/L2Normalize.lua
+++ b/L2Normalize.lua
@@ -33,8 +33,7 @@ function L2Normalize:updateGradInput(input, gradOutput)
    local b2 = input:view(n,1,d)
    self.diag:add(-torch.bmm(b1,b2))
    -- compute the local gradient of the L2 transformation
-   self.buffer:pow(3)
-   self.diag:cdiv(self.buffer:view(n,1,1):expand(n,d,d))
+   self.diag:cdiv(torch.pow(self.buffer,3):view(n,1,1):expand(n,d,d))
    -- chain the gradient
    self.gradInput:resize(n,d,1):bmm(self.diag, gradOutput:view(n,d,1)):resize(n,d)
    return self.gradInput

--- a/L2Normalize.lua
+++ b/L2Normalize.lua
@@ -11,8 +11,11 @@ function L2Normalize:updateOutput(input)
    assert(input:dim() == 2, 'only mini-batch supported (2D tensor), got '
              .. input:dim() .. 'D tensor instead')
    self.output:resizeAs(input)
-   local norms = torch.cmul(input,input):sum(2):sqrt()
-   self.output:copy(input):cdiv(norms:expandAs(input))
+   self.buffer = self.buffer or input.new()
+   self.normSquared = self.normSquared or input.new()
+   self.normSquared:sum(self.buffer:cmul(input, input), 2)
+   self.buffer:sqrt(self.normSquared)
+   self.output:copy(input):cdiv(self.buffer:expandAs(input))
    return self.output
 end
 
@@ -21,20 +24,18 @@ function L2Normalize:updateGradInput(input, gradOutput)
    assert(gradOutput:dim() == 2, 'only mini-batch supported')
    local n = input:size(1) -- batch size
    local d = input:size(2) -- dimensionality of vectors
-
-   local sums = torch.sum(torch.cmul(input,input), 2):view(-1)
-   local divterms = torch.pow(sums,3/2)
    -- compute diagonal term
-   local diag = torch.eye(d):typeAs(input):repeatTensor(n,1):view(n,d,d)
-                   :cmul(sums:view(n,1,1):expand(n,d,d))
+   self.eye = self.eye or torch.eye(d):typeAs(input):repeatTensor(n,1):view(n,d,d)
+   self.diag = self.diag or self.eye.new()
+   self.diag:cmul(self.eye, self.normSquared:view(n,1,1):expand(n,d,d))
    -- compute cross term
-   local b1 = input:reshape(n,d,1)
-   local b2 = input:reshape(n,1,d)
-   local cross = - torch.bmm(b1,b2)
+   local b1 = input:view(n,d,1)
+   local b2 = input:view(n,1,d)
+   self.diag:add(-torch.bmm(b1,b2))
    -- compute the local gradient of the L2 transformation
-   local dsum = torch.cdiv(diag + cross, divterms:view(n,1,1):expand(n,d,d))
+   self.buffer:pow(3)
+   self.diag:cdiv(self.buffer:view(n,1,1):expand(n,d,d))
    -- chain the gradient
-   self.gradInput = torch.bmm(dsum, gradOutput:view(n,d,1)):squeeze()
+   self.gradInput:resize(n,d,1):bmm(self.diag, gradOutput:view(n,d,1)):resize(n,d)
    return self.gradInput
 end
-

--- a/L2Normalize.lua
+++ b/L2Normalize.lua
@@ -21,7 +21,7 @@ function L2Normalize:updateGradInput(input, gradOutput)
    assert(gradOutput:dim() == 2, 'only mini-batch supported')
    local n = input:size(1) -- batch size
    local d = input:size(2) -- dimensionality of vectors
-   
+
    local sums = torch.sum(torch.cmul(input,input), 2):view(-1)
    local divterms = torch.pow(sums,3/2)
    -- compute diagonal term
@@ -34,7 +34,7 @@ function L2Normalize:updateGradInput(input, gradOutput)
    -- compute the local gradient of the L2 transformation
    local dsum = torch.cdiv(diag + cross, divterms:view(n,1,1):expand(n,d,d))
    -- chain the gradient
-   self.gradInput = torch.bmm(dsum, gradOutput:view(n,d,1))
+   self.gradInput = torch.bmm(dsum, gradOutput:view(n,d,1)):squeeze()
    return self.gradInput
 end
 

--- a/init.lua
+++ b/init.lua
@@ -46,6 +46,7 @@ include('WeightedEuclidean.lua')
 include('PairwiseDistance.lua')
 include('CosineDistance.lua')
 include('DotProduct.lua')
+include('L2Normalize.lua')
 
 include('Exp.lua')
 include('Log.lua')

--- a/test.lua
+++ b/test.lua
@@ -3554,6 +3554,29 @@ function nntest.Padding()
    mytester:assertTensorEq(gradInput, input, 0.00001, "Padding backward error")
 end
 
+function nntest.L2Normalize()
+   local ini = math.random(6,8)
+   local inj = math.random(3,5)
+   local input = torch.randn(ini, inj)
+
+   local module = nn.L2Normalize()
+
+   -- test correctness of output
+   local output = module:forward(input)
+   local norms = torch.norm(output, 2, 2)
+   local desired_norms = torch.ones(ini)
+   mytester:assertTensorEq(norms, desired_norms, 0.000001, 'L2Normalize forward err')
+
+   -- test the Jacobian
+   local err = jac.testJacobian(module,input)
+   mytester:assertlt(err, precision, 'error on state ')
+
+   -- test IO correctness
+   local ferr, berr = jac.testIO(module,input)
+   mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err ')
+   mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
+end
+
 mytester:add(nntest)
 
 if not nn then


### PR DESCRIPTION
This layer L2 normalizes an `n x d` Tensor. I tested the implementation on both CPU/GPU and gradient checked it with `jac` and also with my (other) custom code. I also compared to a slower version that uses a loop, as can be seen in this [gist](https://gist.github.com/karpathy/f3ee599538ff78e1bbe9). (This batched version is quite a lot faster)

Also, I have only worked with Torch for ~2 weeks so exercise caution :)