### PR TITLE
Fix SpatialBatchNormalization documentation example.

### DIFF
--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -2,7 +2,7 @@
 # Convolutional layers #
 
 A convolution is an integral that expresses the amount of overlap of one function `g` as it is shifted over another function `f`. It therefore "blends" one function with another. The neural network package supports convolution, pooling, subsampling and other relevant facilities. These are divided base on the dimensionality of the input and output [Tensors](https://github.com/torch/torch7/blob/master/doc/tensor.md#tensor):
- 
+
   * [Temporal Modules](#nn.TemporalModules) apply to sequences with a one-dimensional relationship
 (e.g. sequences of words, phonemes and letters. Strings of some kind).
     * [TemporalConvolution](#nn.TemporalConvolution) : a 1D convolution over an input sequence ;
@@ -558,12 +558,12 @@ The module only accepts 4D inputs.
 -- with learnable parameters
 model = nn.SpatialBatchNormalization(m)
 A = torch.randn(b, m, h, w)
-C = model.forward(A)  -- C will be of size `b x m x h x w`
+C = model:forward(A)  -- C will be of size `b x m x h x w`
 
 -- without learnable parameters
 model = nn.SpatialBatchNormalization(m, nil, nil, false)
 A = torch.randn(b, m, h, w)
-C = model.forward(A)  -- C will be of size `b x m x h x w`
+C = model:forward(A)  -- C will be of size `b x m x h x w`
 ```
 
 <a name="nn.VolumetricModules"></a>


### PR DESCRIPTION
The SpatialBatchNormalizationExample does not evaluate, as the colon operator is not used (model.forward is rather than model:forward).