### PR TITLE
SparseLinear.c: fix missing OpenMP include

### DIFF
--- a/generic/SparseLinear.c
+++ b/generic/SparseLinear.c
@@ -2,6 +2,10 @@
 #define TH_GENERIC_FILE "generic/SparseLinear.c"
 #else
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 static int nn_(checkInput)(THTensor* t) {
   return t->nDimension == 2 && t->size[1] == 2;
 }


### PR DESCRIPTION
This fixes the `omp_get_thread_num` implicit declaration warning.