### PR TITLE
Add adjustment term to SpatialFullConvolution to control output size

### DIFF
--- a/SpatialFullConvolution.lua
+++ b/SpatialFullConvolution.lua
@@ -1,7 +1,7 @@
 local SpatialFullConvolution, parent = torch.class('nn.SpatialFullConvolution','nn.Module')
 
 function SpatialFullConvolution:__init(nInputPlane, nOutputPlane,
-                                       kW, kH, dW, dH, padW, padH)
+                                       kW, kH, dW, dH, padW, padH, adjW, adjH)
    parent.__init(self)
 
    dW = dW or 1
@@ -15,6 +15,13 @@ function SpatialFullConvolution:__init(nInputPlane, nOutputPlane,
    self.dH = dH
    self.padW = padW or 0
    self.padH = padH or 0
+   self.adjW = adjW or 0
+   self.adjH = adjH or 0
+
+   if self.adjW > self.dW - 1 or self.adjH > self.dH - 1 then
+      error('adjW and adjH must be smaller than self.dW - 1' ..
+            ' and self.dH - 1 respectively')
+   end
 
    self.weight = torch.Tensor(nInputPlane, nOutputPlane, kH, kW)
    self.gradWeight = torch.Tensor(nInputPlane, nOutputPlane, kH, kW)
@@ -56,12 +63,21 @@ local function makeContiguous(self, input, gradOutput)
   return input, gradOutput
 end
 
+function SpatialFullConvolution:backCompatibility()
+  self.adjW = self.adjW or 0
+  self.adjH = self.adjH or 0
+end
+
 function SpatialFullConvolution:updateOutput(input)
+  self:backCompatibility()
+
   input = makeContiguous(self, input)
   return input.nn.SpatialFullConvolution_updateOutput(self, input)
 end
 
 function SpatialFullConvolution:updateGradInput(input, gradOutput)
+  self:backCompatibility()
+
   if self.gradInput then
     input, gradOutput = makeContiguous(self, input, gradOutput)
     return input.nn.SpatialFullConvolution_updateGradInput(self, input, gradOutput)
@@ -69,6 +85,8 @@ function SpatialFullConvolution:updateGradInput(input, gradOutput)
 end
 
 function SpatialFullConvolution:accGradParameters(input, gradOutput, scale)
+  self:backCompatibility()
+
   input, gradOutput = makeContiguous(self, input, gradOutput)
   return input.nn.SpatialFullConvolution_accGradParameters(self, input, gradOutput, scale)
 end
@@ -87,6 +105,9 @@ function SpatialFullConvolution:__tostring__()
   end
   if (self.padW or self.padH) and (self.padW ~= 0 or self.padH ~= 0) then
     s = s .. ', ' .. self.padW .. ',' .. self.padH
+  end
+  if (self.adjW or self.adjH) and (self.adjW ~= 0 or self.adjH ~= 0) then
+    s = s .. ', ' .. self.adjW .. ',' .. self.adjH
   end
   return s .. ')'
 end

--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -359,7 +359,7 @@ number of outgoing connections to each input node if possible.
 ### SpatialFullConvolution ###
 
 ```lua
-module = nn.SpatialFullConvolution(nInputPlane, nOutputPlane, kW, kH, [dW], [dH], [padW], [padH])
+module = nn.SpatialFullConvolution(nInputPlane, nOutputPlane, kW, kH, [dW], [dH], [padW], [padH], [adjW], [adjH])
 ```
 
 Applies a 2D full convolution over an input image composed of several input planes. The `input` tensor in
@@ -376,12 +376,14 @@ The parameters are the following:
   * `dH`: The step of the convolution in the height dimension. Default is `1`.
   * `padW`: The additional zeros added per width to the input planes. Default is `0`, a good number is `(kW-1)/2`.
   * `padH`: The additional zeros added per height to the input planes. Default is `0`, a good number is `(kH-1)/2`.
+  * `adjW`: Extra width to add to the output image. Default is `0`. Cannot be greater than dW-1.
+  * `adjH`: Extra height to add to the output image. Default is `0`. Cannot be greater than dH-1.
 
 If the input image is a 3D tensor `nInputPlane x height x width`, the output image size
 will be `nOutputPlane x oheight x owidth` where
 ```lua
-owidth  = (width  - 1) * dW - 2*padW + kW
-oheight = (height - 1) * dH - 2*padH + kH
+owidth  = (width  - 1) * dW - 2*padW + kW + adjW
+oheight = (height - 1) * dH - 2*padH + kH + adjH
 ```
 
 Further information about the full convolution can be found in the following paper: [Fully Convolutional Networks for Semantic Segmentation](http://www.cs.berkeley.edu/~jonlong/long_shelhamer_fcn.pdf).
@@ -517,14 +519,14 @@ y_i_end   = ceil(((i+1)/oheight) * iheight)
 module = nn.SpatialMaxUnpooling(poolingModule)
 ```
 
-Applies 2D "max-unpooling" operation using the indices previously computed 
+Applies 2D "max-unpooling" operation using the indices previously computed
 by the SpatialMaxPooling module `poolingModule`.
 
-When `B = poolingModule:forward(A)` is called, the indices of the maximal 
-values (corresponding to their position within each map) are stored: 
-`B[{n,k,i,j}] = A[{n,k,indices[{n,k,i}],indices[{n,k,j}]}]`. 
-If `C` is a tensor of same size as `B`, `module:updateOutput(C)` outputs a 
-tensor `D` of same size as `A` such that: 
+When `B = poolingModule:forward(A)` is called, the indices of the maximal
+values (corresponding to their position within each map) are stored:
+`B[{n,k,i,j}] = A[{n,k,indices[{n,k,i}],indices[{n,k,j}]}]`.
+If `C` is a tensor of same size as `B`, `module:updateOutput(C)` outputs a
+tensor `D` of same size as `A` such that:
 `D[{n,k,indices[{n,k,i}],indices[{n,k,j}]}] = C[{n,k,i,j}]`.
 
 Module inspired by:

--- a/generic/SpatialFullConvolution.c
+++ b/generic/SpatialFullConvolution.c
@@ -69,6 +69,8 @@ static int nn_(SpatialFullConvolution_updateOutput)(lua_State *L) {
   int nOutputPlane = luaT_getfieldcheckint(L, 1, "nOutputPlane");
   int padW = luaT_getfieldcheckint(L, 1, "padW");
   int padH = luaT_getfieldcheckint(L, 1, "padH");
+  int adjW = luaT_getfieldcheckint(L, 1, "adjW");
+  int adjH = luaT_getfieldcheckint(L, 1, "adjH");
 
   THTensor *weight  = (THTensor*)luaT_getfieldcheckudata(L, 1, "weight", torch_Tensor);
   THTensor *bias    = (THTensor*)luaT_getfieldcheckudata(L, 1, "bias", torch_Tensor);
@@ -90,8 +92,8 @@ static int nn_(SpatialFullConvolution_updateOutput)(lua_State *L) {
 
   long inputWidth   = input->size[3];
   long inputHeight  = input->size[2];
-  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW;
-  long outputHeight = (inputHeight - 1) * dH - 2*padH + kH;
+  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW + adjW;
+  long outputHeight = (inputHeight - 1) * dH - 2*padH + kH + adjH;
 
   // Batch size + input planes
   long batchSize = input->size[0];
@@ -194,6 +196,8 @@ static int nn_(SpatialFullConvolution_updateGradInput)(lua_State *L) {
   int nOutputPlane = luaT_getfieldcheckint(L, 1, "nOutputPlane");
   int padW = luaT_getfieldcheckint(L, 1, "padW");
   int padH = luaT_getfieldcheckint(L, 1, "padH");
+  int adjW = luaT_getfieldcheckint(L, 1, "adjW");
+  int adjH = luaT_getfieldcheckint(L, 1, "adjH");
 
   THTensor *weight = (THTensor *)luaT_getfieldcheckudata(L, 1, "weight", torch_Tensor);
   THTensor *gradColumns = (THTensor*)luaT_getfieldcheckudata(L, 1, "finput", torch_Tensor);
@@ -211,8 +215,8 @@ static int nn_(SpatialFullConvolution_updateGradInput)(lua_State *L) {
 
   long inputWidth   = input->size[3];
   long inputHeight  = input->size[2];
-  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW;
-  long outputHeight = (inputHeight - 1) * dH - 2*padH + kH;
+  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW + adjW;
+  long outputHeight = (inputHeight - 1) * dH - 2*padH + kH + adjH;
 
   // Batch size + input planes
   long batchSize = input->size[0];
@@ -291,6 +295,8 @@ static int nn_(SpatialFullConvolution_accGradParameters)(lua_State *L) {
   int nOutputPlane = luaT_getfieldcheckint(L, 1, "nOutputPlane");
   int padW = luaT_getfieldcheckint(L, 1, "padW");
   int padH = luaT_getfieldcheckint(L, 1, "padH");
+  int adjW = luaT_getfieldcheckint(L, 1, "adjW");
+  int adjH = luaT_getfieldcheckint(L, 1, "adjH");
   float scale = luaL_optnumber(L, 4, 1);
 
   THTensor *gradWeight = (THTensor *)luaT_getfieldcheckudata(L, 1, "gradWeight", torch_Tensor);
@@ -310,8 +316,8 @@ static int nn_(SpatialFullConvolution_accGradParameters)(lua_State *L) {
 
   long inputWidth   = input->size[3];
   long inputHeight  = input->size[2];
-  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW;
-  long outputHeight = (inputHeight - 1) * dH - 2*padH + kH;
+  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW + adjW;
+  long outputHeight = (inputHeight - 1) * dH - 2*padH + kH + adjH;
 
   // Batch size + input planes
   long batchSize = input->size[0];


### PR DESCRIPTION
There are multiple valid output sizes when using stride that are greater than 1, since there are multiple input sizes that result in the same output size for the regular SpatialConvolution. This term allows the user to control the size of the output by expanding it, up to a value of (stride-1) in each dimension.