### PR TITLE
BCECriterion rewrite

### DIFF
--- a/BCECriterion.lua
+++ b/BCECriterion.lua
@@ -2,66 +2,105 @@ local BCECriterion, parent = torch.class('nn.BCECriterion', 'nn.Criterion')
 
 local eps = 1e-12
 
-function BCECriterion:__init()
-   parent.__init(self)
-   self.sizeAverage = true
+function BCECriterion:__init(weights, sizeAverage)
+    parent.__init(self)
+    if sizeAverage ~= nil then
+        self.sizeAverage = sizeAverage
+    else
+        self.sizeAverage = true
+    end
+    if weights ~= nil then
+        assert(weights:dim() == 1, "weights input should be 1-D Tensor")
+        self.weights = weights
+    end
+end
+
+
+function BCECriterion:__len()
+    if (self.weights) then
+        return #self.weights
+    else
+        return 0
+    end
 end
 
 function BCECriterion:updateOutput(input, target)
-   -- log(input) * target + log(1 - input) * (1 - target)
+    -- - log(input) * target - log(1 - input) * (1 - target)
 
-   self.term1 = self.term1 or input.new()
-   self.term2 = self.term2 or input.new()
-   self.term3 = self.term3 or input.new()
+    assert( input:nElement() == target:nElement(),
+    "input and target size mismatch")
 
-   self.term1:resizeAs(input)
-   self.term2:resizeAs(input)
-   self.term3:resizeAs(input)
+    self.buffer = self.buffer or torch.Tensor():typeAs(input)
 
-   self.term1:fill(1):add(-1,target)
-   self.term2:fill(1):add(-1,input):add(eps):log():cmul(self.term1)
+    local buffer = self.buffer
+    local weights = self.weights
+    local output
 
-   self.term3:copy(input):add(eps):log():cmul(target)
-   self.term3:add(self.term2)
+    buffer:resizeAs(input)
 
-   if self.sizeAverage then
-      self.term3:div(target:nElement())
-   end
+    if weights ~= nil and target:dim() ~= 1 then
+        weights = self.weights:view(1, target:size()[2]):expandAs(target)
+    end
 
-   self.output = - self.term3:sum()
+    -- log(input) * target
+    buffer:add(input, eps):log()
+    if weights ~= nil then buffer:cmul(weights) end
 
-   return self.output
+    output = torch.dot(target, buffer)
+
+    -- log(1 - input) * (1 - target)
+    buffer:mul(input, -1):add(1 + eps):log()
+    if weights ~= nil then buffer:cmul(weights) end
+
+    output = output + torch.sum(buffer)
+    output = output - torch.dot(target, buffer)
+
+    if self.sizeAverage then
+        output = output / input:nElement()
+    end
+
+    self.output = - output
+
+    return self.output
 end
 
 function BCECriterion:updateGradInput(input, target)
-   -- target / input - (1 - target) / (1 - input)
+    -- - (target - input) / ( input (1 - input) )
+    -- The gradient is slightly incorrect:
+    -- It should have be divided by (input + eps) (1 - input + eps)
+    -- but it is divided by input (1 - input + eps) + eps
+    -- This modification requires less memory to be computed.
 
-   self.term1 = self.term1 or input.new()
-   self.term2 = self.term2 or input.new()
-   self.term3 = self.term3 or input.new()
+    assert( input:nElement() == target:nElement(),
+    "input and target size mismatch")
 
-   self.term1:resizeAs(input)
-   self.term2:resizeAs(input)
-   self.term3:resizeAs(input)
+    self.buffer = self.buffer or torch.Tensor():typeAs(input)
 
-   self.term1:fill(1):add(-1,target)
-   self.term2:fill(1):add(-1,input)
+    local buffer = self.buffer
+    local weights = self.weights
+    local gradInput = self.gradInput
 
-   self.term2:add(eps)
-   self.term1:cdiv(self.term2)
+    if weights ~= nil and target:dim() ~= 1 then
+        weights = self.weights:view(1, target:size()[2]):expandAs(target)
+    end
 
-   self.term3:copy(input):add(eps)
+    buffer:resizeAs(input)
+    -- - x ( 1 + eps -x ) + eps
+    buffer:add(input, -1-eps):cmul(input):add(-eps)
 
-   self.gradInput:resizeAs(input)
-   self.gradInput:copy(target):cdiv(self.term3)
+    gradInput:resizeAs(input)
+    -- y - x
+    gradInput:add(target, -1, input)
+    -- - (y - x) / ( x ( 1 + eps -x ) + eps )
+    gradInput:cdiv(buffer)
 
-   self.gradInput:add(-1,self.term1)
+    if weights ~= nil then
+        gradInput:cmul(weights)
+    end
 
-   if self.sizeAverage then
-      self.gradInput:div(target:nElement())
-   end
+    if self.sizeAverage then
+        gradInput:div(target:nElement())
+    end
 
-   self.gradInput:mul(-1)
-
-   return self.gradInput
+    return gradInput
 end

--- a/doc/criterion.md
+++ b/doc/criterion.md
@@ -181,13 +181,19 @@ loss(x, target) = \sum(target_i * (log(target_i) - x_i))
 ## BCECriterion
 
 ```lua
-criterion = nn.BCECriterion()
+criterion = nn.BCECriterion([weights])
 ```
 
 Creates a criterion that measures the Binary Cross Entropy between the target and the output:
 
 ```lua
-loss(t, o) = -(t * log(o) + (1 - t) * log(1 - o))
+loss(t, o) = - sum_i (t[i] * log(o[i]) + (1 - t[i]) * log(1 - o[i]))
+```
+
+or in the case of the weights argument being specified:
+
+```lua
+loss(t, o) = - sum_i weights[i] * (t[i] * log(o[i]) + (1 - t[i]) * log(1 - o[i]))
 ```
 
 This is used for measuring the error of a reconstruction in for example an auto-encoder.

--- a/test.lua
+++ b/test.lua
@@ -994,6 +994,15 @@ function nntest.BCECriterion()
    local target = torch.rand(10)*(1-eps) + eps/2
    local cri = nn.BCECriterion()
    criterionJacobianTest1D(cri, input, target)
+   --with weights
+   local weights= torch.rand(10)*(1-eps) + eps/2
+   local cri = nn.BCECriterion(weights)
+   criterionJacobianTest1D(cri, input, target)
+   -- with weights + batch
+   local bsz = 5
+   local input = torch.rand(bsz, 10)*(1-eps) + eps/2
+   local target = torch.rand(bsz, 10)*(1-eps) + eps/2
+   criterionJacobianTest1D(cri, input, target)
 end
 
 function nntest.DistKLDivCriterion()


### PR DESCRIPTION
Author: Armand Joulin

Rewriting the BCECriterion. The goal is to make it clearer and to have the possibility to weight the different terms.

New features:
- can use weights
- use less memory during forward (3 times less) and backward (2 times less).
- slightly faster forward and backward on both gpu and cpu