### PR TITLE
MarginCriterion: cunn compatibility

### DIFF
--- a/MarginCriterion.lua
+++ b/MarginCriterion.lua
@@ -2,15 +2,24 @@ local MarginCriterion, parent = torch.class('nn.MarginCriterion', 'nn.Criterion'
 
 function MarginCriterion:__init(margin)
    parent.__init(self)
-   self.sizeAverage = true
-   self.margin = margin or 1
+   margin=margin or 1   
+   self.margin = margin 
+   self.buffer = torch.Tensor()
+   self.ty = torch.Tensor(1)
+end 
+ 
+function MarginCriterion:updateOutput(input, y)
+   if not torch.isTensor(y) then self.ty[1]=y; y=self.ty end
+   self.buffer:resizeAs(input):fill(self.margin)
+   self.buffer:addcmul(-1, input, y)   
+   self.buffer[torch.le(self.buffer, 0)] = 0
+   self.output = self.buffer:sum()
+   return self.output
 end
 
-function MarginCriterion:updateOutput(input, target)
-   return input.nn.MarginCriterion_updateOutput(self, input, target)
-end
-
-function MarginCriterion:updateGradInput(input, target)
-   input.nn.MarginCriterion_updateGradInput(self, input, target)
-   return self.gradInput
+function MarginCriterion:updateGradInput(input, y)
+   if not torch.isTensor(y) then self.ty[1]=y; y=self.ty end
+   self.gradInput:resizeAs(input):copy(-y)
+   self.gradInput[torch.le(self.buffer, 0)] = 0
+   return self.gradInput 
 end


### PR DESCRIPTION
I suggest to revert from the current C-version of MarginCriterion back to pure Lua implementation. This gives us compatibility with cunn. I believe the functionality is primitive enough not to need a special C and CUDA implementation.