### PR TITLE
Fix problem with nn.SpatialFractionalMaxPooling:clearState()

### DIFF
--- a/SpatialFractionalMaxPooling.lua
+++ b/SpatialFractionalMaxPooling.lua
@@ -144,7 +144,8 @@ function SpatialFractionalMaxPooling:empty()
 end
 
 function SpatialFractionalMaxPooling:clearState()
-   nn.utils.clear(self, 'indices', 'randomSamples')
+   self.indices = nil
+   self.randomSamples = nil
    return parent.clearState(self)
 end
 


### PR DESCRIPTION
:initSampleBuffer_() was producing an error when called (from :updateOutput()) after calling :clearState(). The randomSamples field was an empty tensor in that case.

Now :clearState() sets indices and randomSamples to nil, so the module is in the same state as after construction.