### PR TITLE
Option to add Padding to Volumetric Convolution

### DIFF
--- a/VolumetricConvolution.lua
+++ b/VolumetricConvolution.lua
@@ -20,7 +20,11 @@ function VolumetricConvolution:__init(nInputPlane, nOutputPlane, kT, kW, kH, dT,
    self.bias = torch.Tensor(nOutputPlane)
    self.gradWeight = torch.Tensor(nOutputPlane, nInputPlane, kT, kH, kW)
    self.gradBias = torch.Tensor(nOutputPlane)
-   
+
+   -- temporary buffers for unfolding (CUDA)
+   self.finput = torch.Tensor()
+   self.fgradInput = torch.Tensor()
+
    self:reset()
 end
 

--- a/VolumetricConvolution.lua
+++ b/VolumetricConvolution.lua
@@ -1,6 +1,6 @@
 local VolumetricConvolution, parent = torch.class('nn.VolumetricConvolution', 'nn.Module')
 
-function VolumetricConvolution:__init(nInputPlane, nOutputPlane, kT, kW, kH, dT, dW, dH)
+function VolumetricConvolution:__init(nInputPlane, nOutputPlane, kT, kW, kH, dT, dW, dH, padT, padW, padH)
    parent.__init(self)
 
    dT = dT or 1
@@ -15,16 +15,17 @@ function VolumetricConvolution:__init(nInputPlane, nOutputPlane, kT, kW, kH, dT,
    self.dT = dT
    self.dW = dW
    self.dH = dH
+   self.padT = padT or 0
+   self.padW = padW or self.padT
+   self.padH = padH or self.padW
 
    self.weight = torch.Tensor(nOutputPlane, nInputPlane, kT, kH, kW)
    self.bias = torch.Tensor(nOutputPlane)
    self.gradWeight = torch.Tensor(nOutputPlane, nInputPlane, kT, kH, kW)
    self.gradBias = torch.Tensor(nOutputPlane)
-
    -- temporary buffers for unfolding (CUDA)
    self.finput = torch.Tensor()
-   self.fgradInput = torch.Tensor()
-
+   self.fgradInput = torch.Tensor()   
    self:reset()
 end
 


### PR DESCRIPTION
Padding option wasn't previously applicable to the Volumetric Convolution, though the CUDA kernel has it. This is the CUDA version of it.

Padding can be provided in the same was as for `SpatialConvolution` :

    module = nn.SpatialConvolution(nInputPlane, nOutputPlane, kT, kW, kH, [dT], [dW], [dH], [padT], [padW], [padH])

Default is `0`

Note : I have sent a PR for the CUDA version of it, but I am unable to do it for the CPU version. It would be wonderful if someone can do the same for the CPU version `VolumetricConvolution.c` in the `nn` package.