### PR TITLE
Set default value of total weight in ClassNLL to 1

### DIFF
--- a/ClassNLLCriterion.lua
+++ b/ClassNLLCriterion.lua
@@ -16,7 +16,7 @@ function ClassNLLCriterion:__init(weights, sizeAverage)
     end
 
     self.output_tensor = torch.zeros(1)
-    self.total_weight_tensor = torch.zeros(1)
+    self.total_weight_tensor = torch.ones(1)
     self.target = torch.zeros(1):long()
 end
 


### PR DESCRIPTION
`total_weight_tensor` becomes to have a meaningful number after loss:forward(). Calling loss:backward() without loss:forward() will end up with zero output https://github.com/torch/nn/commit/ef2e3d290418c411add8eee8dd5ca7d486362ad8#diff-e3ab2ae1e4ca35f9a37e0702421d52ffR97. This commit considers the case.