### PR TITLE
Fixed unsigned logic for signed numbers in SpatialConvolutionMM

### DIFF
--- a/generic/SpatialConvolutionMM.c
+++ b/generic/SpatialConvolutionMM.c
@@ -18,7 +18,8 @@ static void nn_(unfolded_acc)(THTensor *finput, THTensor *input,
 #pragma omp parallel for private(nip)
   for(nip = 0; nip < nInputPlane; nip++)
   {
-    size_t kw, kh, y, x, ix, iy;
+    size_t kw, kh, y, x; 
+    long long ix = 0, iy = 0;
     for(kh = 0; kh < kH; kh++)
     {
       for(kw = 0; kw < kW; kw++)
@@ -28,34 +29,34 @@ static void nn_(unfolded_acc)(THTensor *finput, THTensor *input,
         if (padW > 0 || padH > 0) {
           size_t lpad,rpad;
           for(y = 0; y < outputHeight; y++) {
-            iy = y*dH - padH + kh;
+            iy = (long long)(y*dH - padH + kh);
             if (iy < 0 || iy >= inputHeight) {
             } else {
               if (dW==1){
-                 ix = 0 - padW + kw;
+                 ix = (long long)(0 - padW + kw);
                  lpad = fmaxf(0,padW-kw);
                  rpad = fmaxf(0,padW-(kW-kw-1));
-                 THVector_(add)(dst+iy*inputWidth+ix+lpad, src+y*outputWidth+lpad, 1, outputWidth - lpad - rpad); /* note: THVector_add could handle 1 value better */
+                 THVector_(add)(dst+(size_t)(iy*inputWidth+ix+lpad), src+(size_t)(y*outputWidth+lpad), 1, outputWidth - lpad - rpad); /* note: THVector_add could handle 1 value better */
               }
               else{
                 for (x=0; x<outputWidth; x++){
-                   ix = x*dW - padW + kw;
+                   ix = (long long)(x*dW - padW + kw);
                    if (ix < 0 || ix >= inputWidth){
                    }else
-                     THVector_(add)(dst+iy*inputWidth+ix, src+y*outputWidth+x, 1, 1);
+                     THVector_(add)(dst+(size_t)(iy*inputWidth+ix), src+(size_t)(y*outputWidth+x), 1, 1);
                 }
               }
             }
           }
         } else {
           for(y = 0; y < outputHeight; y++) {
-            iy = y*dH + kh;
-            ix = 0 + kw;
+            iy = (long long)(y*dH + kh);
+            ix = (long long)(0 + kw);
             if (dW == 1 )
-               THVector_(add)(dst+iy*inputWidth+ix, src+y*outputWidth, 1, outputWidth); /* note: THVector_add could handle 1 value better */
+               THVector_(add)(dst+(size_t)(iy*inputWidth+ix), src+(size_t)(y*outputWidth), 1, outputWidth); /* note: THVector_add could handle 1 value better */
             else{
               for(x = 0; x < outputWidth; x++)
-                THVector_(add)(dst+iy*inputWidth+ix+x*dW, src+y*outputWidth+x, 1, 1);
+                THVector_(add)(dst+(size_t)(iy*inputWidth+ix+x*dW), src+(size_t)(y*outputWidth+x), 1, 1);
             }
           }
         }
@@ -82,48 +83,49 @@ static void nn_(unfolded_copy)(THTensor *finput, THTensor *input,
     size_t rest = k % (kH*kW);
     size_t kh = rest / kW;
     size_t kw = rest % kW;
-    size_t x,y,ix,iy;
+    size_t x,y;
+    long long ix,iy;
     real *dst = finput_data + nip*(kH*kW*outputHeight*outputWidth) + kh*(kW*outputHeight*outputWidth) + kw*(outputHeight*outputWidth);
     real *src = input_data + nip*(inputHeight*inputWidth);
     if (padW > 0 || padH > 0) {
       size_t lpad,rpad;
       for(y = 0; y < outputHeight; y++) {
-        iy = y*dH - padH + kh;
+        iy = (long long)(y*dH - padH + kh);
         if (iy < 0 || iy >= inputHeight) {
           memset(dst+y*outputWidth, 0, sizeof(real)*outputWidth);
         } else {
           if (dW==1){
-             ix = 0 - padW + kw;
+             ix = (long long)(0 - padW + kw);
              lpad = fmaxf(0,padW-kw);
              rpad = fmaxf(0,padW-(kW-kw-1));
              if (outputWidth-rpad-lpad <= 0) {
-                memset(dst+y*outputWidth, 0, sizeof(real)*outputWidth);
+                memset(dst+(size_t)(y*outputWidth), 0, sizeof(real)*outputWidth);
              } else {
                 if (lpad > 0) memset(dst+y*outputWidth, 0, sizeof(real)*lpad);
-                memcpy(dst+y*outputWidth+lpad, src+iy*inputWidth+ix+lpad, sizeof(real)*(outputWidth-rpad-lpad));
+                memcpy(dst+(size_t)(y*outputWidth+lpad), src+(size_t)(iy*inputWidth+ix+lpad), sizeof(real)*(outputWidth-rpad-lpad));
                 if (rpad > 0) memset(dst+y*outputWidth + outputWidth - rpad, 0, sizeof(real)*rpad);
              }
           }
           else{
             for (x=0; x<outputWidth; x++){
-               ix = x*dW - padW + kw;
+               ix = (long long)(x*dW - padW + kw);
                if (ix < 0 || ix >= inputWidth)
-                 memset(dst+y*outputWidth+x, 0, sizeof(real)*1);
+                 memset(dst+(size_t)(y*outputWidth+x), 0, sizeof(real)*1);
                else
-                 memcpy(dst+y*outputWidth+x, src+iy*inputWidth+ix, sizeof(real)*(1));
+                 memcpy(dst+(size_t)(y*outputWidth+x), src+(size_t)(iy*inputWidth+ix), sizeof(real)*(1));
             }
           }
         }
       }
     } else {
       for(y = 0; y < outputHeight; y++) {
-        iy = y*dH + kh;
-        ix = 0 + kw;
+        iy = (long long)(y*dH + kh);
+        ix = (long long)(0 + kw);
         if (dW == 1)
-           memcpy(dst+y*outputWidth, src+iy*inputWidth+ix, sizeof(real)*outputWidth);
+           memcpy(dst+(size_t)(y*outputWidth), src+(size_t)(iy*inputWidth+ix), sizeof(real)*outputWidth);
         else{
           for (x=0; x<outputWidth; x++)
-             memcpy(dst+y*outputWidth+x, src+iy*inputWidth+ix+x*dW, sizeof(real)*(1));
+             memcpy(dst+(size_t)(y*outputWidth+x), src+(size_t)(iy*inputWidth+ix+x*dW), sizeof(real)*(1));
          }
       }
     }


### PR DESCRIPTION
This one will fix the following issue: https://github.com/torch/nn/issues/457 for ix & iy being <0