### PR TITLE
Fix VolumetricConvolution for cpu/gpu interoperability

### DIFF
--- a/VolumetricConvolution.lua
+++ b/VolumetricConvolution.lua
@@ -169,3 +169,9 @@ function VolumetricConvolution:accGradParameters(input, gradOutput, scale)
       unviewWeight(self)
    end
 end
+
+function VolumetricConvolution:type(type, tensorCache)
+   self.finput:set()
+   self.fgradInput:set()
+   return parent.type(self, type, tensorCache)
+end


### PR DESCRIPTION
This is a similar issue than the one pointed out in https://github.com/torch/nn/issues/211.

Indeed, the role of `fgradInput` in [the CPU version](https://github.com/torch/nn/blob/master/lib/THNN/generic/VolumetricConvolutionMM.c#L299) is different from [the GPU one](https://github.com/torch/cunn/blob/master/lib/THCUNN/VolumetricConvolution.cu#L208-L213) (which expects only 1s).