### PR TITLE
Fix variable length input bug in concattable

### DIFF
--- a/ConcatTable.lua
+++ b/ConcatTable.lua
@@ -51,7 +51,11 @@ function ConcatTable:updateGradInput(input, gradOutput)
          else
             retable(self.gradInput, currentGradInput,
                function(t, k, v)
-                  t[k]:add(v)
+                  if t[k] then
+                     t[k]:add(v)
+                  else
+                     t[k] = v:clone()
+                  end
                end
             )
          end


### PR DESCRIPTION
ConcatTable would throw an error when the inputs were tables of tables of variable length and the length of the second input's elements was smaller than the first's.

e.g.
```lua
in1 = {{torch.randn(5), torch.randn(5)}, torch.randn(5)}
in2 = {{torch.randn(5)}, torch.randn(5)}
c = nn.ConcatTable():add(nn.SelectTable(1)):add(nn.SelectTable(2))
c:forward(in1)
c:backward(in1, in1)
c:forward(in2)
c:backward(in2, in2)
```

returns an "attempt to index a nil value" error on old line 54.