### PR TITLE
Using the speed-up version of updateParameters for SparseLinear

### DIFF
--- a/SparseLinear.lua
+++ b/SparseLinear.lua
@@ -60,3 +60,7 @@ function SparseLinear:updateGradInput(input, gradOutput)
       return self.gradInput
    end
 end
+
+function SparseLinear:updateParameters(learningRate)
+   self.lastInput.nn.SparseLinear_updateParameters(self, learningRate)
+end


### PR DESCRIPTION
Is there any reason not to do this in the current code? The special SparseLinear_updateParameters function is implemented in C but SparseLinear.updateParameters still points to Module.updateParameters. Let me know if there is some purpose I did not see.