### PR TITLE
Less cluttering tostring

### DIFF
--- a/SpatialAveragePooling.lua
+++ b/SpatialAveragePooling.lua
@@ -30,3 +30,8 @@ function SpatialAveragePooling:updateGradInput(input, gradOutput)
       return self.gradInput
    end
 end
+
+function SpatialAveragePooling:__tostring__()
+   return string.format('%s(%d,%d,%d,%d)', torch.type(self),
+         self.kW, self.kH, self.dW, self.dH)
+end

--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -121,13 +121,15 @@ function SpatialConvolution:type(type)
 end
 
 function SpatialConvolution:__tostring__()
-   local s = string.format('%s(in: %d, out: %d, kW: %d, kH: %d', torch.type(self),
+   local s = string.format('%s(%d -> %d, %dx%d', torch.type(self),
          self.nInputPlane, self.nOutputPlane, self.kW, self.kH)
    if self.dW ~= 1 or self.dH ~= 1 then
-      s = s .. string.format(', dW: %d, dH: %d', self.dW, self.dH)
+     s = s .. string.format(', %d,%d', self.dW, self.dH)
    end
-   if self.padding ~= 0 then
-      s = s .. ', padding: ' .. self.padding
+   if self.padding and self.padding ~= 0 then
+     s = s .. ', ' .. self.padding .. ',' .. self.padding
+   elseif self.pad_w or self.pad_h then
+     s = s .. ', ' .. self.pad_w .. ',' .. self.pad_h
    end
    return s .. ')'
 end

--- a/SpatialConvolutionMM.lua
+++ b/SpatialConvolutionMM.lua
@@ -85,13 +85,15 @@ function SpatialConvolutionMM:type(type)
 end
 
 function SpatialConvolutionMM:__tostring__()
-   local s = string.format('%s(in: %d, out: %d, kW: %d, kH: %d', torch.type(self),
+   local s = string.format('%s(%d -> %d, %dx%d', torch.type(self),
          self.nInputPlane, self.nOutputPlane, self.kW, self.kH)
    if self.dW ~= 1 or self.dH ~= 1 then
-      s = s .. string.format(', dW: %d, dH: %d', self.dW, self.dH)
+     s = s .. string.format(', %d,%d', self.dW, self.dH)
    end
-   if self.padding ~= 0 then
-      s = s .. ', padding: ' .. self.padding
+   if self.padding and self.padding ~= 0 then
+     s = s .. ', ' .. self.padding .. ',' .. self.padding
+   elseif self.pad_w or self.pad_h then
+     s = s .. ', ' .. self.pad_w .. ',' .. self.pad_h
    end
    return s .. ')'
 end

--- a/SpatialMaxPooling.lua
+++ b/SpatialMaxPooling.lua
@@ -34,6 +34,6 @@ function SpatialMaxPooling:empty()
 end
 
 function SpatialMaxPooling:__tostring__()
-   return string.format('%s(kW: %d, kH: %d, dW: %d, dH: %d)', torch.type(self),
+   return string.format('%s(%d,%d,%d,%d)', torch.type(self),
          self.kW, self.kH, self.dW, self.dH)
 end


### PR DESCRIPTION
As discussed with @Atcold tostrings look like this:
```
nn.Sequential {
  [input -> (1) -> (2) -> (3) -> (4) -> (5) -> (6) -> (7) -> (8) -> (9) -> (10) -> output]
  (1): nn.SpatialConvolution(2 -> 96, 7x7, 3,3)
  (2): nn.ReLU
  (3): nn.SpatialMaxPooling(2,2,2,2)
  (4): nn.SpatialConvolution(96 -> 192, 5x5)
  (5): nn.ReLU
  (6): nn.SpatialMaxPooling(2,2,2,2)
  (7): nn.SpatialConvolution(192 -> 256, 3x3)
  (8): nn.ReLU
  (9): nn.View
  (10): nn.Linear(256 -> 1)
}
```
Also fixes https://github.com/torch/nn/issues/279 and adds similar tostring to average pooling