### PR TITLE
Do not change state variables in CosineDistance/CosineEmbeddingCriterion

### DIFF
--- a/CosineDistance.lua
+++ b/CosineDistance.lua
@@ -55,7 +55,7 @@ function CosineDistance:updateOutput(input)
    self.w:sqrt()
 
    self.output:cmul(self.w1,self.w)
-   self.output = self.output:select(2,1)
+   self.output:resize(input1:size(1))
 
    return self.output
 end
@@ -78,29 +78,22 @@ function CosineDistance:updateGradInput(input, gradOutput)
    gw1:resizeAs(v1):copy(v2)
    gw2:resizeAs(v1):copy(v1)
 
-   self.w = self.w:expandAs(v1)
    self.buffer:cmul(self.w1,self.w22)
-   self.buffer = self.buffer:expandAs(v1)
-   gw1:addcmul(-1,self.buffer,v1)
-   gw1:cmul(self.w)
+   gw1:addcmul(-1,self.buffer:expandAs(v1),v1)
+   gw1:cmul(self.w:expandAs(v1))
 
    self.buffer:cmul(self.w1,self.w32)
-   self.buffer = self.buffer:expandAs(v1)
-   gw2:addcmul(-1,self.buffer,v2)
-   gw2:cmul(self.w)
+   gw2:addcmul(-1,self.buffer:expandAs(v1),v2)
+   gw2:cmul(self.w:expandAs(v1))
 
    local go = gradOutput:view(-1,1):expandAs(v1)
    gw1:cmul(go)
    gw2:cmul(go)
 
    if not_batch then
-      self.gradInput[1] = gw1:select(1,1)
-      self.gradInput[2] = gw2:select(1,1)
+      self.gradInput[1]:resize(gw1:size(2))
+      self.gradInput[2]:resize(gw2:size(2))
    end
-
-   -- fix for torch bug 
-   -- https://github.com/torch/torch7/issues/289
-   self.buffer:resize()
 
    return self.gradInput
 end

--- a/CosineEmbeddingCriterion.lua
+++ b/CosineEmbeddingCriterion.lua
@@ -97,16 +97,13 @@ function CosineEmbeddingCriterion:updateGradInput(input, y)
    gw1:resizeAs(v1):copy(v2)
    gw2:resizeAs(v1):copy(v1)
 
-   self.w = self.w:expandAs(v1)
    self.buffer:cmul(self.w1,self.w22)
-   self.buffer = self.buffer:expandAs(v1)
-   gw1:addcmul(-1,self.buffer,v1)
-   gw1:cmul(self.w)
+   gw1:addcmul(-1,self.buffer:expandAs(v1),v1)
+   gw1:cmul(self.w:expandAs(v1))
 
    self.buffer:cmul(self.w1,self.w32)
-   self.buffer = self.buffer:expandAs(v1)
-   gw2:addcmul(-1,self.buffer,v2)
-   gw2:cmul(self.w)
+   gw2:addcmul(-1,self.buffer:expandAs(v1),v2)
+   gw2:cmul(self.w:expandAs(v1))
 
    -- self._idx = self._outputs <= 0
    y.le(self._idx,self._outputs,0)
@@ -125,13 +122,9 @@ function CosineEmbeddingCriterion:updateGradInput(input, y)
    end
 
    if not_batch then
-      self.gradInput[1] = gw1:select(1,1)
-      self.gradInput[2] = gw2:select(1,1)
+      self.gradInput[1]:resize(gw1:size(2))
+      self.gradInput[2]:resize(gw2:size(2))
    end
-
-   -- fix for torch bug 
-   -- https://github.com/torch/torch7/issues/289
-   self.buffer:resize()
 
    return self.gradInput
 end


### PR DESCRIPTION
Previous version was changing the state variables if not in batch mode, similar issue as the one pointed out in https://github.com/torch/nn/pull/432.
A few notes:
* I'm resizing the state variables `output`, `gradInput`. If you prefer, I can create a temporary buffer instead
* I also cleaned a bit the use of the `buffer` variable. Replacing it by a zero-strided tensor was not a good idea (and lead to the bug mentioned in the bottom of the files), so I just expand it when needed.