### PR TITLE
Updated VolumetricMaxUnpooling to support unpooling of padded pooling

### DIFF
--- a/VolumetricMaxUnpooling.lua
+++ b/VolumetricMaxUnpooling.lua
@@ -23,6 +23,9 @@ function VolumetricMaxUnpooling:setParams()
   self.dT = self.pooling.dT
   self.dH = self.pooling.dH
   self.dW = self.pooling.dW
+  self.padT = self.pooling.padT
+  self.padH = self.pooling.padH
+  self.padW = self.pooling.padW
 end
 
 function VolumetricMaxUnpooling:updateOutput(input)

--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -822,12 +822,12 @@ oheight = (height - 1) * dH - 2*padH + kH
 ### VolumetricMaxPooling ###
 
 ```lua
-module = nn.VolumetricMaxPooling(kT, kW, kH [, dT, dW, dH])
+module = nn.VolumetricMaxPooling(kT, kW, kH [, dT, dW, dH, padT, padW, padH])
 ```
 
 Applies 3D max-pooling operation in `kTxkWxkH` regions by step size
 `dTxdWxdH` steps. The number of output features is equal to the number of
-input planes / dT.
+input planes / dT. The input can optionally be padded with zeros. Padding should be smaller than half of kernel size.  That is, `padT < kT/2`, `padW < kW/2` and `padH < kH/2`.
 
 <a name="nn.VolumetricAveragePooling"></a>
 ### VolumetricAveragePooling ###

--- a/test.lua
+++ b/test.lua
@@ -3409,11 +3409,14 @@ function nntest.VolumetricMaxUnpooling()
    local outt = math.random(3,4)
    local outi = math.random(3,4)
    local outj = math.random(3,4)
-   local int = (outt-1)*st+kt
-   local ini = (outi-1)*si+ki
-   local inj = (outj-1)*sj+kj
+   local padT = math.min(math.random(0,2),math.floor(kt/2))
+   local padW = math.min(math.random(0,2),math.floor(ki/2))
+   local padH = math.min(math.random(0,2),math.floor(kj/2))
+   local int = (outt-1)*st+kt-2*padT
+   local ini = (outi-1)*si+ki-2*padW
+   local inj = (outj-1)*sj+kj-2*padH
    
-   local poolingModule = nn.VolumetricMaxPooling(kt,ki,kj,st,si,sj)
+   local poolingModule = nn.VolumetricMaxPooling(kt, ki, kj, st, si, sj, padT, padW, padH)
    local module = nn.VolumetricMaxUnpooling(poolingModule)
 
    local original = torch.rand(from,int,inj,ini)


### PR DESCRIPTION
Patch for `VolumetricMaxUnpooling` to support *padded pooling* introduced [here](https://github.com/torch/nn/pull/589).
Also, updated **README** to reflect `VolumetricMaxPooling` supports *padding*.

modified:   VolumetricMaxUnpooling.lua
modified:   doc/convolution.md
modified:   generic/VolumetricMaxUnpooling.c
modified:   test.lua