### PR TITLE
Remove outdated table items in recursiveResizeAs

### DIFF
--- a/utils.lua
+++ b/utils.lua
@@ -80,6 +80,11 @@ function nn.utils.recursiveResizeAs(t1,t2)
       for key,_ in pairs(t2) do
          t1[key], t2[key] = nn.utils.recursiveResizeAs(t1[key], t2[key])
       end
+      for key,_ in pairs(t1) do
+         if not t2[key] then
+            t1[key] = nil
+         end
+      end
    elseif torch.isTensor(t2) then
       t1 = torch.isTensor(t1) and t1 or t2.new()
       t1:resizeAs(t2)


### PR DESCRIPTION
I'm currently doing some kind of RNN with variable length training.

The current version of recursiveResizeAs(t1, t2) does not erase the contents of the t1 that does not match t2, which leads to error in some cases.

Here is the code to reproduce the error:
```lua
require 'nn'
require 'rnn'

criterion = nn.ParallelCriterion():add(nn.SequencerCriterion(nn.MSECriterion()))

x = torch.randn(1, 10)
y = torch.randn(1, 10)

s1 = {x, x, x, x, x}
s2 = {y, y, y, y, y}
criterion:forward({s1},{s2})
print(criterion:backward({s1},{s2}))
--[[ Output:
{
  1 : 
    {
      1 : DoubleTensor - size: 1x10
      2 : DoubleTensor - size: 1x10
      3 : DoubleTensor - size: 1x10
      4 : DoubleTensor - size: 1x10
      5 : DoubleTensor - size: 1x10
    }
}
--]]

s1 = {x, x, x}
s2 = {y, y, y}
criterion:forward({s1}, {s2})
print(criterion:backward({s1},{s2}))
--[[
{ Output (wrong):
  1 : 
    {
      1 : DoubleTensor - size: 1x10
      2 : DoubleTensor - size: 1x10
      3 : DoubleTensor - size: 1x10
      4 : DoubleTensor - size: 1x10
      5 : DoubleTensor - size: 1x10
    }
}
--]]
```
