### PR TITLE
CMul: Added support for non-contiguous input and gradOuput

### DIFF
--- a/CMul.lua
+++ b/CMul.lua
@@ -77,8 +77,8 @@ function CMul:updateGradInput(input, gradOutput)
       self.gradInput:addcmul(1, self.weight, gradOutput)
    else
       local batchSize = input:size(1)
-      self._gradOutput:view(gradOutput, batchSize, -1)
-      self._gradInput:view(self.gradInput, batchSize, -1)
+      nn.utils.contiguousView(self._gradOutput, gradOutput, batchSize, -1)
+      nn.utils.contiguousView(self._gradInput, self.gradInput, batchSize, -1)
       self._weight:view(self.weight, 1, -1)
       self._expand:expandAs(self._weight, self._gradOutput)
       
@@ -104,8 +104,8 @@ function CMul:accGradParameters(input, gradOutput, scale)
       self.gradWeight:addcmul(scale, input, gradOutput)
    else
       local batchSize = input:size(1)
-      self._input:view(input, batchSize, -1)
-      self._gradOutput:view(gradOutput, batchSize, -1)
+      nn.utils.contiguousView(self._input, input, batchSize, -1)
+      nn.utils.contiguousView(self._gradOutput, gradOutput, batchSize, -1)
       self._gradWeight:view(self.gradWeight, 1, -1)
       
       self._repeat:cmul(self._input, self._gradOutput)

--- a/utils.lua
+++ b/utils.lua
@@ -150,4 +150,16 @@ function nn.utils.addSingletonDimension(t, dim)
   return view
 end
 
+function nn.utils.contiguousView(output, input, ...)
+  output = output or input.new()
+  if input:isContiguous() then
+    output:view(input, ...)
+  else
+    output:resizeAs(input)
+    output:copy(input)
+    output:view(...)
+  end
+  return output
+end
+
 table.unpack = table.unpack or unpack


### PR DESCRIPTION
Currently, if either the input or gradOuput is non-contiguous, this Module will not work. The change will enable the use of Module in this scenario by performing the necessary tensor copies. 