### PR TITLE
Add GradientReversal layer

### DIFF
--- a/GradientReversal.lua
+++ b/GradientReversal.lua
@@ -1,0 +1,13 @@
+local GradientReversal = torch.class('nn.GradientReversal', 'nn.Module')
+
+function GradientReversal:updateOutput(input)
+   self.output = input
+   return self.output
+end
+
+function GradientReversal:updateGradInput(input, gradOutput)
+   self.gradInput:resizeAs(gradOutput)
+   self.gradInput:copy(gradOutput)
+   self.gradInput:mul(-1)
+   return self.gradInput
+end

--- a/doc/simple.md
+++ b/doc/simple.md
@@ -32,12 +32,13 @@ Simple Modules are used for various tasks like adapting Tensor methods and provi
     * [Normalize](#nn.Normalize) : normalizes the input to have unit `L_p` norm ;
     * [MM](#nn.MM) : matrix-matrix multiplication (also supports batches of matrices) ;
   * Miscellaneous Modules :
-    * [BatchNormalization](#nn.BatchNormalization) - mean/std normalization over the mini-batch inputs (with an optional affine transform) ;
-    * [Identity](#nn.Identity) : forward input as-is to output (useful with [ParallelTable](table.md#nn.ParallelTable));
+    * [BatchNormalization](#nn.BatchNormalization) : mean/std normalization over the mini-batch inputs (with an optional affine transform) ;
+    * [Identity](#nn.Identity) : forward input as-is to output (useful with [ParallelTable](table.md#nn.ParallelTable)) ;
     * [Dropout](#nn.Dropout) : masks parts of the `input` using binary samples from a [bernoulli](http://en.wikipedia.org/wiki/Bernoulli_distribution) distribution ;
-    * [SpatialDropout](#nn.SpatialDropout) : Same as Dropout but for spatial inputs where adjacent pixels are strongly correlated ;
+    * [SpatialDropout](#nn.SpatialDropout) : same as Dropout but for spatial inputs where adjacent pixels are strongly correlated ;
     * [Padding](#nn.Padding) : adds padding to a dimension ;
-    * [L1Penalty](#nn.L1Penalty) : adds an L1 penalty to an input (for sparsity);
+    * [L1Penalty](#nn.L1Penalty) : adds an L1 penalty to an input (for sparsity) ;
+    * [GradientReversal](#nn.GradientReversal) : reverses the gradient (to maximize an objective function) ;
 
 <a name="nn.Linear"></a>
 ## Linear ##
@@ -1043,3 +1044,10 @@ autoencoder:add(decoder)
 criterion = nn.MSECriterion()  -- To measure reconstruction error
 -- ...
 ```
+
+<a name="nn.GradientReversal"></a>
+## GradientReversal ##
+
+`module` = `nn.GradientReversal()`
+
+This module preserves the input, but reverses the gradient. This can be used to maximise an objective function whilst using gradient descent, as in "Domain-Adversarial Training of Neural Networks" (http://arxiv.org/abs/1505.07818).

--- a/init.lua
+++ b/init.lua
@@ -23,6 +23,7 @@ include('Replicate.lua')
 include('Transpose.lua')
 include('BatchNormalization.lua')
 include('Padding.lua')
+include('GradientReversal.lua')
 
 include('Copy.lua')
 include('Min.lua')

--- a/test.lua
+++ b/test.lua
@@ -4239,6 +4239,24 @@ function nntest.SpatialBatchNormalization()
    mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
 end
 
+function nntest.GradientReversal()
+   local ini = math.random(3,5)
+   local inj = math.random(3,5)
+   local ink = math.random(3,5)
+   local input = torch.Tensor(ini,inj,ink):zero()
+   -- Two GradientReversal layers should cancel each other out
+   local module = nn.Sequential()
+   module:add(nn.GradientReversal())
+   module:add(nn.GradientReversal())
+
+   local err = jac.testJacobian(module,input, 0.1, 10)
+   mytester:assertlt(err,precision, 'error on state ')
+
+   local ferr,berr = jac.testIO(module,input, 0.1, 10)
+   mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err ')
+   mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
+end
+
 function nntest.Padding()
    local fanin = math.random(1,3)
    local sizex = math.random(4,16)


### PR DESCRIPTION
Implemented a GradientReversal layer, as seen in [Domain-Adversarial Training of Neural Networks](http://arxiv.org/abs/1505.07818) (though quite possibly not its first appearance). Can be used to maximise a loss function with gradient descent, especially in tandem with minimising other loss functions normally.

Also did a little tidying up of the docs.