### PR TITLE
SpatialConvolutionMM supports padW/padH != 1

### DIFF
--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -1,6 +1,6 @@
 local SpatialConvolution, parent = torch.class('nn.SpatialConvolution', 'nn.Module')
 
-function SpatialConvolution:__init(nInputPlane, nOutputPlane, kW, kH, dW, dH, padding)
+function SpatialConvolution:__init(nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH)
    parent.__init(self)
 
    dW = dW or 1
@@ -13,7 +13,8 @@ function SpatialConvolution:__init(nInputPlane, nOutputPlane, kW, kH, dW, dH, pa
 
    self.dW = dW
    self.dH = dH
-   self.padding = padding or 0
+   self.padW = padW or 0
+   self.padH = padH or self.padW
 
    self.weight = torch.Tensor(nOutputPlane, nInputPlane, kH, kW)
    self.bias = torch.Tensor(nOutputPlane)
@@ -45,7 +46,14 @@ end
 local function backCompatibility(self)
    self.finput = self.finput or self.weight.new()
    self.fgradInput = self.fgradInput or self.weight.new()
-   self.padding = self.padding or 0
+   if self.padding then
+      self.padW = self.padding
+      self.padH = self.padding
+      self.padding = nil
+   else
+      self.padW = self.padW or 0
+      self.padH = self.padH or 0
+   end
    if self.weight:dim() == 2 then
       self.weight = self.weight:view(self.nOutputPlane, self.nInputPlane, self.kH, self.kW)
    end
@@ -128,8 +136,8 @@ function SpatialConvolution:__tostring__()
    end
    if self.padding and self.padding ~= 0 then
      s = s .. ', ' .. self.padding .. ',' .. self.padding
-   elseif self.pad_w or self.pad_h then
-     s = s .. ', ' .. self.pad_w .. ',' .. self.pad_h
+   elseif (self.padW or self.padH) and (self.padW ~= 0 or self.padH ~= 0) then
+     s = s .. ', ' .. self.padW .. ',' .. self.padW
    end
    return s .. ')'
 end

--- a/SpatialConvolutionMM.lua
+++ b/SpatialConvolutionMM.lua
@@ -1,6 +1,6 @@
 local SpatialConvolutionMM, parent = torch.class('nn.SpatialConvolutionMM', 'nn.Module')
 
-function SpatialConvolutionMM:__init(nInputPlane, nOutputPlane, kW, kH, dW, dH, padding)
+function SpatialConvolutionMM:__init(nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH)
    parent.__init(self)
    
    dW = dW or 1
@@ -13,7 +13,8 @@ function SpatialConvolutionMM:__init(nInputPlane, nOutputPlane, kW, kH, dW, dH, 
 
    self.dW = dW
    self.dH = dH
-   self.padding = padding or 0
+   self.padW = padW or 0
+   self.padH = padH or self.padW
 
    self.weight = torch.Tensor(nOutputPlane, nInputPlane*kH*kW)
    self.bias = torch.Tensor(nOutputPlane)
@@ -62,6 +63,12 @@ local function makeContiguous(self, input, gradOutput)
 end
 
 function SpatialConvolutionMM:updateOutput(input)
+   -- backward compatibility
+   if self.padding then
+      self.padW = self.padding
+      self.padH = self.padding
+      self.padding = nil
+   end
    input = makeContiguous(self, input)
    return input.nn.SpatialConvolutionMM_updateOutput(self, input)
 end
@@ -92,8 +99,8 @@ function SpatialConvolutionMM:__tostring__()
    end
    if self.padding and self.padding ~= 0 then
      s = s .. ', ' .. self.padding .. ',' .. self.padding
-   elseif self.pad_w or self.pad_h then
-     s = s .. ', ' .. self.pad_w .. ',' .. self.pad_h
+   elseif (self.padW or self.padH) and (self.padW ~= 0 or self.padH ~= 0) then
+     s = s .. ', ' .. self.padW .. ',' .. self.padW
    end
    return s .. ')'
 end

--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -263,7 +263,7 @@ are spatial (e.g. `height x width`). These are commonly used for processing imag
 ### SpatialConvolution ###
 
 ```lua
-module = nn.SpatialConvolution(nInputPlane, nOutputPlane, kW, kH, [dW], [dH], [padding])
+module = nn.SpatialConvolution(nInputPlane, nOutputPlane, kW, kH, [dW], [dH], [padW], [padH])
 ```
 
 Applies a 2D convolution over an input image composed of several input planes. The `input` tensor in
@@ -276,7 +276,8 @@ The parameters are the following:
   * `kH`: The kernel height of the convolution
   * `dW`: The step of the convolution in the width dimension. Default is `1`.
   * `dH`: The step of the convolution in the height dimension. Default is `1`.
-  * `padding`: The additional zeros added per side to the input planes. Default is `0`, a good number is `(kernelSize-1)/2` for square kernels.
+  * `padW`: The additional zeros added per width to the input planes. Default is `0`, a good number is `(kW-1)/2`.
+  * `padH`: The additional zeros added per height to the input planes. Default is `0`, a good number is `(kH-1)/2`.
 
 Note that depending of the size of your kernel, several (of the last)
 columns or rows of the input image might be lost. It is up to the user to
@@ -285,8 +286,8 @@ add proper padding in images.
 If the input image is a 3D tensor `nInputPlane x height x width`, the output image size
 will be `nOutputPlane x oheight x owidth` where
 ```lua
-owidth  = floor((width  + 2*padding - kW) / dW + 1)
-oheight = floor((height + 2*padding - kH) / dH + 1)
+owidth  = floor((width  + 2*padW - kW) / dW + 1)
+oheight = floor((height + 2*padH - kH) / dH + 1)
 ```
 
 The parameters of the convolution can be found in `self.weight` (Tensor of

--- a/test.lua
+++ b/test.lua
@@ -1446,12 +1446,13 @@ function nntest.SpatialConvolutionMM()
    local kj = math.random(1,5)
    local di =  math.random(1,4)
    local dj =  math.random(1,4)
-   local padding = math.random(0,2)
+   local padW = math.random(0,2)
+   local padH = math.random(0,2)
    local outi = math.random(5,9)
    local outj = math.random(5,9)
-   local ini = (outi-1)*di+ki-padding*2
-   local inj = (outj-1)*dj+kj-padding*2
-   local module = nn.SpatialConvolutionMM(from, to, ki, kj, di, dj, padding)
+   local ini = (outi-1)*di+ki-padW*2
+   local inj = (outj-1)*dj+kj-padH*2
+   local module = nn.SpatialConvolutionMM(from, to, ki, kj, di, dj, padW, padH)
    local input = torch.Tensor(from, inj, ini):zero()
 
    -- stochastic
@@ -1486,7 +1487,7 @@ function nntest.SpatialConvolutionMM()
    --verbose = true
    local batch = math.random(2,5)
 
-   module = nn.SpatialConvolutionMM(from, to, ki, kj, di, dj, padding)
+   module = nn.SpatialConvolutionMM(from, to, ki, kj, di, dj, padW, padH)
    input = torch.Tensor(batch,from,inj,ini):zero()
 
    local err = jac.testJacobian(module, input)


### PR DESCRIPTION
This commit allows different paddings for each spatial dimension.

A PR with the Cuda version will come tomorrow.

I changed the print function a bit, as it was calling a `self.pad_h` and `self.pad_w` that, to the best of my knowledge, didn't exist anywhere (`cudnn` uses `padH` and `padW`). I think though that the current print version is ambiguous when `pad !=0` and `dW=dH=1`, or `pad=0` and `dW!=1 or dH!=1`, but I decided not to change it in this commit.