### PR TITLE
wrong example in View

### DIFF
--- a/doc/simple.md
+++ b/doc/simple.md
@@ -718,7 +718,7 @@ Example 2:
 > print(#m:forward(input))
 
  6
-[torch.LongStorage of size 2]
+[torch.LongStorage of size 1]
 
 > print(#m:forward(minibatch))
 


### PR DESCRIPTION
The running results should be as follows:

```
th> model=nn.View(-1):setNumInputDims(2)
                                                                      [0.0001s]
th> model:forward(input)
 0.8104
 0.6197
 0.0124
 0.2712
 0.0574
 0.6872
[torch.DoubleTensor of size 6]

                                                                      [0.0002s]
th> input
 0.8104  0.6197  0.0124
 0.2712  0.0574  0.6872
[torch.DoubleTensor of size 2x3]

                                                                      [0.0002s]
th> #model:forward(input)

 6
[torch.LongStorage of size 1]

```