### PR TITLE
Make nn.utils.recursiveType add empty Tensors to the tensorCache.

### DIFF
--- a/utils.lua
+++ b/utils.lua
@@ -64,8 +64,8 @@ function nn.utils.recursiveType(param, type, tensorCache)
                   param:size(),
                   param:stride()
                )
-               tensorCache[param] = newparam
             end
+            tensorCache[param] = newparam
          end
          assert(torch.type(newparam) == type)
          param = newparam


### PR DESCRIPTION
This means if we have a module which wraps another module, and does
something like:

function MyWrapper:__init(innerModule)
  self._innerModule = innerModule
  self.gradInput = self._innerModule.gradInput
end

.. Then calling :type before we have forwarded anything (and when we
still have zero-size Tensors) will now correctly preserve this aliasing.