### PR TITLE
Also clone grad weights and biases

### DIFF
--- a/doc/criterion.md
+++ b/doc/criterion.md
@@ -562,7 +562,7 @@ loss(x, y) = max(0, -y * (x[1] - x[2]) + margin)
 
 ```lua
 p1_mlp = nn.Linear(5, 2)
-p2_mlp = p1_mlp:clone('weight', 'bias')
+p2_mlp = p1_mlp:clone('weight', 'bias', 'gradWeight', 'gradBias')
 
 prl = nn.ParallelTable()
 prl:add(p1_mlp)
@@ -572,7 +572,7 @@ mlp1 = nn.Sequential()
 mlp1:add(prl)
 mlp1:add(nn.DotProduct())
 
-mlp2 = mlp1:clone('weight', 'bias')
+mlp2 = mlp1:clone('weight', 'bias', 'gradWeight', 'gradBias')
 
 mlpa = nn.Sequential()
 prla = nn.ParallelTable()


### PR DESCRIPTION
As per https://github.com/torch/optim/issues/73, gradWeight and gradBias should also be cloned.