### PR TITLE
Update LogSoftMax to work in spatial domain

### DIFF
--- a/SpatialLogSoftMax.lua
+++ b/SpatialLogSoftMax.lua
@@ -1,0 +1,19 @@
+local SpatialLogSoftMax = torch.class('nn.SpatialLogSoftMax', 'nn.Module')
+
+function SpatialLogSoftMax:updateOutput(input)
+   input.THNN.LogSoftMax_updateOutput(
+      input:cdata(),
+      self.output:cdata()
+   )
+   return self.output
+end
+
+function SpatialLogSoftMax:updateGradInput(input, gradOutput)
+   input.THNN.LogSoftMax_updateGradInput(
+      input:cdata(),
+      gradOutput:cdata(),
+      self.gradInput:cdata(),
+      self.output:cdata()
+   )
+   return self.gradInput
+end

--- a/doc/transfer.md
+++ b/doc/transfer.md
@@ -359,6 +359,20 @@ m=nn.SpatialSoftMax()
 oo = m:forward(ii)
 ```
 
+<a name="nn.SpatialLogSoftMax"></a>
+## SpatialLogSoftMax ##
+
+Applies [LogSoftMax](#nn.LogSoftMax) over features to each spatial location (height x width of planes).
+The module accepts 1D (vector), 2D (batch of vectors), 3D (vectors in space) or 4D (batch of vectors in space) tensor as input.
+Functionally it is equivalent to [LogSoftMax](#nn.LogSoftMax) when 1D or 2D input is used.
+The output dimension is always the same as input dimension.
+
+```lua
+ii=torch.randn(4,8,16,16)  -- batchSize x features x height x width
+m=nn.SpatialLogSoftMax()
+oo = m:forward(ii)
+```
+
 <a name="nn.AddConstant"></a>
 ## AddConstant ##
 

--- a/init.lua
+++ b/init.lua
@@ -77,6 +77,7 @@ include('ReLU.lua')
 include('PReLU.lua')
 include('LeakyReLU.lua')
 include('SpatialSoftMax.lua')
+include('SpatialLogSoftMax.lua')
 include('RReLU.lua')
 include('ELU.lua')
 

--- a/lib/THNN/generic/LogSoftMax.c
+++ b/lib/THNN/generic/LogSoftMax.c
@@ -5,23 +5,35 @@
 void THNN_(LogSoftMax_updateOutput)(THNNState *state, THTensor *input, THTensor *output)
 {
   real *input_data, *output_data;
-  long nframe = 0, dim = 0;
+  long nframe = 0, dim = 0, stride = 0;
   long t, d;
 
   if (input->nDimension == 1)
   {
     nframe = 1;
     dim = input->size[0];
+    stride = 1;
   }
   else if (input->nDimension == 2)
   {
     nframe = input->size[0];
     dim = input->size[1];
+    stride = 1;
+  }
+  else if (input->nDimension == 3)
+  {
+    nframe = 1;
+    dim = input->size[0];
+    stride = input->size[1]*input->size[2];
+  }
+  else if (input->nDimension == 4)
+  {
+    nframe = input->size[0];
+    dim = input->size[1];
+    stride = input->size[2]*input->size[3];
   }
   else
-  {
-    THArgCheck(0, 2, "vector or matrix expected");
-  }
+    THArgCheck(0, 2, "1D, 2D, 3D or 4D tensor expected");
 
   input = THTensor_(newContiguous)(input);
   THTensor_(resizeAs)(output, input);
@@ -32,22 +44,22 @@ void THNN_(LogSoftMax_updateOutput)(THNNState *state, THTensor *input, THTensor 
   accreal logsum;
   real maxInput;
   #pragma omp parallel for private(t, d, maxInput, logsum, input_data, output_data)
-  for (t = 0; t < nframe; t++)
+  for (t = 0; t < stride*nframe; t++)
   {
     logsum = 0;
     maxInput = -THInf;
-    input_data = input_data0 + dim*t;
-    output_data = output_data0 + dim*t;
+    input_data = input_data0 + (t/stride)*dim*stride + t % stride;
+    output_data = output_data0 + (t/stride)*dim*stride + t % stride;
 
     for (d = 0; d < dim; d++)
-      maxInput = THMax(maxInput, input_data[d]);
+      maxInput = THMax(maxInput, input_data[d*stride]);
 
     for (d = 0; d < dim; d++)
-      logsum += THExpMinusApprox(maxInput-input_data[d]);
+      logsum += THExpMinusApprox(maxInput-input_data[d*stride]);
     logsum = maxInput + log(logsum);
 
     for (d = 0; d < dim; d++)
-      output_data[d] = input_data[d] - logsum;
+      output_data[d*stride] = input_data[d*stride] - logsum;
   }
 
   THTensor_(free)(input);
@@ -56,23 +68,38 @@ void THNN_(LogSoftMax_updateOutput)(THNNState *state, THTensor *input, THTensor 
 void THNN_(LogSoftMax_updateGradInput)(THNNState *state, THTensor *input, THTensor *gradOutput, THTensor *gradInput, THTensor *output)
 {
   real *gradInput_data, *gradOutput_data, *output_data;
-  long nframe = 0, dim = 0;
+  long nframe = 0, dim = 0, stride = 0;
   long t, d;
 
   if (output->nDimension == 1)
   {
     nframe = 1;
     dim = output->size[0];
+    stride = 1;
   }
   else if (output->nDimension == 2)
   {
     nframe = output->size[0];
     dim = output->size[1];
+    stride = 1;
+  }
+  else if (output->nDimension == 3)
+  {
+    nframe = 1;
+    dim = output->size[0];
+    stride = output->size[1]*output->size[2];
+  }
+  else if (output->nDimension == 4)
+  {
+    nframe = output->size[0];
+    dim = output->size[1];
+    stride = output->size[2]*output->size[3];
   }
   else
-  {
-    THError("vector or matrix expected");
-  }
+    THError("1D, 2D, 3D or 4D tensor expected");
+
+  output = THTensor_(newContiguous)(output);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
 
   THTensor_(resizeAs)(gradInput, output);
   real *gradInput_data0 = THTensor_(data)(gradInput);
@@ -80,19 +107,22 @@ void THNN_(LogSoftMax_updateGradInput)(THNNState *state, THTensor *input, THTens
   real *gradOutput_data0 = THTensor_(data)(gradOutput);
   accreal sum;
   #pragma omp parallel for private(t, sum, d, gradInput_data, output_data, gradOutput_data)
-  for (t = 0; t < nframe; t++)
+  for (t = 0; t < stride*nframe; t++)
   {
     sum = 0;
-    gradInput_data = gradInput_data0 + dim*t;
-    output_data = output_data0 + dim*t;
-    gradOutput_data = gradOutput_data0 + dim*t;
+    gradInput_data = gradInput_data0 + (t/stride)*dim*stride + t % stride;
+    output_data = output_data0 + (t/stride)*dim*stride + t % stride;
+    gradOutput_data = gradOutput_data0 + (t/stride)*dim*stride + t % stride;
 
     for (d = 0; d < dim; d++)
-      sum += gradOutput_data[d];
+      sum += gradOutput_data[d*stride];
 
     for (d = 0; d < dim; d++)
-      gradInput_data[d] = gradOutput_data[d] - exp(output_data[d])*sum;
+      gradInput_data[d*stride] = gradOutput_data[d*stride] - exp(output_data[d*stride])*sum;
   }
+
+  THTensor_(free)(gradOutput);
+  THTensor_(free)(output);
 }
 
 #endif

--- a/test.lua
+++ b/test.lua
@@ -7,7 +7,7 @@ local jac
 local sjac
 
 local precision = 1e-5
-local expprecision = 1e-4
+local expprecision = 1.1e-4
 
 local nntest = {}
 
@@ -1269,6 +1269,22 @@ function nntest.LogSoftmax()
 
    local err = jac.testJacobian(module,input)
    mytester:assertlt(err, 1e-3, 'error on state ')
+
+   local ferr,berr = jac.testIO(module,input)
+   mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err ')
+   mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
+end
+
+function nntest.SpatialLogSoftMax()
+   local ini = math.random(3,5)
+   local inj = math.random(3,5)
+   local ink = math.random(3,5)
+   local inl = math.random(3,5)
+   local input = torch.Tensor(inl, ink, inj, ini):zero()
+   local module = nn.SpatialLogSoftMax()
+
+   local err = jac.testJacobian(module,input)
+   mytester:assertlt(err,expprecision, 'error on state ')
 
    local ferr,berr = jac.testIO(module,input)
    mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err ')


### PR DESCRIPTION
Extends `LogSoftMax` to work with 3D and 4D tensors.

I did the same thing as in https://github.com/torch/nn/pull/370 , so currently both `LogSoftMax` and `SpatialLogSoftMax` shares the same C code and are by all means equivalent. I wonder if we should only have a `LogSoftMax` which handles 1D/2D/3D/4D cases (which is already the case btw).
I was going to add some asserts to limit the use cases of each function, but then I saw that `cudnn` `SpatialLogSoftMax` [also supports 1D/2D tensors](https://github.com/soumith/cudnn.torch/blob/master/SpatialSoftMax.lua#L18-L28), so I left it like that.

I also slightly increased the tolerance `expprecision` in the tests, as they were sometimes failing.

Addresses the remarks presented https://github.com/torch/nn/issues/548.

I'll prepare a CUDA version later.