### PR TITLE
batchnorm is clonable by adding the running estimates to constructor

### DIFF
--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -512,10 +512,10 @@ w2=image.display(processed)
 <a name="nn.SpatialBatchNormalization"/>
 ## SpatialBatchNormalization ##
 
-`module` = `nn.SpatialBatchNormalization(N [,eps] [, momentum])`
+`module` = `nn.SpatialBatchNormalization(N [,eps] [, momentum] [,affine])`
  where N = number of input feature maps
-giving N = 0 disables the learnable affine transform.
 eps is a small value added to the standard-deviation to avoid divide-by-zero. Defaults to 1e-5
+`affine` is a boolean. When set to false, the learnable affine transform is disabled.  Defaults to true
 
 Implements Batch Normalization as described in the paper:
    "Batch Normalization: Accelerating Deep Network Training
@@ -547,7 +547,7 @@ A = torch.randn(b, m, h, w)
 C = model.forward(A)  -- C will be of size `b x m x h x w`
 
 -- without learnable parameters
-model = nn.SpatialBatchNormalization(0)
+model = nn.SpatialBatchNormalization(m, nil, nil, false)
 A = torch.randn(b, m, h, w)
 C = model.forward(A)  -- C will be of size `b x m x h x w`
 ```

--- a/doc/simple.md
+++ b/doc/simple.md
@@ -905,10 +905,11 @@ C = model.forward({A, B})  -- C will be of size `b x m x n`
 ## BatchNormalization ##
 
 ```lua
-module = nn.BatchNormalization(N [, eps] [, momentum])
+module = nn.BatchNormalization(N [, eps] [, momentum] [,affine])
 ```
-where `N` is the dimensionality of input, giving `N = 0` disables the learnable affine transform.
+where `N` is the dimensionality of input
 `eps` is a small value added to the standard-deviation to avoid divide-by-zero. Defaults to `1e-5`.
+`affine` is a boolean. When set to false, the learnable affine transform is disabled. Defaults to true
 
 During training, this layer keeps a running estimate of its computed mean and std.
 The running sum is kept with a default momentum of 0.1 (unless over-ridden)
@@ -935,7 +936,7 @@ A = torch.randn(b, m)
 C = model.forward(A)  -- C will be of size `b x m`
 
 -- without learnable parameters
-model = nn.BatchNormalization(0)
+model = nn.BatchNormalization(m, nil, nil, false)
 A = torch.randn(b, m)
 C = model.forward(A)  -- C will be of size `b x m`
 ```

--- a/test.lua
+++ b/test.lua
@@ -438,6 +438,13 @@ function nntest.Sqrt()
    local err = out:dist(in1:sqrt())
    mytester:assertlt(err, 1e-15, torch.typename(module) .. ' - forward err ')
 
+   -- Test zero inputs; we will avoid a div-by-zero by setting to zero
+   local zin = torch.DoubleTensor(5, 7):zero()
+   module:forward(zin)
+   local zgradout = torch.rand(5, 7)
+   local zgradin = module:backward(zin, zgradout)
+   mytester:assertTensorEq(zgradin, torch.DoubleTensor(5, 7):zero(), 0.000001, "error in sqrt backward singularity")
+
    local ini = math.random(3,5)
    local inj = math.random(3,5)
    local ink = math.random(3,5)
@@ -3471,7 +3478,7 @@ function nntest.BatchNormalization()
    mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
 
    -- batch norm without affine transform
-   module = nn.BatchNormalization(0)
+   module = nn.BatchNormalization(indim, 1e-5, 0.1, false)
 
    local err = jac.testJacobian(module,input)
    mytester:assertlt(err,precision, 'error on state ')
@@ -3525,7 +3532,7 @@ function nntest.SpatialBatchNormalization()
    mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
 
    -- batch norm without affine transform
-   module = nn.SpatialBatchNormalization(0)
+   module = nn.SpatialBatchNormalization(indim, 1e-5, 0.1, false)
 
    local err = jac.testJacobian(module,input)
    mytester:assertlt(err,precision, 'error on state ')


### PR DESCRIPTION
fixing batchnorm tests

fixes https://github.com/torch/nn/issues/282