### PR TITLE
clearState

### DIFF
--- a/BatchNormalization.lua
+++ b/BatchNormalization.lua
@@ -154,3 +154,14 @@ function BN:accGradParameters(input, gradOutput, scale)
       self.gradBias:add(scale, self.buffer)
    end
 end
+
+function BN:clearState()
+   nn.utils.clear(self, {
+      'buffer',
+      'buffer2',
+      'centered',
+      'std',
+      'normalized',
+   })
+   return parent.clearState(self)
+end

--- a/Bilinear.lua
+++ b/Bilinear.lua
@@ -140,3 +140,8 @@ function Bilinear:__tostring__()
          (self.bias == nil and ' without bias' or '')
       )
 end
+
+function Bilinear:clearState()
+   if self.buff then self.buff:set() end
+   return parent.clearState(self)
+end

--- a/CMul.lua
+++ b/CMul.lua
@@ -116,13 +116,20 @@ end
 
 function CMul:type(type, tensorCache)
    if type then
-      self._input = nil
-      self._output = nil
-      self._weight = nil
-      self._gradWeight = nil
-      self._expand = nil
-      self._repeat = nil
-      self._sum = nil
+      self:clearState()
    end
    return parent.type(self, type, tensorCache)
+end
+
+function CMul:clearState()
+   nn.utils.clear(self, {
+      '_input',
+      '_output',
+      '_weight',
+      '_gradWeight',
+      '_expand',
+      '_repeat',
+      '_sum',
+   })
+   return parent.clearState(self)
 end

--- a/CMulTable.lua
+++ b/CMulTable.lua
@@ -48,3 +48,8 @@ function CMulTable:updateGradInput(input, gradOutput)
 
    return self.gradInput
 end
+
+function CMulTable:clearState()
+   if self.tout then self.tout:set() end
+   return parent.clearState(self)
+end

--- a/Container.lua
+++ b/Container.lua
@@ -75,3 +75,26 @@ function Container:parameters()
     end
     return w,gw
 end
+
+function Container:clearState()
+   -- don't call set because it might reset referenced tensors
+   local function clear(f)
+      if self[f] then
+         if torch.isTensor(self[f]) then
+            self[f] = self[f].new()
+         elseif type(self[f]) == 'table' then
+            self[f] = {}
+         else
+            self[f] = nil
+         end
+      end
+   end
+   clear('output')
+   clear('gradInput')
+   if self.modules then
+      for i,module in pairs(self.modules) do
+         module:clearState()
+      end
+   end
+   return self
+end

--- a/Cosine.lua
+++ b/Cosine.lua
@@ -161,3 +161,15 @@ function Cosine:type(type, tensorCache)
    end
    return parent.type(self, type, tensorCache)
 end
+
+function Cosine:clearState()
+   nn.utils.clear(self, {
+      '_input',
+      '_weight',
+      '_gradOutput',
+      '_sum',
+      '_inputNorm',
+      '_weightNorm',
+   })
+   return parent.clearState(self)
+end

--- a/CosineDistance.lua
+++ b/CosineDistance.lua
@@ -73,6 +73,11 @@ function CosineDistance:updateGradInput(input, gradOutput)
       not_batch = true
    end
 
+   if #self.gradInput ~= 2 then
+      self.gradInput[1] = self.gradInput[1] or v1.new()
+      self.gradInput[2] = self.gradInput[2] or v1.new()
+   end
+
    local gw1 = self.gradInput[1]
    local gw2 = self.gradInput[2]
    gw1:resizeAs(v1):copy(v2)
@@ -96,4 +101,16 @@ function CosineDistance:updateGradInput(input, gradOutput)
    end
 
    return self.gradInput
+end
+
+function CosineDistance:clearState()
+   nn.utils.clear(self, {
+      'buffer',
+      'w1',
+      'w22',
+      'w',
+      'w32',
+      'ones',
+   })
+   return parent.clearState(self)
 end

--- a/DotProduct.lua
+++ b/DotProduct.lua
@@ -26,6 +26,11 @@ function DotProduct:updateGradInput(input, gradOutput)
    local v2 = input[2]
    local not_batch = false
 
+   if #self.gradInput ~= 2 then
+     self.gradInput[1] = self.gradInput[1] or input[1].new()
+     self.gradInput[2] = self.gradInput[2] or input[2].new()
+   end
+
    if v1:dim() == 1 then
       v1 = v1:view(1,-1)
       v2 = v2:view(1,-1)
@@ -48,4 +53,9 @@ function DotProduct:updateGradInput(input, gradOutput)
    end
 
    return self.gradInput
+end
+
+function DotProduct:clearState()
+   if self.buffer then self.buffer:set() end
+   return parent.clearState(self)
 end

--- a/Dropout.lua
+++ b/Dropout.lua
@@ -64,3 +64,11 @@ end
 function Dropout:__tostring__()
    return string.format('%s(%f)', torch.type(self), self.p)
 end
+
+
+function Dropout:clearState()
+   if self.noise then
+      self.noise:set()
+   end
+   return Parent.clearState(self)
+end

--- a/Euclidean.lua
+++ b/Euclidean.lua
@@ -174,17 +174,24 @@ end
 function Euclidean:type(type, tensorCache)
    if type then
       -- prevent premature memory allocations
-      self._input = nil
-      self._output = nil
-      self._gradOutput = nil
-      self._weight = nil
-      self._div = nil
-      self._sum = nil
-      self._expand = nil
-      self._expand2 = nil
-      self._expand3 = nil
-      self._repeat = nil
-      self._repeat2 = nil
+      self:clearState()
    end
    return parent.type(self, type, tensorCache)
+end
+
+function Euclidean:clearState()
+   nn.utils.clear(self, {
+      '_input',
+      '_output',
+      '_gradOutput',
+      '_weight',
+      '_div',
+      '_sum',
+      '_expand',
+      '_expand2',
+      '_expand3',
+      '_repeat',
+      '_repeat2',
+   })
+   return parent.clearState(self)
 end

--- a/FlattenTable.lua
+++ b/FlattenTable.lua
@@ -97,6 +97,10 @@ end
 function FlattenTable:type(type, tensorCache)
   -- This function just stores references so we don't need to do any type
   -- conversions.  Just force the tables to be empty.
-  self.output = {}
+  self:clearState()
+end
+
+function FlattenTable:clearState()
   self.input_map = {}
+  return parent.clearState(self)
 end

--- a/GradientReversal.lua
+++ b/GradientReversal.lua
@@ -1,7 +1,7 @@
 local GradientReversal = torch.class('nn.GradientReversal', 'nn.Module')
 
 function GradientReversal:updateOutput(input)
-   self.output = input
+   self.output:set(input)
    return self.output
 end
 

--- a/Identity.lua
+++ b/Identity.lua
@@ -10,3 +10,21 @@ function Identity:updateGradInput(input, gradOutput)
    self.gradInput = gradOutput
    return self.gradInput
 end
+
+function Identity:clearState()
+   -- don't call set because it might reset referenced tensors
+   local function clear(f)
+      if self[f] then
+         if torch.isTensor(self[f]) then
+            self[f] = self[f].new()
+         elseif type(self[f]) == 'table' then
+            self[f] = {}
+         else
+            self[f] = nil
+         end
+      end
+   end
+   clear('output')
+   clear('gradInput')
+   return self
+end

--- a/Jacobian.lua
+++ b/Jacobian.lua
@@ -305,6 +305,7 @@ function nn.Jacobian.testIO(module,input, minval, maxval)
    -- write module
    local filename = os.tmpname()
    local f = torch.DiskFile(filename, 'w'):binary()
+   module:clearState()
    f:writeObject(module)
    f:close()
    -- read module

--- a/L1Cost.lua
+++ b/L1Cost.lua
@@ -23,3 +23,8 @@ function L1Cost:updateGradInput(input)
    )
    return self.gradInput
 end
+
+function L1Cost:clearState()
+   if self.output_tensor then self.output_tensor:set() end
+   return parent.clearState(self)
+end

--- a/L1Penalty.lua
+++ b/L1Penalty.lua
@@ -41,3 +41,7 @@ function L1Penalty:updateGradInput(input, gradOutput)
     return self.gradInput 
 end
 
+function L1Penalty:clearState()
+   if self.loss then self.loss:set() end
+   return parent.clearState(self)
+end

--- a/Linear.lua
+++ b/Linear.lua
@@ -95,6 +95,10 @@ end
 -- we do not need to accumulate parameters when sharing
 Linear.sharedAccUpdateGradParameters = Linear.accUpdateGradParameters
 
+function Linear:clearState()
+   if self.addBuffer then self.addBuffer:set() end
+   return parent.clearState(self)
+end
 
 function Linear:__tostring__()
   return torch.type(self) ..

--- a/LogSigmoid.lua
+++ b/LogSigmoid.lua
@@ -23,3 +23,9 @@ function LogSigmoid:updateGradInput(input, gradOutput)
    )
    return self.gradInput
 end
+
+function LogSigmoid:clearState()
+   if self.buffer then self.buffer:set() end
+   return parent.clearState(self)
+end
+

--- a/LookupTable.lua
+++ b/LookupTable.lua
@@ -100,5 +100,9 @@ function LookupTable:type(type, tensorCache)
    return self
 end
 
+function LookupTable:clearState()
+   return self
+end
+
 -- we do not need to accumulate parameters when sharing
 LookupTable.sharedAccUpdateGradParameters = LookupTable.accUpdateGradParameters

--- a/Max.lua
+++ b/Max.lua
@@ -63,3 +63,8 @@ function Max:type(type, tensorCache)
   end
   return self
 end
+
+function Max:clearState()
+   nn.utils.clear(self, '_indices', '_output')
+   return parent.clearState(self)
+end

--- a/Min.lua
+++ b/Min.lua
@@ -63,3 +63,8 @@ function Min:type(type, tensorCache)
   end
   return self
 end
+
+function Min:clearState()
+   nn.utils.clear(self, '_indices', '_output')
+   return parent.clearState(self)
+end

--- a/MixtureTable.lua
+++ b/MixtureTable.lua
@@ -156,3 +156,15 @@ function MixtureTable:type(type, tensorCache)
    self._expertView2 = nil
    return parent.type(self, type, tensorCache)
 end
+
+function MixtureTable:clearState()
+   nn.utils.clear(self, {
+     '_gaterView',
+     '_expert',
+     '_expertView',
+     '_sum',
+     '_expert2',
+     '_expertView2',
+   })
+   return parent.clearState(self)
+end

--- a/Module.lua
+++ b/Module.lua
@@ -364,3 +364,7 @@ function Module:listModules()
    end
    return modules
 end
+
+function Module:clearState()
+   return nn.utils.clear(self, 'output', 'gradInput')
+end

--- a/Normalize.lua
+++ b/Normalize.lua
@@ -140,3 +140,16 @@ function Normalize:type(type, tensorCache)
   end
   return self
 end
+
+function Normalize:clearState()
+   nn.utils.clear(self, {
+      '_output',
+      '_indices',
+      '_gradInput',
+      'buffer',
+      'norm',
+      'normp',
+      'cross',
+   })
+   return parent.clearState(self)
+end

--- a/PReLU.lua
+++ b/PReLU.lua
@@ -45,3 +45,8 @@ function PReLU:accGradParameters(input, gradOutput, scale)
    )
    return self.gradWeight
 end
+
+function PReLU:clearState()
+   nn.utils.clear(self, 'gradWeightBuf', 'gradWeightBuf2')
+   return parent.clearState(self)
+end

--- a/PairwiseDistance.lua
+++ b/PairwiseDistance.lua
@@ -10,6 +10,7 @@ function PairwiseDistance:__init(p)
 end 
   
 function PairwiseDistance:updateOutput(input)
+   self.output:resize(1)
    if input[1]:dim() == 1 then
       self.output:resize(1)
       self.output[1]=input[1]:dist(input[2],self.norm)
@@ -82,4 +83,9 @@ function PairwiseDistance:updateGradInput(input, gradOutput)
    end
    self.gradInput[2]:zero():add(-1, self.gradInput[1])
    return self.gradInput
+end
+
+function PairwiseDistance:clearState()
+   nn.utils.clear(self, 'diff', 'outExpand', 'grad', 'ones')
+   return parent.clearState(self)
 end

--- a/RReLU.lua
+++ b/RReLU.lua
@@ -43,3 +43,8 @@ end
 function RReLU:__tostring__()
   return string.format('%s (l:%f, u:%f)', torch.type(self), self.lower, self.upper)
 end
+
+function RReLU:clearState()
+   if self.noise then self.noise:set() end
+   return parent.clearState(self)
+end

--- a/Reshape.lua
+++ b/Reshape.lua
@@ -67,3 +67,8 @@ function Reshape:__tostring__()
   return torch.type(self) .. '(' ..
       table.concat(self.size:totable(), 'x') .. ')'
 end
+
+function Reshape:clearState()
+   nn.utils.clear(self, '_input', '_gradOutput')
+   return parent.clearState(self)
+end

--- a/SoftMin.lua
+++ b/SoftMin.lua
@@ -1,4 +1,4 @@
-local SoftMin, _ = torch.class('nn.SoftMin', 'nn.Module')
+local SoftMin, parent = torch.class('nn.SoftMin', 'nn.Module')
 
 function SoftMin:updateOutput(input)
    self.mininput = self.mininput or input.new()
@@ -23,4 +23,9 @@ function SoftMin:updateGradInput(input, gradOutput)
 
    self.gradInput:mul(-1)
    return self.gradInput
+end
+
+function SoftMin:clearState()
+   if self.mininput then self.mininput:set() end
+   return parent.clearState(self)
 end

--- a/SoftSign.lua
+++ b/SoftSign.lua
@@ -1,4 +1,4 @@
-local SoftSign = torch.class('nn.SoftSign', 'nn.Module')
+local SoftSign, parent = torch.class('nn.SoftSign', 'nn.Module')
 
 function SoftSign:updateOutput(input)
    self.temp = self.temp or input.new()
@@ -12,4 +12,9 @@ function SoftSign:updateGradInput(input, gradOutput)
    self.tempgrad:resizeAs(self.output):copy(input):abs():add(1):cmul(self.tempgrad)
    self.gradInput:resizeAs(input):copy(gradOutput):cdiv(self.tempgrad)
    return self.gradInput
+end
+
+function SoftSign:clearState()
+   nn.utils.clear(self, 'temp', 'tempgrad')
+   return parent.clearState(self)
 end

--- a/SparseLinear.lua
+++ b/SparseLinear.lua
@@ -76,3 +76,8 @@ function SparseLinear:zeroGradParameters()
       parent.zeroGradParameters(self)
    end
 end
+
+function SparseLinear:clearState()
+   if self.lastInput then self.lastInput:set() end
+   return parent.clearState(self)
+end

--- a/SpatialAdaptiveMaxPooling.lua
+++ b/SpatialAdaptiveMaxPooling.lua
@@ -29,11 +29,14 @@ function SpatialAdaptiveMaxPooling:updateGradInput(input, gradOutput)
    return self.gradInput
 end
 
+-- for backward compat
 function SpatialAdaptiveMaxPooling:empty()
-   self.gradInput:resize()
-   self.gradInput:storage():resize(0)
-   self.output:resize()
-   self.output:storage():resize(0)
-   self.indices:resize()
-   self.indices:storage():resize(0)
+   self:clearState()
+end
+
+function SpatialAdaptiveMaxPooling:clearState()
+   if self.indices then
+      self.indices:set()
+   end
+   return parent.clearState(self)
 end

--- a/SpatialBatchNormalization.lua
+++ b/SpatialBatchNormalization.lua
@@ -140,3 +140,14 @@ function BN:read(file, version)
       end
    end
 end
+
+function BN:clearState()
+   nn.utils.clear(self, {
+      'buffer',
+      'buffer2',
+      'centered',
+      'std',
+      'normalized',
+   })
+   return parent.clearState(self)
+end

--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -171,3 +171,9 @@ function SpatialConvolution:__tostring__()
    end
    return s .. ')'
 end
+
+function SpatialConvolution:clearState()
+   nn.utils.clear(self, 'finput', 'fgradInput', '_input', '_gradOutput')
+   return parent.clearState(self)
+end
+

--- a/SpatialConvolutionLocal.lua
+++ b/SpatialConvolutionLocal.lua
@@ -164,3 +164,8 @@ function SpatialConvolutionLocal:__tostring__()
    end
    return s .. ')'
 end
+
+function SpatialConvolutionLocal:clearState()
+   nn.utils.clear(self, 'finput', 'fgradInput', '_input', '_gradOutput')
+   return parent.clearState(self)
+end

--- a/SpatialConvolutionMM.lua
+++ b/SpatialConvolutionMM.lua
@@ -23,7 +23,7 @@ function SpatialConvolutionMM:__init(nInputPlane, nOutputPlane, kW, kH, dW, dH, 
 
    self.finput = torch.Tensor()
    self.fgradInput = torch.Tensor()
-   
+
    self:reset()
 end
 
@@ -137,3 +137,9 @@ function SpatialConvolutionMM:__tostring__()
    end
    return s .. ')'
 end
+
+function SpatialConvolutionMM:clearState()
+   nn.utils.clear(self, 'finput', 'fgradInput', '_input', '_gradOutput')
+   return parent.clearState(self)
+end
+

--- a/SpatialCrossMapLRN.lua
+++ b/SpatialCrossMapLRN.lua
@@ -127,3 +127,9 @@ function SpatialCrossMapLRN:updateGradInput(input, gradOutput)
 
   return self.gradInput
 end
+
+
+function SpatialCrossMapLRN:clearState()
+   nn.utils.clear(self, 'scale', 'paddedRatio', 'accumRatio')
+  return parent.clearState(self)
+end

--- a/SpatialDivisiveNormalization.lua
+++ b/SpatialDivisiveNormalization.lua
@@ -126,3 +126,11 @@ function SpatialDivisiveNormalization:updateGradInput(input, gradOutput)
    -- done
    return self.gradInput
 end
+
+function SpatialDivisiveNormalization:clearState()
+   if self.ones then self.ones:set() end
+   if self._coef then self._coef:set() end
+   self.meanestimator:clearState()
+   self.stdestimator:clearState()
+   return parent.clearState(self)
+end

--- a/SpatialDropout.lua
+++ b/SpatialDropout.lua
@@ -45,3 +45,10 @@ end
 function SpatialDropout:__tostring__()
   return string.format('%s(%f)', torch.type(self), self.p)
 end
+
+function SpatialDropout:clearState()
+  if self.noise then
+    self.noise:set()
+  end
+  return Parent.clearState(self)
+end

--- a/SpatialFractionalMaxPooling.lua
+++ b/SpatialFractionalMaxPooling.lua
@@ -138,14 +138,14 @@ function SpatialFractionalMaxPooling:updateGradInput(input, gradOutput)
    return self.gradInput
 end
 
+-- backward compat
 function SpatialFractionalMaxPooling:empty()
-   self.gradInput:resize()
-   self.gradInput:storage():resize(0)
-   self.output:resize()
-   self.output:storage():resize(0)
-   self.indices:resize()
-   self.indices:storage():resize(0)
-   self.randomSamples = nil
+   self:clearState()
+end
+
+function SpatialFractionalMaxPooling:clearState()
+   nn.utils.clear(self, 'indices', 'randomSamples')
+   return parent.clearState(self)
 end
 
 function SpatialFractionalMaxPooling:__tostring__()

--- a/SpatialFullConvolution.lua
+++ b/SpatialFullConvolution.lua
@@ -111,3 +111,9 @@ function SpatialFullConvolution:__tostring__()
   end
   return s .. ')'
 end
+
+function SpatialFullConvolution:clearState()
+   nn.utils.clear(self, 'finput', 'fgradInput', '_input', '_gradOutput')
+   return parent.clearState(self)
+end
+

--- a/SpatialMaxPooling.lua
+++ b/SpatialMaxPooling.lua
@@ -59,13 +59,9 @@ function SpatialMaxPooling:updateGradInput(input, gradOutput)
    return self.gradInput
 end
 
+-- for backward compat
 function SpatialMaxPooling:empty()
-   self.gradInput:resize()
-   self.gradInput:storage():resize(0)
-   self.output:resize()
-   self.output:storage():resize(0)
-   self.indices:resize()
-   self.indices:storage():resize(0)
+   self:clearState()
 end
 
 function SpatialMaxPooling:__tostring__()
@@ -77,4 +73,11 @@ function SpatialMaxPooling:__tostring__()
    s = s .. ')'
 
    return s
+end
+
+function SpatialMaxPooling:clearState()
+   if self.indices then
+      self.indices:set()
+   end
+   return parent.clearState(self)
 end

--- a/SpatialMaxUnpooling.lua
+++ b/SpatialMaxUnpooling.lua
@@ -33,10 +33,7 @@ function SpatialMaxUnpooling:updateGradInput(input, gradOutput)
 end
 
 function SpatialMaxUnpooling:empty()
-   self.gradInput:resize()
-   self.gradInput:storage():resize(0)
-   self.output:resize()
-   self.output:storage():resize(0)
+   self:clearState()
 end
 
 function SpatialMaxUnpooling:__tostring__()

--- a/SpatialSubtractiveNormalization.lua
+++ b/SpatialSubtractiveNormalization.lua
@@ -106,3 +106,10 @@ function SpatialSubtractiveNormalization:updateGradInput(input, gradOutput)
    -- done
    return self.gradInput
 end
+
+function SpatialSubtractiveNormalization:clearState()
+   if self.ones then self.ones:set() end
+   if self._coef then self._coef:set() end
+   self.meanestimator:clearState()
+   return parent.clearState(self)
+end

--- a/TemporalMaxPooling.lua
+++ b/TemporalMaxPooling.lua
@@ -22,10 +22,10 @@ function TemporalMaxPooling:updateGradInput(input, gradOutput)
 end
 
 function TemporalMaxPooling:empty()
-   self.gradInput:resize()
-   self.gradInput:storage():resize(0)
-   self.output:resize()
-   self.output:storage():resize(0)
-   self.indices:resize()
-   self.indices:storage():resize(0)
+   self:clearState()
+end
+
+function TemporalMaxPooling:clearState()
+   if self.indices then self.indices:set() end
+   return parent.clearState(self)
 end

--- a/VolumetricAveragePooling.lua
+++ b/VolumetricAveragePooling.lua
@@ -38,8 +38,5 @@ function VolumetricAveragePooling:updateGradInput(input, gradOutput)
 end
 
 function VolumetricAveragePooling:empty()
-   self.gradInput:resize()
-   self.gradInput:storage():resize(0)
-   self.output:resize()
-   self.output:storage():resize(0)
+   return parent.clearState(self)
 end

--- a/VolumetricConvolution.lua
+++ b/VolumetricConvolution.lua
@@ -25,7 +25,7 @@ function VolumetricConvolution:__init(nInputPlane, nOutputPlane, kT, kW, kH, dT,
    self.gradBias = torch.Tensor(nOutputPlane)
    -- temporary buffers for unfolding (CUDA)
    self.finput = torch.Tensor()
-   self.fgradInput = torch.Tensor()   
+   self.fgradInput = torch.Tensor()
    self:reset()
 end
 
@@ -174,4 +174,9 @@ function VolumetricConvolution:type(type, tensorCache)
    self.finput:set()
    self.fgradInput:set()
    return parent.type(self, type, tensorCache)
+end
+
+function VolumetricConvolution:clearState()
+   nn.utils.clear(self, 'finput', 'fgradInput', '_input', '_gradOutput')
+   return parent.clearState(self)
 end

--- a/VolumetricMaxPooling.lua
+++ b/VolumetricMaxPooling.lua
@@ -61,12 +61,12 @@ function VolumetricMaxPooling:updateGradInput(input, gradOutput)
 end
 
 function VolumetricMaxPooling:empty()
-   self.gradInput:resize()
-   self.gradInput:storage():resize(0)
-   self.output:resize()
-   self.output:storage():resize(0)
-   self.indices:resize()
-   self.indices:storage():resize(0)
+   self:clearState()
+end
+
+function VolumetricMaxPooling:clearState()
+   if self.indices then self.indices:set() end
+   return parent.clearState(self)
 end
 
 function VolumetricMaxPooling:read(file, version)

--- a/VolumetricMaxUnpooling.lua
+++ b/VolumetricMaxUnpooling.lua
@@ -56,10 +56,7 @@ function VolumetricMaxUnpooling:updateGradInput(input, gradOutput)
 end
 
 function VolumetricMaxUnpooling:empty()
-   self.gradInput:resize()
-   self.gradInput:storage():resize(0)
-   self.output:resize()
-   self.output:storage():resize(0)
+   self:clearState()
 end
 
 function VolumetricMaxUnpooling:__tostring__()

--- a/doc/module.md
+++ b/doc/module.md
@@ -117,8 +117,8 @@ situations.
 Keep in mind that, this function uses a simple trick to achieve its
 goal and it might not be valid for a custom module.
 
-Also note that compared to accGradParameters(), the gradients are not retained 
-for future use. 
+Also note that compared to accGradParameters(), the gradients are not retained
+for future use.
 
 ```lua
 function Module:accUpdateGradParameters(input, gradOutput, lr)
@@ -154,12 +154,12 @@ Example:
 ```lua
 
 -- make an mlp
-mlp1=nn.Sequential(); 
+mlp1=nn.Sequential();
 mlp1:add(nn.Linear(100,10));
 
 -- make a second mlp
-mlp2=nn.Sequential(); 
-mlp2:add(nn.Linear(100,10)); 
+mlp2=nn.Sequential();
+mlp2:add(nn.Linear(100,10));
 
 -- the second mlp shares the bias of the first
 mlp2:share(mlp1,'bias');
@@ -187,7 +187,7 @@ some shared parameters.
 Example:
 ```lua
 -- make an mlp
-mlp1=nn.Sequential(); 
+mlp1=nn.Sequential();
 mlp1:add(nn.Linear(100,10));
 
 -- make a copy that shares the weights and biases
@@ -208,7 +208,7 @@ This function converts all the parameters of a module to the given
 `type`. The `type` can be one of the types defined for
 [torch.Tensor](https://github.com/torch/torch7/blob/master/doc/tensor.md).
 
-If tensors (or their storages) are shared between multiple modules in a 
+If tensors (or their storages) are shared between multiple modules in a
 network, this sharing will be preserved after type is called.
 
 To preserve sharing between multiple modules and/or tensors, use
@@ -216,12 +216,12 @@ To preserve sharing between multiple modules and/or tensors, use
 
 ```lua
 -- make an mlp
-mlp1=nn.Sequential(); 
+mlp1=nn.Sequential();
 mlp1:add(nn.Linear(100,10));
 
 -- make a second mlp
-mlp2=nn.Sequential(); 
-mlp2:add(nn.Linear(100,10)); 
+mlp2=nn.Sequential();
+mlp2:add(nn.Linear(100,10));
 
 -- the second mlp shares the bias of the first
 mlp2:share(mlp1,'bias');
@@ -254,7 +254,7 @@ a `Module`. The object pointer is _never_ supposed to change. However, its
 contents (including its size if it is a Tensor) are supposed to change.
 
 In general state variables are
-[Tensors](https://github.com/torch/torch7/blob/master/doc/tensor.md). 
+[Tensors](https://github.com/torch/torch7/blob/master/doc/tensor.md).
 However, some special sub-classes
 like [table layers](table.md#nn.TableLayers) contain something else. Please,
 refer to each module specification for further information.
@@ -269,7 +269,7 @@ This contains the output of the module, computed with the last call of
 #### gradInput ####
 
 This contains the gradients with respect to the inputs of the module, computed with the last call of
-[updateGradInput(input, gradOutput)](#nn.Module.updateGradInput). 
+[updateGradInput(input, gradOutput)](#nn.Module.updateGradInput).
 
 ### Parameters and gradients w.r.t parameters ###
 
@@ -353,9 +353,9 @@ end
 <a name="nn.Module.listModules"></a>
 ### listModules() ###
 
-List all Modules instances in a network. Returns a flattened list of modules, 
-including container modules (which will be listed first), self, and any other 
-component modules. 
+List all Modules instances in a network. Returns a flattened list of modules,
+including container modules (which will be listed first), self, and any other
+component modules.
 
 For example :
 ```lua
@@ -392,3 +392,9 @@ nn.Linear(10 -> 20)
 nn.Tanh
 nn.ReLU
 ```
+
+### clearState() ###
+
+Clears intermediate module states as `output`, `gradInput` and others.
+Useful when serializing networks and running low on memory. Internally calls `set()`
+on tensors so it does not break buffer sharing.

--- a/utils.lua
+++ b/utils.lua
@@ -162,4 +162,27 @@ function nn.utils.contiguousView(output, input, ...)
   return output
 end
 
+-- go over specified fields and clear them. accepts
+-- nn.utils.clearState(self, {'_buffer', '_buffer2'}) and
+-- nn.utils.clearState(self, '_buffer', '_buffer2')
+function nn.utils.clear(self, ...)
+   local arg = {...}
+   if #arg > 0 and type(arg[1]) == 'table' then
+      arg = arg[1]
+   end
+   local function clear(f)
+      if self[f] then
+         if torch.isTensor(self[f]) then
+            self[f]:set()
+         elseif type(self[f]) == 'table' then
+            self[f] = {}
+         else
+            self[f] = nil
+         end
+      end
+   end
+   for i,v in ipairs(arg) do clear(v) end
+   return self
+end
+
 table.unpack = table.unpack or unpack


### PR DESCRIPTION
This introduces sanitization of nn modules so that
```lua
torch.save('model.t7', model:clearState())
```
will save a model without any internal buffers.
`nn.Module` has it's default clearState that clears `output` and `gradInput`.
Any module that uses buffers should have it's own clearState, I went over nn modules and fixed the ones I knew, it is possible that I missed something.

Test added into `Jacobian.testIO` that calls clearState before serializing the module. There might be a better solution because it does not test the old behaviour.

I will add `clearState` to `cudnn`, `inn` and nn.DataParallelTable with `cunn` tests later.

Comments? the original name was `sanitize`, we should discuss if the new name is better.

Was implemented when I was at facebook, it's been in use for a couple of months, pretty stable.