### PR TITLE
adding a Bilinear layer

### DIFF
--- a/Bilinear.lua
+++ b/Bilinear.lua
@@ -1,0 +1,140 @@
+local Bilinear, parent = torch.class('nn.Bilinear', 'nn.Module')
+
+local function isint(x) return type(x) == 'number' and x == math.floor(x) end
+function Bilinear:__assertInput(input)
+   assert(input and type(input) == 'table' and #input == 2,
+      'input should be a table containing two data Tensors')
+   assert(input[1]:nDimension() == 2 and input[2]:nDimension() == 2,
+      'input Tensors should be two-dimensional')
+   assert(input[1]:size(1) == input[2]:size(1),
+      'input Tensors should have the same number of rows (instances)')
+   assert(input[1]:size(2) == self.weight:size(2),
+      'dimensionality of first input is erroneous')
+   assert(input[2]:size(2) == self.weight:size(3),
+      'dimensionality of second input is erroneous')
+end
+function Bilinear:__assertInputGradOutput(input, gradOutput)
+   assert(input[1]:size(1) == gradOutput:size(1),
+      'number of rows in gradOutput does not match input')
+   assert(gradOutput:size(2) == self.weight:size(1),
+      'number of columns in gradOutput does not output size of layer')
+end
+
+function Bilinear:__init(inputSize1, inputSize2, outputSize, bias)
+
+   -- assertions:
+   assert(self and inputSize1 and inputSize2 and outputSize,
+      'should specify inputSize1 and inputSize2 and outputSize')
+   assert(isint(inputSize1) and isint(inputSize2) and isint(outputSize),
+      'inputSize1 and inputSize2 and outputSize should be integer numbers')
+   assert(inputSize1 > 0 and inputSize2 > 0 and outputSize > 0,
+      'inputSize1 and inputSize2 and outputSize should be positive numbers')
+
+   -- set up model:
+   parent.__init(self)
+   local bias = ((bias == nil) and true) or bias
+   self.weight     = torch.Tensor(outputSize, inputSize1, inputSize2)
+   self.gradWeight = torch.Tensor(outputSize, inputSize1, inputSize2)
+   if bias then
+      self.bias     = torch.Tensor(outputSize)
+      self.gradBias = torch.Tensor(outputSize)
+   end
+   self.gradInput = {torch.Tensor(), torch.Tensor()}
+   self:reset()
+end
+
+function Bilinear:reset(stdv)
+   assert(self)
+   if stdv then
+      assert(stdv and type(stdv) == 'number' and stdv > 0,
+         'standard deviation should be a positive number')
+      stdv = stdv * math.sqrt(3)
+   else
+      stdv = 1 / math.sqrt(self.weight:size(2))
+   end
+   self.weight:uniform(-stdv, stdv)
+   if self.bias then self.bias:uniform(-stdv, stdv) end
+   return self
+end
+
+function Bilinear:updateOutput(input)
+   assert(self)
+   self:__assertInput(input)
+
+   -- set up buffer:
+   self.buff = self.buff or input[1].new()
+   self.buff:resizeAs(input[2])
+
+   -- compute output scores:
+   self.output:resize(input[1]:size(1), self.weight:size(1))
+   for k = 1,self.weight:size(1) do
+      torch.mm(self.buff, input[1], self.weight[k])
+      self.buff:cmul(input[2])
+      torch.sum(self.output:narrow(2, k, 1), self.buff, 2)
+   end
+   self.output:add(
+      self.bias:reshape(1, self.bias:nElement()):expandAs(self.output)
+   )
+   return self.output
+end
+
+function Bilinear:updateGradInput(input, gradOutput)
+   assert(self)
+   if self.gradInput then
+      self:__assertInputGradOutput(input, gradOutput)
+
+      -- compute d output / d input:
+      self.gradInput[1]:resizeAs(input[1]):fill(0)
+      self.gradInput[2]:resizeAs(input[2]):fill(0)
+      if torch.type(self.weight, 'torch.CudaTensor') then
+         for k = 1,self.weight:size(1) do
+            torch.addmm(self.gradInput[1], input[2], self.weight[k]:t())
+            torch.addmm(self.gradInput[2], input[1], self.weight[k])
+         end  -- TODO: Remove this once cutorch gets addbmm() function
+      else
+         self.gradInput[1]:addbmm(
+            input[2]:view(1, input[2]:size(1), input[2]:size(2)):expand(
+               self.weight:size(1), input[2]:size(1), input[2]:size(2)
+            ),
+            self.weight:transpose(2, 3)
+         )
+         self.gradInput[2]:addbmm(
+            input[1]:view(1, input[1]:size(1), input[1]:size(2)):expand(
+               self.weight:size(1), input[1]:size(1), input[1]:size(2)
+            ), self.weight
+         )
+      end
+      return self.gradInput
+   end
+end
+
+function Bilinear:accGradParameters(input, gradOutput, scale)
+   local scale = scale or 1
+   self:__assertInputGradOutput(input, gradOutput)
+   assert(scale and type(scale) == 'number' and scale >= 0)
+
+   -- make sure we have buffer:
+   self.buff = self.buff or input[1].new()
+   self.buff:resizeAs(input[2])
+
+   -- accumulate parameter gradients:
+   for k = 1,self.weight:size(1) do
+      torch.cmul(
+         self.buff, input[1], gradOutput:narrow(2, k, 1):expandAs(input[1])
+      )
+      self.gradWeight[k]:addmm(self.buff:t(), input[2])
+   end
+   if self.bias then self.gradBias:add(scale, gradOutput:sum(1)) end
+end
+
+-- we do not need to accumulate parameters when sharing:
+Bilinear.sharedAccUpdateGradParameters = Bilinear.accUpdateGradParameters
+
+function Bilinear:__tostring__()
+  return torch.type(self) ..
+      string.format(
+         '(%dx%d -> %d) %s',
+         self.weight:size(2), self.weight:size(3), self.weight:size(1),
+         (self.bias == nil and ' without bias' or '')
+      )
+end

--- a/doc/simple.md
+++ b/doc/simple.md
@@ -5,6 +5,7 @@ Simple Modules are used for various tasks like adapting Tensor methods and provi
   * Parameterized Modules :
     * [Linear](#nn.Linear) : a linear transformation ;
     * [SparseLinear](#nn.SparseLinear) : a linear transformation with sparse inputs ;
+    * [Bilinear](#nn.Bilinear) : a bilinear transformation with sparse inputs ;
     * [Add](#nn.Add) : adds a bias term to the incoming data ;
     * [Mul](#nn.Mul) : multiply a single scalar factor to the incoming data ;
     * [CMul](#nn.CMul) : a component-wise multiplication to the incoming data ;
@@ -118,6 +119,28 @@ x = torch.Tensor({ {1, 0.1}, {2, 0.3}, {10, 0.3}, {31, 0.2} })
 ```
 
 The first column contains indices, the second column contains values in a a vector where all other elements are zeros. The indices should not exceed the stated dimensions of the input to the layer (10000 in the example).
+
+<a name="nn.Bilinear"></a>
+## Bilinear ##
+
+```lua
+module = nn.Bilinear(inputDimension1, inputDimension2, outputDimension, [bias = true])
+```
+
+Applies a bilinear transformation to the incoming data, i.e. `\forall k: y_k = x_1 A_k x_2 + b`. The `input` tensor given in `forward(input)` is a table containing both inputs `x_1` and `x_2`, which are tensors of size `N x inputDimension1`
+and `N x inputDimension1`, respectively. The layer can be trained without biases by setting `bias = false`.
+
+You can create a layer in the following way:
+
+```lua
+ module = nn.Bilinear(10, 5, 3)  -- 10 and 5 inputs, 3 outputs
+```
+
+Input data for this layer would look as follows:
+```lua
+ input = {torch.randn(128, 10), torch.randn(128, 5)}  -- 128 input examples
+ module:forward(input)
+```
 
 <a name="nn.Dropout"></a>
 ## Dropout ##

--- a/init.lua
+++ b/init.lua
@@ -15,6 +15,7 @@ include('Sequential.lua')
 include('DepthConcat.lua')
 
 include('Linear.lua')
+include('Bilinear.lua')
 include('SparseLinear.lua')
 include('Reshape.lua')
 include('View.lua')


### PR DESCRIPTION
Applies a bilinear transformation to the incoming data, i.e. `\forall k: y_k = x_1 A_k x_2 + b`. The `input` tensor given in `forward(input)` is a table containing both inputs `x_1` and `x_2`, which are tensors of size `N x inputDimension1` and `N x inputDimension1`, respectively. The layer can be trained without biases by setting `bias = false`.

Implemented by @lvdmaaten 