### PR TITLE
SpatialMaxPooling supports padding and ceil mode

### DIFF
--- a/SpatialMaxPooling.lua
+++ b/SpatialMaxPooling.lua
@@ -1,6 +1,6 @@
 local SpatialMaxPooling, parent = torch.class('nn.SpatialMaxPooling', 'nn.Module')
 
-function SpatialMaxPooling:__init(kW, kH, dW, dH)
+function SpatialMaxPooling:__init(kW, kH, dW, dH, padW, padH)
    parent.__init(self)
 
    dW = dW or kW
@@ -11,10 +11,28 @@ function SpatialMaxPooling:__init(kW, kH, dW, dH)
    self.dW = dW
    self.dH = dH
 
+   self.padW = padW or 0
+   self.padH = padH or 0
+
+   self.ceil_mode = false
    self.indices = torch.Tensor()
 end
 
+function SpatialMaxPooling:ceil()
+  self.ceil_mode = true
+  return self
+end
+
+function SpatialMaxPooling:floor()
+  self.ceil_mode = false
+  return self
+end
+
 function SpatialMaxPooling:updateOutput(input)
+   -- backward compatibility
+   self.ceil_mode = self.ceil_mode or false
+   self.padW = self.padW or 0
+   self.padH = self.padH or 0
    input.nn.SpatialMaxPooling_updateOutput(self, input)
    return self.output
 end
@@ -34,6 +52,12 @@ function SpatialMaxPooling:empty()
 end
 
 function SpatialMaxPooling:__tostring__()
-   return string.format('%s(%d,%d,%d,%d)', torch.type(self),
-         self.kW, self.kH, self.dW, self.dH)
+   local s =  string.format('%s(%d,%d,%d,%d', torch.type(self),
+                            self.kW, self.kH, self.dW, self.dH)
+   if (self.padW or self.padH) and (self.padW ~= 0 or self.padH ~= 0) then
+      s = s .. ',' .. self.padW .. ','.. self.padH
+   end
+   s = s .. ')'
+
+   return s
 end

--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -361,12 +361,23 @@ Computes the `p` norm in a convolutional manner on a set of 2D input planes.
 ### SpatialMaxPooling ###
 
 ```lua
-module = nn.SpatialMaxPooling(kW, kH [, dW, dH])
+module = nn.SpatialMaxPooling(kW, kH [, dW, dH, padW, padH])
 ```
 
 Applies 2D max-pooling operation in `kWxkH` regions by step size
 `dWxdH` steps. The number of output features is equal to the number of
 input planes.
+
+If the input image is a 3D tensor `nInputPlane x height x width`, the output
+image size will be `nOutputPlane x oheight x owidth` where
+
+```lua
+owidth  = op((width  + 2*padW - kW) / dW + 1)
+oheight = op((height + 2*padH - kH) / dH + 1)
+```
+
+`op` is a rounding operator. By default, it is `floor`. It can be changed
+by calling `:ceil()` or `:floor()` methods.
 
 <a name="nn.SpatialAveragePooling"/>
 ### SpatialAveragePooling ###

--- a/test.lua
+++ b/test.lua
@@ -1926,38 +1926,44 @@ function nntest.SpatialSubSampling()
 end
 
 function nntest.SpatialMaxPooling()
-   local from = math.random(1,5)
-   local ki = math.random(1,4)
-   local kj = math.random(1,4)
-   local si = math.random(1,3)
-   local sj = math.random(1,3)
-   local outi = math.random(4,5)
-   local outj = math.random(4,5)
-   local ini = (outi-1)*si+ki
-   local inj = (outj-1)*sj+kj
+   for _,ceil_mode in pairs({true,false}) do
+      local from = math.random(1,5)
+      local ki = math.random(1,4)
+      local kj = math.random(1,4)
+      local si = math.random(1,3)
+      local sj = math.random(1,3)
+      local outi = math.random(4,5)
+      local outj = math.random(4,5)
+      local padW = math.min(math.random(0,1),math.floor(ki/2))
+      local padH =  math.min(math.random(0,1),math.floor(kj/2))
+      local ini = (outi-1)*si+ki-2*padW
+      local inj = (outj-1)*sj+kj-2*padH
+ 
+      local ceil_string = ceil_mode and 'ceil' or 'floor'
+      local module = nn.SpatialMaxPooling(ki,kj,si,sj,padW,padH)
+      if ceil_mode then module:ceil() else module:floor() end
+      local input = torch.rand(from,inj,ini)
 
-   local module = nn.SpatialMaxPooling(ki,kj,si,sj)
-   local input = torch.rand(from,ini,inj)
+      local err = jac.testJacobian(module, input)
+      mytester:assertlt(err, precision, 'error '..ceil_string..' mode on state ')
 
-   local err = jac.testJacobian(module, input)
-   mytester:assertlt(err, precision, 'error on state ')
+      local ferr, berr = jac.testIO(module, input)
+      mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err ')
+      mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
 
-   local ferr, berr = jac.testIO(module, input)
-   mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err ')
-   mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
+      -- batch
+      local nbatch = math.random(2,5)
+      input = torch.rand(nbatch,from,inj,ini)
+      module = nn.SpatialMaxPooling(ki,kj,si,sj,padW,padH)
+      if ceil_mode then module:ceil() else module:floor() end
 
-   -- batch
-   local nbatch = math.random(2,5)
-   input = torch.rand(nbatch,from,ini,inj)
-   module = nn.SpatialMaxPooling(ki,kj,si,sj)
+      local err = jac.testJacobian(module, input)
+      mytester:assertlt(err, precision, 'error '..ceil_string..' mode on state (Batch)')
 
-   local err = jac.testJacobian(module, input)
-   mytester:assertlt(err, precision, 'error on state (Batch) ')
-
-   local ferr, berr = jac.testIO(module, input)
-   mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err (Batch) ')
-   mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err (Batch) ')
-
+      local ferr, berr = jac.testIO(module, input)
+      mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err (Batch) ')
+      mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err (Batch) ')
+  end
 end
 
 function nntest.SpatialAveragePooling()


### PR DESCRIPTION
- Adds padding
- adds ceil mode similar to `cudnn`, allowing `loadcaffe` to run on CPU
- changes the way the max indexes are stored, saving memory and computation time. For huge tensors we could have problems in the backward pass though, as we are storing the indices in a `Tensor` and not `LongTensor`.

@szagoruyko is preparing a PR for `cunn` with the same changes.