### PR TITLE
Replace Module.flatten by nn.Module.flatten

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -219,9 +219,9 @@ function Module:getParameters()
    -- get parameters
    local parameters,gradParameters = self:parameters()
    -- flatten parameters and gradients
-   local flatParameters = Module.flatten(parameters)
+   local flatParameters = nn.Module.flatten(parameters)
    collectgarbage()
-   local flatGradParameters = Module.flatten(gradParameters)
+   local flatGradParameters = nn.Module.flatten(gradParameters)
    collectgarbage()
 
    -- return new flat vector that contains all discrete parameters


### PR DESCRIPTION
This is a minor fix. The reference to the local `Module` variable creates an unnecessary upvalue which can make serialization more troublesome. 