### PR TITLE
Lazy init when gradOutput is not contiguous

### DIFF
--- a/Reshape.lua
+++ b/Reshape.lua
@@ -51,6 +51,7 @@ end
 
 function Reshape:updateGradInput(input, gradOutput)
    if not gradOutput:isContiguous() then
+      self._gradOutput = self._gradOutput or input.new()
       self._gradOutput:resizeAs(gradOutput)
       self._gradOutput:copy(gradOutput)
       gradOutput = self._gradOutput


### PR DESCRIPTION
It's possible when the input is contiguous but the gradOutput is not (e.g. when doing nn.Parallel and Reshape is located at the end of each branch). So _gradOutput needs another lazy initialization to avoid exceptions.