### PR TITLE
Add gradient backprop for dropout in evaluation mode

### DIFF
--- a/Dropout.lua
+++ b/Dropout.lua
@@ -45,7 +45,14 @@ function Dropout:updateGradInput(input, gradOutput)
          self.gradInput:cmul(self.noise) -- simply mask the gradients with the noise vector
       end
    else
-      error('backprop only defined while training')
+      if self.inplace then
+         self.gradInput = gradOutput
+      else
+         self.gradInput:resizeAs(gradOutput):copy(gradOutput)
+      end
+      if not self.v2 and self.p > 0 then
+         self.gradInput:cdiv(1-self.p)
+      end
    end
    return self.gradInput
 end


### PR DESCRIPTION
Initially, the input gradient is not allowed if the dropout layer is not in training mode. However, there shouldn't be anything preventing back propagation. This is useful if we want deterministic behavior with learning model and want to get the derivative with respect to the low input layer. 