### PR TITLE
THNN: add missing OpenMP include

### DIFF
--- a/lib/THNN/THNN.h
+++ b/lib/THNN/THNN.h
@@ -3,6 +3,9 @@
 
 #include <stdbool.h>
 #include <TH.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
 #define THNN_(NAME) TH_CONCAT_3(THNN_, Real, NAME)
 


### PR DESCRIPTION
To fix "implicit declaration of function" warnings.

Note: prior to THNN there was no warning since `SparseLinear.c` already includes `omp.h` (see #286). Now, as soon as sparse linear is moved to THNN there is no need to do [this include](https://github.com/Moodstocks/nn/blob/465c7f1/generic/SparseLinear.c#L5-L7) anymore (cc @andreaskoepf).