### PR TITLE
Remove unused code in nn.Module

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -257,12 +257,6 @@ function Module._gather(tensors)
       return flatUsedParameters
    end
 
-   -- flatten parameters and gradients
-   local flatParameters = flatten(parameters)
-   collectgarbage()
-   local flatGradParameters = flatten(gradParameters)
-   collectgarbage()
-
    -- return new flat vector that contains all discrete parameters
    return flatten(tensors)
 end


### PR DESCRIPTION
I think this code should have been removed in 50de1a9.
This is causing access to undeclared global variable (when running with `-g` flag) and could have some side effect if these globals are already used.