### PR TITLE
Fix print and correct non-contiguous test in SpatialConvolutionMM

### DIFF
--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -137,7 +137,7 @@ function SpatialConvolution:__tostring__()
    if self.padding and self.padding ~= 0 then
      s = s .. ', ' .. self.padding .. ',' .. self.padding
    elseif (self.padW or self.padH) and (self.padW ~= 0 or self.padH ~= 0) then
-     s = s .. ', ' .. self.padW .. ',' .. self.padW
+     s = s .. ', ' .. self.padW .. ',' .. self.padH
    end
    return s .. ')'
 end

--- a/SpatialConvolutionMM.lua
+++ b/SpatialConvolutionMM.lua
@@ -100,7 +100,7 @@ function SpatialConvolutionMM:__tostring__()
    if self.padding and self.padding ~= 0 then
      s = s .. ', ' .. self.padding .. ',' .. self.padding
    elseif (self.padW or self.padH) and (self.padW ~= 0 or self.padH ~= 0) then
-     s = s .. ', ' .. self.padW .. ',' .. self.padW
+     s = s .. ', ' .. self.padW .. ',' .. self.padH
    end
    return s .. ')'
 end

--- a/test.lua
+++ b/test.lua
@@ -1520,7 +1520,7 @@ function nntest.SpatialConvolutionMM()
    mytester:asserteq(0, berr, torch.typename(module) .. ' - i/o backward err ')
 
    -- non-contiguous
-   local input = torch.randn(batch,from,inj,ini):transpose(3,4) -- non-contiguous
+   local input = torch.randn(batch,from,ini,inj):transpose(3,4) -- non-contiguous
    local inputc = input:contiguous() -- contiguous
    local output = module:forward(input)
    local outputc = module:forward(inputc)


### PR DESCRIPTION
@szagoruyko pointed that sometimes the tests for `SpatialConvolutionMM` were failing, with error
`SpatialConvolutionMM$ Error: matrices expected, got 2D, 1D tensors at /opt/rocks/torch7/lib/TH/generic/THTensorMath.c:594`.
There was an inversion of the dimensions while defining the non-contiguous tensor, thus some tests fed invalid input sizes.
Do you think we should we assert that proper-sized input tensors are given to the forward pass ?
Plus, small fix in the `__tostring__` methods.