### PR TITLE
self.train defaults explicitly to 'true'

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -3,6 +3,7 @@ local Module = torch.class('nn.Module')
 function Module:__init()
    self.gradInput = torch.Tensor()
    self.output = torch.Tensor()
+   self.train = true
 end
 
 function Module:parameters()


### PR DESCRIPTION
self.train defaults explicitly to 'true'

(means we can avoid having to deal with the possibility that it might be `nil`, eg see https://github.com/Element-Research/rnn/blob/master/Recursor.lua#L22 )
