### PR TITLE
make nn.Linear handle 3D tensor

### DIFF
--- a/Linear.lua
+++ b/Linear.lua
@@ -62,10 +62,10 @@ function Linear:updateOutput(input)
       if not self.addBuffer or self.addBuffer:nElement() ~= (nframe * nLength) then
          self.addBuffer = input.new(nframe * nLength):fill(1)
       end
-      self.output:addmm(0, self.output, 1, input:view(nframe * nLength, nDimIn), self.weight:t())
+      self.output:addmm(0, self.output, 1, input:resize(nframe * nLength, nDimIn), self.weight:t())
       self.output:addr(1, self.addBuffer, self.bias)
-      self.output = self.output:view(nframe, nLength, nDimOut)
-      input = input:view(nframe, nLength, nDimIn)
+      self.output:resize(nframe, nLength, nDimOut)
+      input:resize(nframe, nLength, nDimIn)
    else
       error('input must be vector or matrix or 3D tensor')
    end
@@ -86,14 +86,14 @@ function Linear:updateGradInput(input, gradOutput)
       elseif input:dim() == 2 then
          self.gradInput:addmm(0, 1, gradOutput, self.weight)
       elseif input:dim() == 3 then
-         local nframe = input:size(1)
-         local nLength = input:size(2)
+         local nframe = gradOutput:size(1)
+         local nLength = gradOutput:size(2)
          local nDimOut = self.weight:size(1)
          local nDimIn = self.weight:size(2)
-         self.gradInput = self.gradInput:view(nframe * nLength, nDimIn)
-         self.gradInput:addmm(0, 1, gradOutput:view(nframe * nLength, nDimOut), self.weight)
-         self.gradInput = self.gradInput:view(nframe, nLength, nDimIn)
-         gradOutput = gradOutput:view(nframe, nLength, nDimOut)
+         self.gradInput:resize(nframe * nLength, nDimIn)
+         self.gradInput:addmm(0, 1, gradOutput:resize(nframe * nLength, nDimOut), self.weight)
+         self.gradInput:resize(nframe, nLength, nDimIn)
+         gradOutput:resize(nframe, nLength, nDimOut)
       end
 
       return self.gradInput
@@ -109,16 +109,16 @@ function Linear:accGradParameters(input, gradOutput, scale)
       self.gradWeight:addmm(scale, gradOutput:t(), input)
       self.gradBias:addmv(scale, gradOutput:t(), self.addBuffer)
    elseif input:dim() == 3 then
-      local nframe = input:size(1)
-      local nLength = input:size(2)
+      local nframe = gradOutput:size(1)
+      local nLength = gradOutput:size(2)
       local nDimOut = self.weight:size(1)
       local nDimIn = self.weight:size(2)
-      gradOutput = gradOutput:view(nframe * nLength, nDimOut)
-      input = input:view(nframe * nLength, nDimIn)
+      gradOutput:resize(nframe * nLength, nDimOut)
+      input:resize(nframe * nLength, nDimIn)
       self.gradWeight:addmm(scale, gradOutput:t(), input)
       self.gradBias:addmv(scale, gradOutput:t(), self.addBuffer)
-      gradOutput = gradOutput:view(nframe, nLength, nDimOut)
-      input = input:view(nframe, nLength, nDimIn)
+      gradOutput:resize(nframe, nLength, nDimOut)
+      input:resize(nframe, nLength, nDimIn)
    end
 end
 

--- a/Linear.lua
+++ b/Linear.lua
@@ -49,8 +49,25 @@ function Linear:updateOutput(input)
       end
       self.output:addmm(0, self.output, 1, input, self.weight:t())
       self.output:addr(1, self.addBuffer, self.bias)
+   elseif input:dim() == 3 then
+      local nframe = input:size(1)
+      local nLength = input:size(2)
+      local nDimOut = self.weight:size(1)
+      local nDimIn = self.weight:size(2)
+      local nElement = self.output:nElement()
+      self.output:resize(nframe * nLength, nDimOut)
+      if self.output:nElement() ~= nElement then
+         self.output:zero()
+      end
+      if not self.addBuffer or self.addBuffer:nElement() ~= (nframe * nLength) then
+         self.addBuffer = input.new(nframe * nLength):fill(1)
+      end
+      self.output:addmm(0, self.output, 1, input:resize(nframe * nLength, nDimIn), self.weight:t())
+      self.output:addr(1, self.addBuffer, self.bias)
+      self.output:resize(nframe, nLength, nDimOut)
+      input:resize(nframe, nLength, nDimIn)
    else
-      error('input must be vector or matrix')
+      error('input must be vector or matrix or 3D tensor')
    end
 
    return self.output
@@ -68,6 +85,15 @@ function Linear:updateGradInput(input, gradOutput)
          self.gradInput:addmv(0, 1, self.weight:t(), gradOutput)
       elseif input:dim() == 2 then
          self.gradInput:addmm(0, 1, gradOutput, self.weight)
+      elseif input:dim() == 3 then
+         local nframe = gradOutput:size(1)
+         local nLength = gradOutput:size(2)
+         local nDimOut = self.weight:size(1)
+         local nDimIn = self.weight:size(2)
+         self.gradInput:resize(nframe * nLength, nDimIn)
+         self.gradInput:addmm(0, 1, gradOutput:resize(nframe * nLength, nDimOut), self.weight)
+         self.gradInput:resize(nframe, nLength, nDimIn)
+         gradOutput:resize(nframe, nLength, nDimOut)
       end
 
       return self.gradInput
@@ -82,6 +108,17 @@ function Linear:accGradParameters(input, gradOutput, scale)
    elseif input:dim() == 2 then
       self.gradWeight:addmm(scale, gradOutput:t(), input)
       self.gradBias:addmv(scale, gradOutput:t(), self.addBuffer)
+   elseif input:dim() == 3 then
+      local nframe = gradOutput:size(1)
+      local nLength = gradOutput:size(2)
+      local nDimOut = self.weight:size(1)
+      local nDimIn = self.weight:size(2)
+      gradOutput:resize(nframe * nLength, nDimOut)
+      input:resize(nframe * nLength, nDimIn)
+      self.gradWeight:addmm(scale, gradOutput:t(), input)
+      self.gradBias:addmv(scale, gradOutput:t(), self.addBuffer)
+      gradOutput:resize(nframe, nLength, nDimOut)
+      input:resize(nframe, nLength, nDimIn)
    end
 end
 

--- a/Linear.lua
+++ b/Linear.lua
@@ -62,10 +62,10 @@ function Linear:updateOutput(input)
       if not self.addBuffer or self.addBuffer:nElement() ~= (nframe * nLength) then
          self.addBuffer = input.new(nframe * nLength):fill(1)
       end
-      self.output:addmm(0, self.output, 1, input:resize(nframe * nLength, nDimIn), self.weight:t())
+      self.output:addmm(0, self.output, 1, input:view(nframe * nLength, nDimIn), self.weight:t())
       self.output:addr(1, self.addBuffer, self.bias)
-      self.output:resize(nframe, nLength, nDimOut)
-      input:resize(nframe, nLength, nDimIn)
+      self.output = self.output:view(nframe, nLength, nDimOut)
+      input = input:view(nframe, nLength, nDimIn)
    else
       error('input must be vector or matrix or 3D tensor')
    end
@@ -86,14 +86,14 @@ function Linear:updateGradInput(input, gradOutput)
       elseif input:dim() == 2 then
          self.gradInput:addmm(0, 1, gradOutput, self.weight)
       elseif input:dim() == 3 then
-         local nframe = gradOutput:size(1)
-         local nLength = gradOutput:size(2)
+         local nframe = input:size(1)
+         local nLength = input:size(2)
          local nDimOut = self.weight:size(1)
          local nDimIn = self.weight:size(2)
-         self.gradInput:resize(nframe * nLength, nDimIn)
-         self.gradInput:addmm(0, 1, gradOutput:resize(nframe * nLength, nDimOut), self.weight)
-         self.gradInput:resize(nframe, nLength, nDimIn)
-         gradOutput:resize(nframe, nLength, nDimOut)
+         self.gradInput = self.gradInput:view(nframe * nLength, nDimIn)
+         self.gradInput:addmm(0, 1, gradOutput:view(nframe * nLength, nDimOut), self.weight)
+         self.gradInput = self.gradInput:view(nframe, nLength, nDimIn)
+         gradOutput = gradOutput:view(nframe, nLength, nDimOut)
       end
 
       return self.gradInput
@@ -109,16 +109,16 @@ function Linear:accGradParameters(input, gradOutput, scale)
       self.gradWeight:addmm(scale, gradOutput:t(), input)
       self.gradBias:addmv(scale, gradOutput:t(), self.addBuffer)
    elseif input:dim() == 3 then
-      local nframe = gradOutput:size(1)
-      local nLength = gradOutput:size(2)
+      local nframe = input:size(1)
+      local nLength = input:size(2)
       local nDimOut = self.weight:size(1)
       local nDimIn = self.weight:size(2)
-      gradOutput:resize(nframe * nLength, nDimOut)
-      input:resize(nframe * nLength, nDimIn)
+      gradOutput = gradOutput:view(nframe * nLength, nDimOut)
+      input = input:view(nframe * nLength, nDimIn)
       self.gradWeight:addmm(scale, gradOutput:t(), input)
       self.gradBias:addmv(scale, gradOutput:t(), self.addBuffer)
-      gradOutput:resize(nframe, nLength, nDimOut)
-      input:resize(nframe, nLength, nDimIn)
+      gradOutput = gradOutput:view(nframe, nLength, nDimOut)
+      input = input:view(nframe, nLength, nDimIn)
    end
 end
 

--- a/test.lua
+++ b/test.lua
@@ -596,7 +596,7 @@ function nntest.Linear()
 
      -- 3D
      local nframe = math.random(50,70)
-     local nLength = math.random(50, 70)
+     local nLength = math.random(20, 30)
      local input = torch.Tensor(nframe, nLength, ini):zero()
 
      local err = jac.testJacobian(module,input)

--- a/test.lua
+++ b/test.lua
@@ -594,7 +594,46 @@ function nntest.Linear()
                            'error on bias [%s]', t))
      end
 
-     -- IO
+     -- 3D
+     local nframe = math.random(50,70)
+     local nLength = math.random(50, 70)
+     local input = torch.Tensor(nframe, nLength, ini):zero()
+
+     local err = jac.testJacobian(module,input)
+     mytester:assertlt(err,precision, 'error on state ')
+
+     local err = jac.testJacobianParameters(module, input, module.weight, module.gradWeight)
+     mytester:assertlt(err,precision, 'error on weight ')
+
+     local err = jac.testJacobianParameters(module, input, module.bias, module.gradBias)
+     mytester:assertlt(err,precision, 'error on weight ')
+
+     local err = jac.testJacobianUpdateParameters(module, input, module.weight)
+     mytester:assertlt(err,precision, 'error on weight [direct update] ')
+
+     local err = jac.testJacobianUpdateParameters(module, input, module.bias)
+     mytester:assertlt(err,precision, 'error on bias [direct update] ')
+
+     local err = jac.testDiagHessianInput(module, input)
+     mytester:assertlt(err , precision, 'error on diagHessianInput')
+
+     local err = jac.testDiagHessianWeight(module, input)
+     mytester:assertlt(err , precision, 'error on diagHessianWeight')
+
+     local err = jac.testDiagHessianBias(module, input)
+     mytester:assertlt(err , precision, 'error on diag HessianBias')
+
+     for t,err in pairs(jac.testAllUpdate(module, input, 'weight', 'gradWeight')) do
+        mytester:assertlt(err, precision, string.format(
+                           'error on weight [%s]', t))
+     end
+
+     for t,err in pairs(jac.testAllUpdate(module, input, 'bias', 'gradBias')) do
+        mytester:assertlt(err, precision, string.format(
+                           'error on bias [%s]', t))
+     end
+
+     --IO
      local ferr,berr = jac.testIO(module,input)
      mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err ')
      mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')

--- a/test.lua
+++ b/test.lua
@@ -596,7 +596,7 @@ function nntest.Linear()
 
      -- 3D
      local nframe = math.random(50,70)
-     local nLength = math.random(20, 30)
+     local nLength = math.random(50, 70)
      local input = torch.Tensor(nframe, nLength, ini):zero()
 
      local err = jac.testJacobian(module,input)


### PR DESCRIPTION
Make nn.Linear handle 3D tensor, see #396 issue for details

Basically, when handling 3D tensor of shape (nb_batch, nb_length, nb_dim), I first resize it to (nb_batch *nb_length, nb_dim), do computation similar to that of handling 2D tensor, and then resize back to 3D tensor. I also add some test case in test.lua.