### PR TITLE
Volumteric Max pooling now supports padding

### DIFF
--- a/VolumetricMaxPooling.lua
+++ b/VolumetricMaxPooling.lua
@@ -2,7 +2,7 @@ local VolumetricMaxPooling, parent = torch.class('nn.VolumetricMaxPooling', 'nn.
 
 VolumetricMaxPooling.__version = 2
 
-function VolumetricMaxPooling:__init(kT, kW, kH, dT, dW, dH)
+function VolumetricMaxPooling:__init(kT, kW, kH, dT, dW, dH, padT, padW, padH)
    parent.__init(self)
 
    dT = dT or kT
@@ -15,6 +15,11 @@ function VolumetricMaxPooling:__init(kT, kW, kH, dT, dW, dH)
    self.dT = dT
    self.dW = dW
    self.dH = dH
+
+   self.padT = padT or 0
+   self.padW = padW or 0
+   self.padH = padH or 0
+
 
    self.ceil_mode = false
    self.indices = torch.Tensor()

--- a/generic/VolumetricMaxPooling.c
+++ b/generic/VolumetricMaxPooling.c
@@ -6,7 +6,7 @@ static void nn_(VolumetricMaxPooling_updateOutput_frame)(
   real *input_p, real *output_p, real *indz_p,
   long nslices, long itime, long iwidth, long iheight,
   long otime, long owidth, long oheight,
-  int kT, int kW, int kH, int dT, int dW, int dH) {
+  int kT, int kW, int kH, int dT, int dW, int dH, int padT, int padW, int padH) {
   long k;
 #pragma omp parallel for private(k)
   for (k = 0; k < nslices; k++)
@@ -17,8 +17,21 @@ static void nn_(VolumetricMaxPooling_updateOutput_frame)(
       for(i = 0; i < oheight; i++) {
         for(j = 0; j < owidth; j++) {
           /* local pointers */
+          
+          long start_t = ti * dT - padT;
+          long start_h = i * dH - padH;
+          long start_w = j * dW - padW;
+          
+          long kernel_t = fminf(kT, kT + start_t);
+          long kernel_h = fminf(kH, kH + start_h);
+          long kernel_w = fminf(kW, kW + start_w);
+          
+          start_t = fmaxf(start_t, 0);
+          start_h = fmaxf(start_h, 0);
+          start_w = fmaxf(start_w, 0);
+          
           real *ip = input_p + k * itime * iwidth * iheight
-            + ti * iwidth * iheight * dT + i * iwidth * dH + j * dW;
+            + start_t * iwidth * iheight + start_h * iwidth + start_w;
           real *op = output_p + k * otime * owidth * oheight
             + ti * owidth * oheight + i * owidth + j;
           real *indzp = indz_p + k * otime * owidth * oheight
@@ -29,17 +42,18 @@ static void nn_(VolumetricMaxPooling_updateOutput_frame)(
           int x,y,z;
           int mx, my, mz;
 
-          for(z = 0; z < kT; z++) {
-            for(y = 0; y < kH; y++) {
-              for(x = 0; x < kW; x++) {
-                if ( (ti * dT + z < itime) && (i * dH + y < iheight) &&
-                   (j * dW + x < iwidth) ) {
+          for(z = 0; z < kernel_t; z++) {
+            for(y = 0; y < kernel_h; y++) {
+              for(x = 0; x < kernel_w; x++) {
+                if ((start_t + z < itime) && (start_h + y < iheight) && (start_w + x < iwidth))
+                {
                   real val = *(ip + z * iwidth * iheight + y * iwidth + x);
                   if (val > maxval) {
                     maxval = val;
-                    mz = z;
-                    my = y;
-                    mx = x;
+                    // Store indices w.r.t the kernel dimension
+                    mz = z + (kT - kernel_t); 
+                    my = y + (kH - kernel_h);
+                    mx = x + (kW - kernel_w);
                   }
                 }
               }
@@ -68,6 +82,9 @@ static int nn_(VolumetricMaxPooling_updateOutput)(lua_State *L)
   int dT = luaT_getfieldcheckint(L, 1, "dT");
   int dW = luaT_getfieldcheckint(L, 1, "dW");
   int dH = luaT_getfieldcheckint(L, 1, "dH");
+  int padT = luaT_getfieldcheckint(L, 1, "padT");
+  int padW = luaT_getfieldcheckint(L, 1, "padW");
+  int padH = luaT_getfieldcheckint(L, 1, "padH");
   int ceil_mode = luaT_getfieldcheckboolean(L,1,"ceil_mode");
   THTensor *indices = luaT_getfieldcheckudata(L, 1, "indices", torch_Tensor);
   THTensor *output = luaT_getfieldcheckudata(L, 1, "output", torch_Tensor);
@@ -101,19 +118,32 @@ static int nn_(VolumetricMaxPooling_updateOutput)(lua_State *L)
                 input->size[dimh] >= kH && input->size[dimt] >= kT, 2,
                 "input image smaller than kernel size");
 
+  luaL_argcheck(L, kT/2 >= padT && kW/2 >= padW && kH/2 >= padH, 2, "pad should be smaller than half of kernel size");
+
   /* sizes */
   nslices = input->size[dimN];
   itime   = input->size[dimt];
   iheight = input->size[dimh];
   iwidth  = input->size[dimw];
   if (ceil_mode) {
-    otime   = (int)(ceil((float)(itime   - kT) / dT) + 1);
-    oheight = (int)(ceil((float)(iheight - kH) / dH) + 1);
-    owidth  = (int)(ceil((float)(iwidth  - kW) / dW) + 1);
+    otime   = (int)(ceil((float)(itime   - kT + 2 * padT) / dT) + 1);
+    oheight = (int)(ceil((float)(iheight - kH + 2 * padH) / dH) + 1);
+    owidth  = (int)(ceil((float)(iwidth  - kW + 2 * padW) / dW) + 1);
   } else {
-    otime   = (int)(floor((float)(itime   - kT) / dT) + 1);
-    oheight = (int)(floor((float)(iheight - kH) / dH) + 1);
-    owidth  = (int)(floor((float)(iwidth  - kW) / dW) + 1);
+    otime   = (int)(floor((float)(itime   - kT + 2 * padT) / dT) + 1);
+    oheight = (int)(floor((float)(iheight - kH + 2 * padH) / dH) + 1);
+    owidth  = (int)(floor((float)(iwidth  - kW + 2 * padW) / dW) + 1);
+  }
+
+  if (padT || padW || padH)
+  {
+    // ensure that the last pooling starts inside the image
+    if ((otime - 1)*dT >= itime + padT)
+      --otime;
+    if ((oheight - 1)*dH >= iheight + padH)
+      --oheight;
+    if ((owidth  - 1)*dW >= iwidth  + padW)
+      --owidth;
   }
 
   /* get contiguous input */
@@ -134,7 +164,7 @@ static int nn_(VolumetricMaxPooling_updateOutput)(lua_State *L)
                                                  nslices,
                                                  itime, iwidth, iheight,
                                                  otime, owidth, oheight,
-                                                 kT, kW, kH, dT, dW, dH);
+                                                 kT, kW, kH, dT, dW, dH, padT, padW, padH);
   } else { /* batch mode */
     long p;
     long nBatch = input->size[0];
@@ -160,7 +190,7 @@ static int nn_(VolumetricMaxPooling_updateOutput)(lua_State *L)
         nslices,
         itime, iwidth, iheight,
         otime, owidth, oheight,
-        kT, kW, kH, dT, dW, dH);
+        kT, kW, kH, dT, dW, dH, padT, padW, padH);
     }
   }
 
@@ -174,7 +204,8 @@ static void nn_(VolumetricMaxPooling_updateGradInput_frame)(
   long nslices,
   long itime, long iwidth, long iheight,
   long otime, long owidth, long oheight,
-  int dT, int dW, int dH) {
+  int dT, int dW, int dH,
+  int padT, int padW, int padH) {
   long k;
 #pragma omp parallel for private(k)
   for (k = 0; k < nslices; k++) {
@@ -189,9 +220,9 @@ static void nn_(VolumetricMaxPooling_updateGradInput_frame)(
         for(j = 0; j < owidth; j++) {
           /* retrieve position of max */
           real * indzp = &indz_p_k[ti * oheight * owidth + i * owidth + j];
-          long maxti = ((unsigned char*)(indzp))[0] + ti * dT;
-          long maxi  = ((unsigned char*)(indzp))[1] + i * dH;
-          long maxj  = ((unsigned char*)(indzp))[2] + j * dW;
+          long maxti = ((unsigned char*)(indzp))[0] + ti * dT - padT;
+          long maxi  = ((unsigned char*)(indzp))[1] + i * dH - padH;
+          long maxj  = ((unsigned char*)(indzp))[2] + j * dW - padW;
 
           /* update gradient */
           gradInput_p_k[maxti * iheight * iwidth + maxi * iwidth + maxj] +=
@@ -209,6 +240,9 @@ static int nn_(VolumetricMaxPooling_updateGradInput)(lua_State *L)
   int dT = luaT_getfieldcheckint(L, 1, "dT");
   int dW = luaT_getfieldcheckint(L, 1, "dW");
   int dH = luaT_getfieldcheckint(L, 1, "dH");
+  int padT = luaT_getfieldcheckint(L, 1, "padT");
+  int padW = luaT_getfieldcheckint(L, 1, "padW");
+  int padH = luaT_getfieldcheckint(L, 1, "padH");
   THTensor *indices = luaT_getfieldcheckudata(L, 1, "indices", torch_Tensor);
   THTensor *gradInput = luaT_getfieldcheckudata(L, 1, "gradInput", torch_Tensor);
   int nslices;
@@ -264,7 +298,7 @@ static int nn_(VolumetricMaxPooling_updateGradInput)(lua_State *L)
       nslices,
       itime, iwidth, iheight,
       otime, owidth, oheight,
-      dT, dW, dH);
+      dT, dW, dH, padT, padW, padH);
   }
   else { /* batch mode */
     long p;
@@ -282,7 +316,7 @@ static int nn_(VolumetricMaxPooling_updateGradInput)(lua_State *L)
         nslices,
         itime, iwidth, iheight,
         otime, owidth, oheight,
-        dT, dW, dH);
+        dT, dW, dH, padT, padW, padH);
     }
   }
 

--- a/test.lua
+++ b/test.lua
@@ -3371,10 +3371,13 @@ function nntest.VolumetricMaxPooling()
    local outt = math.random(3,4)
    local outi = math.random(3,4)
    local outj = math.random(3,4)
-   local int = (outt-1)*st+kt
-   local ini = (outi-1)*si+ki
-   local inj = (outj-1)*sj+kj
-   local module = nn.VolumetricMaxPooling(kt, ki, kj, st, si, sj)
+   local padT = math.min(math.random(0,2),math.floor(kt/2))
+   local padW = math.min(math.random(0,2),math.floor(ki/2))
+   local padH =  math.min(math.random(0,2),math.floor(kj/2))
+   local int = (outt-1)*st+kt-2*padT
+   local ini = (outi-1)*si+ki-2*padW
+   local inj = (outj-1)*sj+kj-2*padH
+   local module = nn.VolumetricMaxPooling(kt, ki, kj, st, si, sj, padT, padW, padH)
    local input = torch.Tensor(from, int, inj, ini):zero()
 
    local err = jac.testJacobian(module, input)
@@ -3386,7 +3389,7 @@ function nntest.VolumetricMaxPooling()
 
    -- batch
    local nbatch = math.random(2,3)
-   module = nn.VolumetricMaxPooling(kt, ki, kj, st, si, sj)
+   module = nn.VolumetricMaxPooling(kt, ki, kj, st, si, sj, padT, padW, padH)
    input = torch.Tensor(nbatch, from, int, inj, ini):zero()
 
    local err = jac.testJacobian(module, input)


### PR DESCRIPTION
This allows to provide **padding** in `VolumetricMaxPooling`

modified:   VolumetricMaxPooling.lua
modified:   generic/VolumetricMaxPooling.c
modified:   test.lua

**NOTE:** `VolumetricMaxUnpooling` still doesn't support **padded pooling**, though it will work for *pooling module without padding*. I will submit a *patch* for it soon.