### PR TITLE
Add "Deconvolution" note to SpatialFullConvolution docs

### DIFF
--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -364,6 +364,8 @@ module = nn.SpatialFullConvolution(nInputPlane, nOutputPlane, kW, kH, [dW], [dH]
 Applies a 2D full convolution over an input image composed of several input planes. The `input` tensor in
 `forward(input)` is expected to be a 3D or 4D tensor.
 
+Other frameworks call this operation "In-network Upsampling", "Fractionally-strided convolution", "Backwards Convolution," "Deconvolution", or "Upconvolution."
+
 The parameters are the following:
   * `nInputPlane`: The number of expected input planes in the image given into `forward()`.
   * `nOutputPlane`: The number of output planes the convolution layer will produce.


### PR DESCRIPTION
This commit simply adds a greppable note to the docs for `SpatialFullConvolution` to let people find it.

I agree that the terminology used by other frameworks is incorrect (particularly the use of the word "deconvolution"), but this layer is impossible to understand without it. After reading so many papers that refer to "deconvolution" or "upconvolution" layers, I strongly feel that a note like this in the docs is necessary. When I first read the docs for `SpatialFullConvolution`, I thought that it was just convolution with a full connection table since it comes right after the connection-table convolution functions. I wouldn't have ever guessed that this was really deconvolution with a different name.

Other discussions:
https://github.com/torch/nn/pull/405
https://github.com/facebook/eyescream/issues/7