### PR TITLE
Normalize supports infinity (maximum) norm

### DIFF
--- a/doc/simple.md
+++ b/doc/simple.md
@@ -951,6 +951,15 @@ B = m:forward(A) -- B is also 3 x 5
 print(torch.norm(B, 2, 2)) -- norms is [1, 1, 1]
 ```
 
+`Normalize` has a specialized implementation for the `inf` norm, which corresponds to the maximum norm.
+```lua
+A = torch.randn(3,5)
+m = nn.Normalize(math.huge) -- uses maximum/inf norm
+B = m:forward(A)
+maxA = torch.abs(A):max(2)
+print(A,B,maxA)
+```
+
 <a name="nn.MM"></a>
 ## MM ##
 

--- a/test.lua
+++ b/test.lua
@@ -509,7 +509,7 @@ function nntest.Normalize()
    end
 
    -- batch mode
-   for _,p in pairs({1,2,3,4,torch.uniform()*math.random(1,10)}) do
+   for _,p in pairs({1,2,3,4,torch.uniform()*math.random(1,10),math.huge}) do
       local ini = math.random(3,5)
       local inj = math.random(3,5)
       local ink = math.random(3,5)


### PR DESCRIPTION
This PR allows normalization by the maximum absolute-value of each batch element.
I thought it would be better to include this functionality into `Normalize`, instead of creating a new function only for that.
Infinity norm can be used by calling the constructor with `math.huge`, as follows
```lua
normalize = nn.Normalize(math.huge)
```