### PR TITLE
Fix loading of old SpatialBatchNormalization modules

### DIFF
--- a/SpatialBatchNormalization.lua
+++ b/SpatialBatchNormalization.lua
@@ -132,12 +132,11 @@ function BN:accGradParameters(input, gradOutput, scale)
 end
 
 function BN:read(file, version)
-   local var = file:readObject()
-   for k,v in pairs(var) do
-      if version < 2 and k == 'running_std' then
-         k = 'running_var'
-         v = v:cmul(v):pow(-1)
+   parent.read(self, file)
+   if version < 2 then
+      if self.running_std then
+         self.running_var = self.running_std:pow(-2):add(-self.eps)
+         self.running_std = nil
       end
-      self[k] = v
    end
 end


### PR DESCRIPTION
Big oops. I had messed up the backwards compatibility code for SpatialBatchNormalization and my test for this was flawed.

The old-style running_std is actually the E[1/sqrt(var + eps)]. I forgot to subtract out the 'eps' when converting to running_var.