### PR TITLE
nn.Module.replace

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -381,3 +381,15 @@ end
 function Module:clearState()
    return nn.utils.clear(self, 'output', 'gradInput')
 end
+
+-- similar to apply, recursively goes over network and calls
+-- a callback function which returns a new module replacing the old one
+function nn.Module:replace(callback)
+   local out = callback(self)
+   if self.modules then
+      for i, module in ipairs(self.modules) do
+         self.modules[i] = module:replace(callback)
+      end
+   end
+   return out
+end

--- a/doc/module.md
+++ b/doc/module.md
@@ -398,3 +398,40 @@ nn.ReLU
 Clears intermediate module states as `output`, `gradInput` and others.
 Useful when serializing networks and running low on memory. Internally calls `set()`
 on tensors so it does not break buffer sharing.
+
+
+<a name="nn.Module.apply"></a>
+### apply(function)
+
+Calls provided function on itself and all child modules. This function takes
+module to operate on as a first argument:
+
+```lua
+model:apply(function(module)
+   module.train = true
+end)
+```
+
+In the example above `train` will be set to to `true` in all modules of `model`.
+This is how `training()` and `evaluate()` functions implemented.
+
+
+<a name="nn.Module.replace"></a>
+### replace(function)
+
+Similar to apply takes a function which applied to all modules of a model,
+but uses return value to replace the module. Can be used to replace all
+modules of one type to another or remove certain modules.
+
+For example, can be used to remove `nn.Dropout` layers by replacing them with
+`nn.Identity`:
+
+```lua
+model:replace(function(module)
+   if torch.typename(module) == 'nn.Dropout' then
+      return nn.Identity()
+   else
+      return module
+   end
+end)
+```

--- a/test.lua
+++ b/test.lua
@@ -5882,6 +5882,23 @@ function nntest.Module_apply()
   mytester:asserteq(s2.modules[1].bias:size(1), 20)
 end
 
+function nntest.Module_replace()
+   -- test replace in container
+   local s = nn.Sequential()
+   s:add(nn.Linear(10,10))
+   s:add(nn.Sigmoid())
+   s:replace(function(module)
+      return torch.type(module) == 'nn.Sigmoid' and nn.Tanh() or module
+   end)
+   -- test replace of a single module
+   local single = nn.Tanh()
+   local replaced = single:replace(function(module)
+      return torch.type(module) == 'nn.Tanh' and nn.Sigmoid() or module
+   end)
+   mytester:asserteq(torch.type(s:get(2)), 'nn.Tanh', 'replace in container')
+   mytester:asserteq(torch.type(replaced), 'nn.Sigmoid', 'replace in single module')
+end
+
 function nntest.Cosine()
    local inputSize = 4
    local outputSize = 5


### PR DESCRIPTION
I think this function should be included in nn.Module functionality. Similar to apply, it is very useful for quick surgeries. I used it for example in cudnn.convert https://github.com/soumith/cudnn.torch/pull/76
Here is a short example:
```lua
require'nn'

local model = nn.Sequential()
model:add(nn.SpatialConvolution(1,96,5,5))
model:add(nn.ReLU())
model:add(nn.SpatialMaxPooling(2,2,2,2))
model:add(nn.SpatialConvolution(96,50,5,5))
model:add(nn.ReLU())
model:add(nn.SpatialMaxPooling(2,2,2,2))
model:add(nn.View(-1):setNumInputDims(3))
model:add(nn.Dropout())
model:add(nn.Linear(800,500))
model:add(nn.ReLU())
model:add(nn.Dropout())
model:add(nn.Linear(500,10))
```

```
nn.Sequential {
  (1): nn.SpatialConvolution(1 -> 96, 5x5)
  (2): nn.ReLU
  (3): nn.SpatialMaxPooling(2,2,2,2)
  (4): nn.SpatialConvolution(96 -> 50, 5x5)
  (5): nn.ReLU
  (6): nn.SpatialMaxPooling(2,2,2,2)
  (7): nn.View(-1)
  (8): nn.Dropout(0.500000)
  (9): nn.Linear(800 -> 500)
  (10): nn.ReLU
  (11): nn.Dropout(0.500000)
  (12): nn.Linear(500 -> 10)
}
```

after
```lua
model:replace(function(x)
   return torch.type(x) == 'nn.ReLU' and nn.Sigmoid() or x
end)
```

becomes
```
nn.Sequential {
  (1): nn.SpatialConvolution(1 -> 96, 5x5)
  (2): nn.Sigmoid
  (3): nn.SpatialMaxPooling(2,2,2,2)
  (4): nn.SpatialConvolution(96 -> 50, 5x5)
  (5): nn.Sigmoid
  (6): nn.SpatialMaxPooling(2,2,2,2)
  (7): nn.View(-1)
  (8): nn.Dropout(0.500000)
  (9): nn.Linear(800 -> 500)
  (10): nn.Sigmoid
  (11): nn.Dropout(0.500000)
  (12): nn.Linear(500 -> 10)
}
```
I will add doc if we agree to merge it.