### PR TITLE
Unpooling with stored Indices for Volumetric Max Pool

### DIFF
--- a/VolumetricMaxUnpooling.lua
+++ b/VolumetricMaxUnpooling.lua
@@ -1,0 +1,49 @@
+local VolumetricMaxUnpooling, parent = torch.class('nn.VolumetricMaxUnpooling', 'nn.Module')
+
+function VolumetricMaxUnpooling:__init(poolingModule)
+  parent.__init(self)
+  assert(torch.type(poolingModule)=='nn.VolumetricMaxPooling', 'Argument must be a nn.VolumetricMaxPooling module')
+  assert(poolingModule.kT==poolingModule.dT and poolingModule.kH==poolingModule.dH and poolingModule.kW==poolingModule.dW, "The size of pooling module's kernel must be equal to its stride")
+  self.pooling = poolingModule
+
+  poolingModule.updateOutput = function(pool, input)
+    local dims = input:dim()
+    pool.itime = input:size(dims-2)
+    pool.iheight = input:size(dims-1)
+    pool.iwidth = input:size(dims)
+    return nn.VolumetricMaxPooling.updateOutput(pool, input)
+  end
+end
+
+function VolumetricMaxUnpooling:setParams()
+  self.indices = self.pooling.indices
+  self.otime = self.pooling.itime
+  self.oheight = self.pooling.iheight
+  self.owidth = self.pooling.iwidth
+  self.dT = self.pooling.dT
+  self.dH = self.pooling.dH
+  self.dW = self.pooling.dW
+end
+
+function VolumetricMaxUnpooling:updateOutput(input)
+  self:setParams()
+  input.nn.VolumetricMaxUnpooling_updateOutput(self, input)
+  return self.output
+end
+
+function VolumetricMaxUnpooling:updateGradInput(input, gradOutput)
+  self:setParams()
+  input.nn.VolumetricMaxUnpooling_updateGradInput(self, input, gradOutput)
+  return self.gradInput
+end
+
+function VolumetricMaxUnpooling:empty()
+   self.gradInput:resize()
+   self.gradInput:storage():resize(0)
+   self.output:resize()
+   self.output:storage():resize(0)
+end
+
+function VolumetricMaxUnpooling:__tostring__()
+   return 'nn.VolumetricMaxUnpooling associated to '..tostring(self.pooling)
+end

--- a/generic/VolumetricMaxUnpooling.c
+++ b/generic/VolumetricMaxUnpooling.c
@@ -1,0 +1,274 @@
+#ifndef TH_GENERIC_FILE
+#define TH_GENERIC_FILE "generic/VolumetricMaxUnpooling.c"
+#else
+
+static void nn_(VolumetricMaxUnpooling_updateOutput_frame)(real *input_p, real *output_p,
+                                                      real *ind_p,
+                                                      long nslices,
+                                                      long itime, long iwidth, long iheight,
+                                                      long otime, long owidth, long oheight,
+                                                      int dT, int dW, int dH)
+{
+  long k;
+#pragma omp parallel for private(k)
+  for (k = 0; k < nslices; k++)
+  {    
+    long ti, i, j, maxz, maxy, maxx;
+    for(ti = 0; ti < itime; ti++)
+    {
+      for(i = 0; i < iheight; i++)
+      {
+        for(j = 0; j < iwidth; j++)
+        {
+          real *output_p_k = output_p + k*otime*owidth*oheight + ti*owidth*oheight*dT + i*owidth*dH + j*dW;
+          real *input_p_k = input_p + k*itime*iwidth*iheight + ti*iwidth*iheight + i*iwidth + j;
+          real *ind_p_k = ind_p + k*itime*iwidth*iheight + ti*iwidth*iheight + i*iwidth + j;
+          
+          maxz = ((unsigned char*)(ind_p_k))[0]; /* retrieve position of max */
+          maxy = ((unsigned char*)(ind_p_k))[1];
+          maxx = ((unsigned char*)(ind_p_k))[2];
+
+          if(maxz<0 || maxy<0 || maxx<0 || maxz>=otime || maxy>=oheight || maxx>=owidth)
+          {
+              THError("invalid max index maxz= %d, maxy= %d, maxx= %d, otime= %d, owidth= %d, oheight= %d", maxz, maxy, maxx, otime, owidth, oheight);
+          }
+          output_p_k[oheight*owidth*maxz + owidth*maxy + maxx] = *input_p_k; /* update output */
+        }
+      }
+    }
+  }
+}
+
+static int nn_(VolumetricMaxUnpooling_updateOutput)(lua_State *L)
+{
+  THTensor *input = luaT_checkudata(L, 2, torch_Tensor);
+  THTensor *indices = luaT_getfieldcheckudata(L, 1, "indices", torch_Tensor);
+  THTensor *output = luaT_getfieldcheckudata(L, 1, "output", torch_Tensor);
+  int otime = luaT_getfieldcheckint(L, 1, "otime");
+  int owidth = luaT_getfieldcheckint(L, 1, "owidth");
+  int oheight = luaT_getfieldcheckint(L, 1, "oheight");
+  int dT = luaT_getfieldcheckint(L, 1, "dT");
+  int dH = luaT_getfieldcheckint(L, 1, "dH");
+  int dW = luaT_getfieldcheckint(L, 1, "dW");
+  int dimw = 3;
+  int dimh = 2;
+  int dimt = 1;
+  int nbatch = 1;
+  int nslices;
+  int itime;
+  int iheight;
+  int iwidth;
+  real *input_data;
+  real *output_data;
+  real *indices_data;
+
+  luaL_argcheck(L, input->nDimension == 4 || input->nDimension == 5 , 2, "4D or 5D (batch mode) tensor expected");
+  if (!THTensor_(isSameSizeAs)(input, indices)){
+    THError("Invalid input size w.r.t current indices size");
+  }  
+
+  if (input->nDimension == 5) 
+  {
+    nbatch = input->size[0];
+    dimt++;
+    dimw++;
+    dimh++;
+  }
+
+  /* sizes */
+  nslices = input->size[dimt-1];
+  itime = input->size[dimt];
+  iheight = input->size[dimh];
+  iwidth = input->size[dimw];
+
+  /* get contiguous input */
+  input = THTensor_(newContiguous)(input);
+  indices = THTensor_(newContiguous)(indices);
+
+  /* resize output */
+  if (input->nDimension == 4)
+  {
+    THTensor_(resize4d)(output, nslices, otime, oheight, owidth);
+    THTensor_(zero)(output);
+
+    input_data = THTensor_(data)(input);
+    output_data = THTensor_(data)(output);
+    indices_data = THTensor_(data)(indices);
+
+    nn_(VolumetricMaxUnpooling_updateOutput_frame)(input_data, output_data,
+                                              indices_data,
+                                              nslices,
+                                              itime, iwidth, iheight,
+                                              otime, owidth, oheight,
+                                              dT, dW, dH);
+  }
+  else
+  {
+    long p;
+
+    THTensor_(resize5d)(output, nbatch, nslices, otime, oheight, owidth);
+    THTensor_(zero)(output);
+
+    input_data = THTensor_(data)(input);
+    output_data = THTensor_(data)(output);
+    indices_data = THTensor_(data)(indices);
+
+#pragma omp parallel for private(p)
+    for (p = 0; p < nbatch; p++)
+    {
+      nn_(VolumetricMaxUnpooling_updateOutput_frame)(input_data+p*nslices*itime*iwidth*iheight, output_data+p*nslices*otime*owidth*oheight,
+                                                indices_data+p*nslices*itime*iwidth*iheight,
+                                                nslices,
+                                                itime, iwidth, iheight,
+                                                otime, owidth, oheight,
+                                                dT, dW, dH);
+    }
+  }
+
+  /* cleanup */
+  THTensor_(free)(input);
+  THTensor_(free)(indices);
+  return 1;
+}
+
+static void nn_(VolumetricMaxUnpooling_updateGradInput_frame)(real *gradInput_p, real *gradOutput_p,
+                                                         real *ind_p,
+                                                         long nslices,
+                                                         long itime, long iwidth, long iheight,
+                                                         long otime, long owidth, long oheight,
+                                                         int dT, int dW, int dH)
+{
+  long k;
+#pragma omp parallel for private(k)
+  for (k = 0; k < nslices; k++)
+  {
+    long ti, i, j, maxz, maxy, maxx;
+    for(ti = 0; ti < itime; ti++)
+    {
+      for(i = 0; i < iheight; i++)
+      {
+        for(j = 0; j < iwidth; j++)
+        {        
+          real *gradInput_p_k = gradInput_p + k*itime*iwidth*iheight + ti*iwidth*iheight + i*iwidth + j;
+          real *gradOutput_p_k = gradOutput_p + k*otime*owidth*oheight + ti*owidth*oheight*dT + i*owidth*dH + j*dW;
+          real *ind_p_k = ind_p + k*itime*iwidth*iheight + ti*iwidth*iheight + i*iwidth + j;
+          
+          maxz = ((unsigned char*)(ind_p_k))[0]; /* retrieve position of max */
+          maxy = ((unsigned char*)(ind_p_k))[1];
+          maxx = ((unsigned char*)(ind_p_k))[2];
+
+          if(maxz<0 || maxy<0 || maxx<0 || maxz>=otime || maxy>=oheight || maxx>=owidth)
+          {
+              THError("invalid max index maxz= %d, maxy= %d, maxx= %d, otime= %d, owidth= %d, oheight= %d", maxz, maxy, maxx, otime, owidth, oheight);
+          }  
+          *gradInput_p_k = gradOutput_p_k[oheight*owidth*maxz + owidth*maxy + maxx]; /* update gradient */
+        }
+      }
+    }
+  }
+}
+
+static int nn_(VolumetricMaxUnpooling_updateGradInput)(lua_State *L)
+{
+  THTensor *input = luaT_checkudata(L, 2, torch_Tensor);
+  THTensor *gradOutput = luaT_checkudata(L, 3, torch_Tensor);
+  THTensor *indices = luaT_getfieldcheckudata(L, 1, "indices", torch_Tensor);
+  THTensor *gradInput = luaT_getfieldcheckudata(L, 1, "gradInput", torch_Tensor);
+  int otime = luaT_getfieldcheckint(L, 1, "otime");
+  int owidth = luaT_getfieldcheckint(L, 1, "owidth");
+  int oheight = luaT_getfieldcheckint(L, 1, "oheight");
+  int dT = luaT_getfieldcheckint(L, 1, "dT");
+  int dH = luaT_getfieldcheckint(L, 1, "dH");
+  int dW = luaT_getfieldcheckint(L, 1, "dW");
+  int dimw = 3;
+  int dimh = 2;
+  int dimt = 1;
+  int nbatch = 1;
+  int nslices;
+  int itime;
+  int iheight;
+  int iwidth;
+  real *gradInput_data;
+  real *gradOutput_data;
+  real *indices_data;
+
+  if (!THTensor_(isSameSizeAs)(input, indices)){
+    THError("Invalid input size w.r.t current indices size");
+  } 
+
+  /* get contiguous gradOutput */
+  gradOutput = THTensor_(newContiguous)(gradOutput);
+  indices = THTensor_(newContiguous)(indices);
+
+  /* resize */
+  THTensor_(resizeAs)(gradInput, input);
+  THTensor_(zero)(gradInput);
+
+  if (input->nDimension == 5) {
+    nbatch = input->size[0];
+    dimt++;
+    dimw++;
+    dimh++;
+  }
+
+  /* sizes */
+  nslices = input->size[dimt-1];
+  itime = input->size[dimt];
+  iheight = input->size[dimh];
+  iwidth = input->size[dimw];
+
+  if(otime!=gradOutput->size[dimt] || owidth!=gradOutput->size[dimw] || oheight!=gradOutput->size[dimh]){
+    THError("Inconsistent gradOutput size. otime= %d, oheight= %d, owidth= %d, gradOutput: %dx%d", otime, oheight, owidth,gradOutput->size[dimh],gradOutput->size[dimw]);
+  }
+
+  /* get raw pointers */
+  gradInput_data = THTensor_(data)(gradInput);
+  gradOutput_data = THTensor_(data)(gradOutput);
+  indices_data = THTensor_(data)(indices);
+
+  /* backprop */
+  if (input->nDimension == 4)
+  {
+    nn_(VolumetricMaxUnpooling_updateGradInput_frame)(gradInput_data, gradOutput_data,
+                                                 indices_data,
+                                                 nslices,
+                                                 itime, iwidth, iheight,
+                                                 otime, owidth, oheight,
+                                                 dT, dW, dH);
+  }
+  else
+  {
+    long p;
+#pragma omp parallel for private(p)
+    for (p = 0; p < nbatch; p++)
+    {
+      nn_(VolumetricMaxUnpooling_updateGradInput_frame)(gradInput_data+p*nslices*itime*iwidth*iheight, gradOutput_data+p*nslices*otime*owidth*oheight,
+                                                   indices_data+p*nslices*itime*iwidth*iheight,
+                                                   nslices,
+                                                   itime, iwidth, iheight,
+                                                   otime, owidth, oheight,
+                                                   dT, dW, dH);
+    }
+  }
+
+  /* cleanup */
+  THTensor_(free)(gradOutput);
+  THTensor_(free)(indices);
+
+  return 1;
+}
+
+static const struct luaL_Reg nn_(VolumetricMaxUnpooling__) [] = {
+  {"VolumetricMaxUnpooling_updateOutput", nn_(VolumetricMaxUnpooling_updateOutput)},
+  {"VolumetricMaxUnpooling_updateGradInput", nn_(VolumetricMaxUnpooling_updateGradInput)},
+  {NULL, NULL}
+};
+
+static void nn_(VolumetricMaxUnpooling_init)(lua_State *L)
+{
+  luaT_pushmetatable(L, torch_Tensor);
+  luaT_registeratname(L, nn_(VolumetricMaxUnpooling__), "nn");
+  lua_pop(L,1);
+}
+
+#endif

--- a/init.c
+++ b/init.c
@@ -110,6 +110,9 @@
 #include "generic/VolumetricMaxPooling.c"
 #include "THGenerateFloatTypes.h"
 
+#include "generic/VolumetricMaxUnpooling.c"
+#include "THGenerateFloatTypes.h"
+
 #include "generic/VolumetricAveragePooling.c"
 #include "THGenerateFloatTypes.h"
 
@@ -164,6 +167,7 @@ int luaopen_libnn(lua_State *L)
   nn_FloatVolumetricConvolutionMM_init(L);
   nn_FloatVolumetricFullConvolution_init(L);
   nn_FloatVolumetricMaxPooling_init(L);
+  nn_FloatVolumetricMaxUnpooling_init(L);
   nn_FloatVolumetricAveragePooling_init(L);
   nn_FloatMultiMarginCriterion_init(L);
   nn_FloatMultiLabelMarginCriterion_init(L);
@@ -204,6 +208,7 @@ int luaopen_libnn(lua_State *L)
   nn_DoubleVolumetricConvolutionMM_init(L);
   nn_DoubleVolumetricFullConvolution_init(L);
   nn_DoubleVolumetricMaxPooling_init(L);
+  nn_DoubleVolumetricMaxUnpooling_init(L);
   nn_DoubleVolumetricAveragePooling_init(L);
   nn_DoubleMultiMarginCriterion_init(L);
   nn_DoubleMultiLabelMarginCriterion_init(L);

--- a/init.lua
+++ b/init.lua
@@ -108,6 +108,7 @@ include('SpatialBatchNormalization.lua')
 include('VolumetricConvolution.lua')
 include('VolumetricFullConvolution.lua')
 include('VolumetricMaxPooling.lua')
+include('VolumetricMaxUnpooling.lua')
 include('VolumetricAveragePooling.lua')
 
 include('ParallelTable.lua')

--- a/test.lua
+++ b/test.lua
@@ -3331,6 +3331,50 @@ function nntest.VolumetricMaxPooling()
    mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err (Batch) ')
 end
 
+function nntest.VolumetricMaxUnpooling()
+   local from = math.random(2,3)
+   local kt = math.random(3,4)
+   local ki = math.random(3,4)
+   local kj = math.random(3,4)
+   local st, si, sj = kt, ki, kj
+   local outt = math.random(3,4)
+   local outi = math.random(3,4)
+   local outj = math.random(3,4)
+   local int = (outt-1)*st+kt
+   local ini = (outi-1)*si+ki
+   local inj = (outj-1)*sj+kj
+   
+   local poolingModule = nn.VolumetricMaxPooling(kt,ki,kj,st,si,sj)
+   local module = nn.VolumetricMaxUnpooling(poolingModule)
+
+   local original = torch.rand(from,int,inj,ini)
+   local input = poolingModule:forward(original)
+   local output = module:forward(input)
+   mytester:assert(output:isSameSizeAs(original),'VolumetricMaxUnpooling output size err')
+   
+   local err = jac.testJacobian(module, input)
+   mytester:assertlt(err, precision, 'error ')
+   
+   local ferr, berr = jac.testIO(module, input)
+   mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err ')
+   mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
+   
+   -- batch
+   local nbatch = math.random(2,3)
+   original = torch.rand(nbatch,from,int,inj,ini)
+   input = poolingModule:forward(original)
+   output = module:forward(input)
+
+   mytester:assert(output:isSameSizeAs(original),'VolumetricMaxUnpooling batch output size err')
+
+   local err = jac.testJacobian(module, input)
+   mytester:assertlt(err, precision, 'error on Batch')
+
+   local ferr, berr = jac.testIO(module, input)
+   mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err (Batch) ')
+   mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err (Batch) ')
+end
+
 function nntest.Module_getParameters_1()
    local n = nn.Sequential()
    n:add( nn.Linear(10,10) )


### PR DESCRIPTION
Added `Unpooling` option to **VolumetricMaxPooling**. Works with the current `VolumetricMaxPooling` module.
This is the `CPU` version. I will update the `CUDA` version soon.

```lua
    require 'nn'

    max_module = nn.VoulmetricMaxPooling(kT, kW, kH)
    
    model = nn.Sequential()
    model:add(max_module)
    model:add(nn.VolumetricMaxUnpooling(max_module))
```
It requires `kT==dT`, `kW==dW`, `kH==dH`.

Updated `init.lua`, `init.c` and `test.lua`.