### PR TITLE
Fixed Segmentation fault on very big data sizes

### DIFF
--- a/generic/SpatialConvolutionMM.c
+++ b/generic/SpatialConvolutionMM.c
@@ -108,9 +108,7 @@ static void nn_(unfolded_copy)(THTensor *finput, THTensor *input,
             for (x=0; x<outputWidth; x++){
                ix = x*dW - padW + kw;
                if (ix < 0 || ix >= inputWidth)
-               {
                  memset(dst+y*outputWidth+x, 0, sizeof(real)*1);
-               }
                else
                  memcpy(dst+y*outputWidth+x, src+iy*inputWidth+ix, sizeof(real)*(1));
             }

--- a/generic/SpatialConvolutionMM.c
+++ b/generic/SpatialConvolutionMM.c
@@ -83,9 +83,6 @@ static void nn_(unfolded_copy)(THTensor *finput, THTensor *input,
     size_t kh = rest / kW;
     size_t kw = rest % kW;
     size_t x,y,ix,iy;
-
-
-
     real *dst = finput_data + nip*(kH*kW*outputHeight*outputWidth) + kh*(kW*outputHeight*outputWidth) + kw*(outputHeight*outputWidth);
     real *src = input_data + nip*(inputHeight*inputWidth);
     if (padW > 0 || padH > 0) {

--- a/generic/SpatialConvolutionMM.c
+++ b/generic/SpatialConvolutionMM.c
@@ -104,8 +104,6 @@ static void nn_(unfolded_copy)(THTensor *finput, THTensor *input,
              } else {
                 if (lpad > 0) memset(dst+y*outputWidth, 0, sizeof(real)*lpad);
                 memcpy(dst+y*outputWidth+lpad, src+iy*inputWidth+ix+lpad, sizeof(real)*(outputWidth-rpad-lpad));
-
-
                 if (rpad > 0) memset(dst+y*outputWidth + outputWidth - rpad, 0, sizeof(real)*rpad);
              }
           }
@@ -114,7 +112,6 @@ static void nn_(unfolded_copy)(THTensor *finput, THTensor *input,
                ix = x*dW - padW + kw;
                if (ix < 0 || ix >= inputWidth)
                {
-
                  memset(dst+y*outputWidth+x, 0, sizeof(real)*1);
                }
                else


### PR DESCRIPTION
When data size exceeds dozens of GB int variables can’t store data size anymore so memset and memcpy fail with Segmentation fault errors - reproduced when using convolutional neural networks for image processing - in neuralstyle and deepstyle implementation, with images larger than 2000x2000.

You can find that using gdb on lua.

For example [this bug](https://github.com/jcjohnson/neural-style/issues/24) has been closed because of this issue. [This one](https://github.com/kaishengtai/neuralart/issues/11) has not been resolved as well.