### PR TITLE
Add eps correctly

### DIFF
--- a/BCECriterion.lua
+++ b/BCECriterion.lua
@@ -49,7 +49,7 @@ function BCECriterion:updateOutput(input, target)
     output = torch.dot(target, buffer)
 
     -- log(1 - input) * (1 - target)
-    buffer:mul(input, -1):add(1 + eps):log()
+    buffer:mul(input, -1):add(1):add(eps):log()
     if weights ~= nil then buffer:cmul(weights) end
 
     output = output + torch.sum(buffer)
@@ -86,7 +86,7 @@ function BCECriterion:updateGradInput(input, target)
 
     buffer:resizeAs(input)
     -- - x ( 1 + eps -x ) + eps
-    buffer:add(input, -1-eps):cmul(input):add(-eps)
+    buffer:add(input, -1):add(-eps):cmul(input):add(-eps)
 
     gradInput:resizeAs(input)
     -- y - x


### PR DESCRIPTION
Found a bug in the new `BCECriterion`. The `updateOutput` method returns `NaN`
instead of zero when prediction is correct. The bug affects `FloatTensor` and
`CudaTensor`, but not `Tensor`.

    require 'torch'
    require 'nn'

    y = torch.FloatTensor{1, 0}
    t = torch.FloatTensor{1, 0}
    crit = nn.BCECriterion():float()

    -- returns nan, expected 0
    print(crit:forward(y, t))
    
The problem was that `eps` was handled incorrectly. Concretely,

    x:add(1 + eps)
    
is not the same as

    x:add(1):add(eps).
    
The first example just adds one when `x` is `FloatTensor` or `CudaTensor`.
