### PR TITLE
fixed dropout backprop in evaluation mode

### DIFF
--- a/Dropout.lua
+++ b/Dropout.lua
@@ -51,7 +51,7 @@ function Dropout:updateGradInput(input, gradOutput)
          self.gradInput:resizeAs(gradOutput):copy(gradOutput)
       end
       if not self.v2 and self.p > 0 then
-         self.gradInput:cdiv(1-self.p)
+         self.gradInput:mul(1-self.p)
       end
    end
    return self.gradInput


### PR DESCRIPTION
My previous code has a bug. I fixed it and tested with unit test. The computed gradient agrees with finite difference gradient. 