### PR TITLE
SpatialAveragePooling supports padding, ceil mode and more

### DIFF
--- a/SpatialAveragePooling.lua
+++ b/SpatialAveragePooling.lua
@@ -1,16 +1,50 @@
 local SpatialAveragePooling, parent = torch.class('nn.SpatialAveragePooling', 'nn.Module')
 
-function SpatialAveragePooling:__init(kW, kH, dW, dH)
+function SpatialAveragePooling:__init(kW, kH, dW, dH, padW, padH)
    parent.__init(self)
 
    self.kW = kW
    self.kH = kH
    self.dW = dW or 1
    self.dH = dH or 1
+   self.padW = padW or 0
+   self.padH = padH or 0
+   self.ceil_mode = false
+   self.count_include_pad = true
    self.divide = true
 end
 
+function SpatialAveragePooling:ceil()
+   self.ceil_mode = true
+   return self
+end
+
+function SpatialAveragePooling:floor()
+   self.ceil_mode = false
+   return self
+end
+
+function SpatialAveragePooling:setCountIncludePad()
+   self.count_include_pad = true
+   return self
+end
+
+function SpatialAveragePooling:setCountExcludePad()
+   self.count_include_pad = false
+   return self
+end
+
+local function backwardCompatible(self)
+   if self.ceil_mode == nil then
+      self.ceil_mode = false
+      self.count_include_pad = true
+      self.padH = 0
+      self.padW = 0
+   end
+end
+
 function SpatialAveragePooling:updateOutput(input)
+   backwardCompatible(self)
    input.nn.SpatialAveragePooling_updateOutput(self, input)
    -- for backward compatibility with saved models
    -- which are not supposed to have "divide" field
@@ -25,13 +59,18 @@ function SpatialAveragePooling:updateGradInput(input, gradOutput)
       input.nn.SpatialAveragePooling_updateGradInput(self, input, gradOutput)
       -- for backward compatibility
       if not self.divide then
-	self.gradInput:mul(self.kW*self.kH)
+         self.gradInput:mul(self.kW*self.kH)
       end
       return self.gradInput
    end
 end
 
 function SpatialAveragePooling:__tostring__()
-   return string.format('%s(%d,%d,%d,%d)', torch.type(self),
-         self.kW, self.kH, self.dW, self.dH)
+   local s = string.format('%s(%d,%d,%d,%d', torch.type(self),
+                            self.kW, self.kH, self.dW, self.dH)
+   if (self.padW or self.padH) and (self.padW ~= 0 or self.padH ~= 0) then
+      s = s .. ',' .. self.padW .. ','.. self.padH
+   end
+   s = s .. ')'
+   return s 
 end

--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -384,12 +384,30 @@ by calling `:ceil()` or `:floor()` methods.
 ### SpatialAveragePooling ###
 
 ```lua
-module = nn.SpatialAveragePooling(kW, kH [, dW, dH])
+module = nn.SpatialAveragePooling(kW, kH [, dW, dH, padW, padH])
 ```
 
 Applies 2D average-pooling operation in `kWxkH` regions by step size
 `dWxdH` steps. The number of output features is equal to the number of
 input planes.
+
+If the input image is a 3D tensor `nInputPlane x height x width`, the output
+image size will be `nOutputPlane x oheight x owidth` where
+
+```lua
+owidth  = op((width  + 2*padW - kW) / dW + 1)
+oheight = op((height + 2*padH - kH) / dH + 1)
+```
+
+`op` is a rounding operator. By default, it is `floor`. It can be changed
+by calling `:ceil()` or `:floor()` methods.
+
+By default, the output of each pooling region is divided by the number of
+elements inside the padded image (which is usually `kW*kH`, except in some
+corner cases in which it can be smaller). You can also divide by the number
+of elements inside the original non-padded image. To switch between different
+division factors, call `:setCountIncludePad()` or `:setCountExcludePad()`. If
+`padW=padH=0`, both options give the same results.
 
 <a name="nn.SpatialAdaptiveMaxPooling"></a>
 ### SpatialAdaptiveMaxPooling ###

--- a/generic/SpatialAveragePooling.c
+++ b/generic/SpatialAveragePooling.c
@@ -9,7 +9,11 @@ static int nn_(SpatialAveragePooling_updateOutput)(lua_State *L)
   int kH = luaT_getfieldcheckint(L, 1, "kH");
   int dW = luaT_getfieldcheckint(L, 1, "dW");
   int dH = luaT_getfieldcheckint(L, 1, "dH");
-  
+  int padW = luaT_getfieldcheckint(L, 1, "padW");
+  int padH = luaT_getfieldcheckint(L, 1, "padH");
+  int ceil_mode = luaT_getfieldcheckboolean(L,1,"ceil_mode");
+  int count_include_pad = luaT_getfieldcheckboolean(L,1,"count_include_pad");
+
   THTensor *output = luaT_getfieldcheckudata(L, 1, "output", torch_Tensor);
 
   real *output_data;
@@ -29,6 +33,7 @@ static int nn_(SpatialAveragePooling_updateOutput)(lua_State *L)
   long k;
 
   luaL_argcheck(L, input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D(batch mode) tensor expected");
+  luaL_argcheck(L, kW/2 >= padW && kH/2 >= padH, 2, "pad should be smaller than half of kernel size");
 
   if (input->nDimension == 4) {
     nbatch = input->size[0];
@@ -40,10 +45,28 @@ static int nn_(SpatialAveragePooling_updateOutput)(lua_State *L)
   inputWidth = input->size[dimw];
   inputHeight = input->size[dimh];
   nInputPlane = input->size[dimc];
-  outputWidth = (inputWidth - kW) / dW + 1;
-  outputHeight = (inputHeight - kH) / dH + 1;
 
-  luaL_argcheck(L, inputWidth >= kW && inputHeight >= kH, 2, "input image smaller than kernel size");
+  if(ceil_mode)
+  {
+    outputWidth  = (long)(ceil((float)(inputWidth  - kW + 2*padW) / dW)) + 1;
+    outputHeight = (long)(ceil((float)(inputHeight - kH + 2*padH) / dH)) + 1;
+  }
+  else
+  {
+    outputWidth  = (long)(floor((float)(inputWidth  - kW + 2*padW) / dW)) + 1;
+    outputHeight = (long)(floor((float)(inputHeight - kH + 2*padH) / dH)) + 1;
+  }
+  if (padW || padH)
+  {
+    // ensure that the last pooling starts inside the image
+    // needed to avoid problems in ceil mode
+    if ((outputHeight - 1)*dH >= inputHeight + padH)
+      --outputHeight;
+    if ((outputWidth  - 1)*dW >= inputWidth  + padW)
+      --outputWidth;
+  }
+
+  luaL_argcheck(L, inputWidth >= kW - 2 * padW && inputHeight >= kH - 2 * padH, 2, "input image smaller than kernel size");
 
   if (input->nDimension == 3)
     THTensor_(resize3d)(output, nInputPlane, outputHeight, outputWidth);
@@ -64,6 +87,7 @@ static int nn_(SpatialAveragePooling_updateOutput)(lua_State *L)
       long xx, yy;
       /* For all output pixels... */
       real *ptr_output = output_data + p*nInputPlane*outputWidth*outputHeight + k*outputWidth*outputHeight;
+      real *ptr_input = input_data + p*nInputPlane*inputWidth*inputHeight + k*inputWidth*inputHeight;
       long i;
       for(i = 0; i < outputWidth*outputHeight; i++)
         ptr_output[i] = 0;
@@ -73,18 +97,33 @@ static int nn_(SpatialAveragePooling_updateOutput)(lua_State *L)
         for(xx = 0; xx < outputWidth; xx++)
         {
           /* Compute the mean of the input image... */
-          real *ptr_input = input_data + p*nInputPlane*inputWidth*inputHeight + k*inputWidth*inputHeight + yy*dH*inputWidth+xx*dW;
+          long hstart = yy * dH - padH;
+          long wstart = xx * dW - padW;
+          long hend = fminf(hstart + kH, inputHeight + padH);
+          long wend = fminf(wstart + kW, inputWidth + padW);
+          int pool_size = (hend - hstart) * (wend - wstart);
+          hstart = fmaxf(hstart, 0);
+          wstart = fmaxf(wstart, 0);
+          hend = fminf(hend, inputHeight);
+          wend = fminf(wend, inputWidth);
+
           real sum = 0;
+
+          int divide_factor;
+          if(count_include_pad)
+            divide_factor = pool_size;
+          else
+            divide_factor = (hend - hstart) * (wend - wstart);
+
           long kx, ky;
 
-          for(ky = 0; ky < kH; ky++)
+          for(ky = hstart; ky < hend; ky++)
           {
-            for(kx = 0; kx < kW; kx++)
-              sum += ptr_input[kx];
-            ptr_input += inputWidth; /* next input line */
+            for(kx = wstart; kx < wend; kx++)
+              sum += ptr_input[ky*inputWidth + kx];
           }
           /* Update output */
-          *ptr_output++ += sum/(kW*kH);
+          *ptr_output++ += sum/divide_factor;
         }
       }
     }
@@ -102,6 +141,11 @@ static int nn_(SpatialAveragePooling_updateGradInput)(lua_State *L)
   int kH = luaT_getfieldcheckint(L, 1, "kH");
   int dW = luaT_getfieldcheckint(L, 1, "dW");
   int dH = luaT_getfieldcheckint(L, 1, "dH");
+  int padW = luaT_getfieldcheckint(L, 1, "padW");
+  int padH = luaT_getfieldcheckint(L, 1, "padH");
+  int ceil_mode = luaT_getfieldcheckboolean(L,1,"ceil_mode");
+  int count_include_pad = luaT_getfieldcheckboolean(L,1,"count_include_pad");
+
   THTensor *gradInput = luaT_getfieldcheckudata(L, 1, "gradInput", torch_Tensor);
 
   int dimw = 2;
@@ -130,8 +174,26 @@ static int nn_(SpatialAveragePooling_updateGradInput)(lua_State *L)
   inputWidth = input->size[dimw];
   inputHeight = input->size[dimh];
   nInputPlane = input->size[dimc];
-  outputWidth = (inputWidth - kW) / dW + 1;
-  outputHeight = (inputHeight - kH) / dH + 1;
+
+  if(ceil_mode)
+  {
+    outputWidth  = (long)(ceil((float)(inputWidth  - kW + 2*padW) / dW)) + 1;
+    outputHeight = (long)(ceil((float)(inputHeight - kH + 2*padH) / dH)) + 1;
+  }
+  else
+  {
+    outputWidth  = (long)(floor((float)(inputWidth  - kW + 2*padW) / dW)) + 1;
+    outputHeight = (long)(floor((float)(inputHeight - kH + 2*padH) / dH)) + 1;
+  }
+  if (padW || padH)
+  {
+    // ensure that the last pooling starts inside the image
+    // needed to avoid problems in ceil mode
+    if ((outputHeight - 1)*dH >= inputHeight + padH)
+      --outputHeight;
+    if ((outputWidth  - 1)*dW >= inputWidth  + padW)
+      --outputWidth;
+  }
 
   input_data = THTensor_(data)(input);
 
@@ -154,6 +216,8 @@ static int nn_(SpatialAveragePooling_updateGradInput)(lua_State *L)
       long xx, yy;
 
       real* ptr_gi = gradInput_data + p*nInputPlane*inputWidth*inputHeight + k*inputWidth*inputHeight;
+      real *ptr_gradInput = gradInput_data + p*nInputPlane*inputWidth*inputHeight + k*inputWidth*inputHeight;
+
       long i;
       for(i=0; i<inputWidth*inputHeight; i++)
         ptr_gi[i] = 0.0;
@@ -162,15 +226,29 @@ static int nn_(SpatialAveragePooling_updateGradInput)(lua_State *L)
       {
         for(xx = 0; xx < outputWidth; xx++)
         {
-          real *ptr_gradInput = gradInput_data + p*nInputPlane*inputWidth*inputHeight + k*inputWidth*inputHeight + yy*dH*inputWidth+xx*dW;
-          real z = *ptr_gradOutput++;
-          long kx, ky;
+          long hstart = yy * dH - padH;
+          long wstart = xx * dW - padW;
+          long hend = fminf(hstart + kH, inputHeight + padH);
+          long wend = fminf(wstart + kW, inputWidth + padW);
+          int pool_size = (hend - hstart) * (wend - wstart);
+          hstart = fmaxf(hstart, 0);
+          wstart = fmaxf(wstart, 0);
+          hend = fminf(hend, inputHeight);
+          wend = fminf(wend, inputWidth);
 
-          for(ky = 0; ky < kH; ky++)
+          real z = *ptr_gradOutput++;
+
+          int divide_factor;
+          if(count_include_pad)
+            divide_factor = pool_size;
+          else
+            divide_factor = (hend - hstart) * (wend - wstart);
+
+          long kx, ky;
+          for(ky = hstart ; ky < hend; ky++)
           {
-            for(kx = 0; kx < kW; kx++)
-              ptr_gradInput[kx] += z/(kW*kH);
-            ptr_gradInput += inputWidth;
+            for(kx = wstart; kx < wend; kx++)
+              ptr_gradInput[ky*inputWidth + kx] += z/divide_factor;
           }
         }
       }


### PR DESCRIPTION
Generalizes `SpatialAveragePooling` to support free zero padding and ceil mode.

When using padding or ceil mode, the effective number of elements in a region might be different from `kW*kH`. The `:count_exclude_padding()` method considers only the number of elements in the pooling region for the averaging, whereas `:count_include_padding()` always divides by `kW*kH`.

@szagoruyko has a cuda version of this PR.