### PR TITLE
Fix CosineDistance to handle non-contiguous input

### DIFF
--- a/CosineDistance.lua
+++ b/CosineDistance.lua
@@ -4,12 +4,25 @@ function CosineDistance:__init()
    parent.__init(self)
    self.gradInput = {torch.Tensor(), torch.Tensor()}
 end 
- 
+
+local function makeContiguous(self, input1, input2)
+   if not input1:isContiguous() then
+      self._input1 = self._input1 or input1.new()
+      self._input1:resizeAs(input1):copy(input1)
+      input1 = self._input1
+   end
+   if not input2:isContiguous() then
+      self._input2 = self._input2 or input2.new()
+      self._input2:resizeAs(input2):copy(input2)
+      input2 = self._input2
+   end
+   return input1, input2
+end
+
 function CosineDistance:updateOutput(input)
    local input1, input2 = input[1], input[2]
 
-   if not input1:isContiguous() then input1 = input1:clone() end
-   if not input2:isContiguous() then input2 = input2:clone() end
+   input1, input2 = makeContiguous(self, input1, input2)
    
    if input1:dim() == 1 then
       input1 = input1:view(1,-1)
@@ -52,8 +65,7 @@ function CosineDistance:updateGradInput(input, gradOutput)
    local v2  = input[2]
    local not_batch = false
    
-   if not v1:isContiguous() then v1 = v1:clone() end
-   if not v2:isContiguous() then v2 = v2:clone() end
+   v1, v2 = makeContiguous(self, v1, v2)
    
    if v1:dim() == 1 then
       v1 = v1:view(1,-1)

--- a/CosineDistance.lua
+++ b/CosineDistance.lua
@@ -8,6 +8,9 @@ end
 function CosineDistance:updateOutput(input)
    local input1, input2 = input[1], input[2]
 
+   if not input1:isContiguous() then input1 = input1:clone() end
+   if not input2:isContiguous() then input2 = input2:clone() end
+   
    if input1:dim() == 1 then
       input1 = input1:view(1,-1)
       input2 = input2:view(1,-1)
@@ -48,7 +51,10 @@ function CosineDistance:updateGradInput(input, gradOutput)
    local v1  = input[1]
    local v2  = input[2]
    local not_batch = false
-
+   
+   if not v1:isContiguous() then v1 = v1:clone() end
+   if not v2:isContiguous() then v2 = v2:clone() end
+   
    if v1:dim() == 1 then
       v1 = v1:view(1,-1)
       v2 = v2:view(1,-1)


### PR DESCRIPTION
Thanks for the batch version of CosineDistance. Just one quick fix here so it can handle the non-contiguous input. Just for backward-compatibility purpose since the original/old CosineDistance.lua can handle non-contiguous input without problems, and also it is a little bit troublesome for end users to make all input tensors contiguous by themselves. Non-contiguous input cases could happen unfortunately.. for example in this recent [model](http://github.com/hohoCode/textSimilarityConvNet). I tested this fix on my end, it works. 

Thanks again for the batch version update.