### PR TITLE
Add tensorCache to Min and Max type method

### DIFF
--- a/Max.lua
+++ b/Max.lua
@@ -35,16 +35,16 @@ function Max:updateGradInput(input, gradOutput)
    return self.gradInput
 end
 
-function Max:type(type)
+function Max:type(type, tensorCache)
   -- torch.max expects a LongTensor as indices, whereas cutorch.max expects a CudaTensor.
   if type == 'torch.CudaTensor' then
-    parent.type(self, type)
+    parent.type(self, type, tensorCache)
   else
     -- self._indices must be a LongTensor. Setting it to nil temporarily avoids
     -- unnecessary memory allocations.
     local indices
     indices, self._indices = self._indices, nil
-    parent.type(self, type)
+    parent.type(self, type, tensorCache)
     self._indices = indices and indices:long() or nil
   end
   return self

--- a/Min.lua
+++ b/Min.lua
@@ -35,16 +35,16 @@ function Min:updateGradInput(input, gradOutput)
    return self.gradInput
 end
 
-function Min:type(type)
+function Min:type(type, tensorCache)
   -- torch.min expects a LongTensor as indices, whereas cutorch.max expects a CudaTensor.
   if type == 'torch.CudaTensor' then
-    parent.type(self, type)
+    parent.type(self, type, tensorCache)
   else
     -- self._indices must be a LongTensor. Setting it to nil temporarily avoids
     -- unnecessary memory allocations.
     local indices
     indices, self._indices = self._indices, nil
-    parent.type(self, type)
+    parent.type(self, type, tensorCache)
     self._indices = indices and indices:long() or nil
   end
   return self


### PR DESCRIPTION
As mentioned by @koraykv in https://github.com/torch/nn/pull/476, `type` method was not updated with `tensorCache`.
I think it doesn't affect sharing etc because those functions doesn't have learnable parameters, but for consistency, it's better to add this `tensorCache` argument.