### PR TITLE
Identity recursively uses :set instead of assignment

### DIFF
--- a/Identity.lua
+++ b/Identity.lua
@@ -27,7 +27,7 @@ local function identity(out, input)
       -- clean up behind if the current input is
       -- smaller than the previous one
       for k in pairs(out) do
-         if not input[k] then
+         if input[k] == nil then
             out[k] = nil
          end
       end

--- a/Identity.lua
+++ b/Identity.lua
@@ -1,30 +1,47 @@
 local Identity, _ = torch.class('nn.Identity', 'nn.Module')
 
+local function isSameType(a, b)
+   return torch.type(a) == torch.type(b)
+end
+
+local function identity(out, input)
+   if torch.isTensor(input) then
+      -- out could have been a table in a previous call
+      if not isSameType(out, input) then
+         out = input.new()
+      end
+      out:set(input)
+   elseif torch.type(input) ~= 'table' then
+      -- copy numbers, strings or functions
+      out = input
+   else
+      -- avoid recreating tables and tensors
+      -- every time the function is called
+      if not isSameType(out, input) then
+         out = {}
+      end
+      -- recursively sets the entries of out
+      for k,v in pairs(input) do
+         out[k] = identity(out[k], v)
+      end
+      -- clean up behind if the current input is
+      -- smaller than the previous one
+      for k in pairs(out) do
+         if not input[k] then
+            out[k] = nil
+         end
+      end
+   end
+   return out
+end
+
 function Identity:updateOutput(input)
-   self.output = input
+   self.output = identity(self.output, input)
    return self.output
 end
 
 
 function Identity:updateGradInput(input, gradOutput)
-   self.gradInput = gradOutput
+   self.gradInput = identity(self.gradInput, gradOutput)
    return self.gradInput
-end
-
-function Identity:clearState()
-   -- don't call set because it might reset referenced tensors
-   local function clear(f)
-      if self[f] then
-         if torch.isTensor(self[f]) then
-            self[f] = self[f].new()
-         elseif type(self[f]) == 'table' then
-            self[f] = {}
-         else
-            self[f] = nil
-         end
-      end
-   end
-   clear('output')
-   clear('gradInput')
-   return self
 end

--- a/test.lua
+++ b/test.lua
@@ -4119,11 +4119,11 @@ function nntest.Identity()
          mytester:assert(input == out, mname .. ' - elements differ')
       else
          for k, v in pairs(input) do
-            mytester:assert(out[k], mname .. ' - missing element in output')
+            mytester:assert(out[k] ~= nil, mname .. ' - missing element in output')
             testIdentity(out[k], v)
          end
          for k, v in pairs(out) do
-            mytester:assert(input[k], mname .. ' - extra element in output')
+            mytester:assert(input[k] ~= nil, mname .. ' - extra element in output')
             testIdentity(v, input[k])
          end
       end
@@ -4147,7 +4147,8 @@ function nntest.Identity()
    -- nested table with diverse elements inside
    input = { torch.rand(2), torch.rand(3),
              { torch.rand(4), 5, { 'hi', torch.rand(5) } },
-             function() return 'hi' end
+             function() return 'hi' end,
+             true, false
            }
    out = module:forward(input)
    testIdentity(out, input)

--- a/test.lua
+++ b/test.lua
@@ -4099,6 +4099,65 @@ function nntest.Copy()
    mytester:assert(torch.type(output) == 'torch.FloatTensor', 'copy forward type err')
 end
 
+function nntest.Identity()
+   local input
+   local out
+   local module = nn.Identity()
+
+   -- compare the input and the output to see if they share the
+   -- same storages and that they are different Lua elements
+   -- (in case of tensors). Recusively go into tables, and compare
+   -- for equality for other types of data
+   local mname = torch.typename(module)
+   local function testIdentity(out, input)
+      if torch.isTensor(input) then
+         mytester:assert(input:isSetTo(out), mname ..
+            ' - output does not share the same storage as input')
+         mytester:assert(out ~= input, mname ..
+            ' - output should be a new Lua element and not the same as input')
+      elseif torch.type(input) ~= 'table' then
+         mytester:assert(input == out, mname .. ' - elements differ')
+      else
+         for k, v in pairs(input) do
+            mytester:assert(out[k], mname .. ' - missing element in output')
+            testIdentity(out[k], v)
+         end
+         for k, v in pairs(out) do
+            mytester:assert(input[k], mname .. ' - extra element in output')
+            testIdentity(v, input[k])
+         end
+      end
+   end
+
+   -- test tensor
+   input = torch.rand(5)
+   out = module:forward(input)
+   testIdentity(out, input)
+
+   -- test table of tensors
+   input = {torch.rand(5), torch.rand(5)}
+   out = module:forward(input)
+   testIdentity(out, input)
+
+   -- test table of tensors with smaller size
+   input = {torch.rand(5)}
+   out = module:forward(input)
+   testIdentity(out, input)
+
+   -- nested table with diverse elements inside
+   input = { torch.rand(2), torch.rand(3),
+             { torch.rand(4), 5, { 'hi', torch.rand(5) } },
+             function() return 'hi' end
+           }
+   out = module:forward(input)
+   testIdentity(out, input)
+
+   -- test tensor again
+   input = torch.rand(5)
+   out = module:forward(input)
+   testIdentity(out, input)
+end
+
 function nntest.JoinTable()
    local tensor = torch.rand(3,4,5)
    local input = {tensor, tensor}


### PR DESCRIPTION
Here is an attempt to avoid using the assignment operator in `Identity`.
I tried to handle all previous cases, but maybe I missed something.
Here is a summary:
* recursively calls `set` on tensors
* copy non-tensors and non-table objects (as lua numbers, strings and functions)
* reuses previously created tensors/tables.
* add tests to `Identity`

If we want to go through the path of avoiding lua assignments everywhere in lua (as in [several `Containers`](https://github.com/torch/nn/blob/master/ParallelTable.lua#L12) for example), then maybe we should factor out the `identity` function to use it everywhere instead of `=`. In this case maybe it would be better to rename it `assign` or something like that and put it in `nn.utils`.

@jfsantos @soumith as you have worked on that in the past
@dominikgrewe @koraykv to check if I didn't break anything in `nngraph` and in your internal tests.
@szagoruyko for the removal of `clearState`