### PR TITLE
Better __tostring()__ and cleans formatting

### DIFF
--- a/Bilinear.lua
+++ b/Bilinear.lua
@@ -92,19 +92,19 @@ function Bilinear:updateGradInput(input, gradOutput)
        -- do first slice of weight tensor (k = 1)
       self.gradInput[1]:mm(input[2], self.weight[1]:t())
       self.gradInput[1]:cmul(gradOutput:narrow(2,1,1):expand(self.gradInput[1]:size(1),
-          self.gradInput[1]:size(2)))  
+          self.gradInput[1]:size(2)))
       self.gradInput[2]:addmm(1, input[1], self.weight[1])
       self.gradInput[2]:cmul(gradOutput:narrow(2,1,1):expand(self.gradInput[2]:size(1),
           self.gradInput[2]:size(2)))
-      
+
       -- do remaining slices of weight tensor
       if self.weight:size(1) > 1 then
          self.buff1 = self.buff1 or input[1].new()
          self.buff1:resizeAs(input[1])
-            
+
          for k = 2, self.weight:size(1) do
             self.buff1:mm(input[2], self.weight[k]:t())
-            self.buff1:cmul(gradOutput:narrow(2,k,1):expand(self.gradInput[1]:size(1), 
+            self.buff1:cmul(gradOutput:narrow(2,k,1):expand(self.gradInput[1]:size(1),
               self.gradInput[1]:size(2)))
             self.gradInput[1]:add(self.buff1)
 

--- a/ELU.lua
+++ b/ELU.lua
@@ -2,7 +2,7 @@ local ELU, parent = torch.class('nn.ELU', 'nn.Module')
 
 --[[
    Djork-Arné Clevert, Thomas Unterthiner, Sepp Hochreiter
-   Fast and Accurate Deep Network Learning by Exponential Linear Units (ELUs) 
+   Fast and Accurate Deep Network Learning by Exponential Linear Units (ELUs)
    http://arxiv.org/pdf/1511.07289.pdf
 --]]
 

--- a/Parallel.lua
+++ b/Parallel.lua
@@ -18,23 +18,23 @@ function Parallel:updateOutput(input)
       local currentOutput = self.modules[i]:updateOutput(currentInput)
       table.insert(outputs, currentOutput)
       local outputSize = currentOutput:size(self.outputDimension)
-      
+
       if i == 1 then
          totalOutputSize:resize(currentOutput:dim()):copy(currentOutput:size())
       else
          totalOutputSize[self.outputDimension] = totalOutputSize[self.outputDimension] + outputSize
       end
-      
+
    end
    self.output:resize(totalOutputSize)
-   
+
    local offset = 1
    for i=1,nModule do
       local currentOutput = outputs[i]
       local outputSize = currentOutput:size(self.outputDimension)
       self.output:narrow(self.outputDimension, offset, outputSize):copy(currentOutput)
       offset = offset + currentOutput:size(self.outputDimension)
-   end 
+   end
    return self.output
 end
 
@@ -43,15 +43,15 @@ function Parallel:updateGradInput(input, gradOutput)
    self.gradInput:resizeAs(input)
 
    local offset = 1
-   for i=1,nModule do 
+   for i=1,nModule do
       local module=self.modules[i]
       local currentInput = input:select(self.inputDimension,i)
       local currentOutput = module.output
       local outputSize = currentOutput:size(self.outputDimension)
       local currentGradOutput = gradOutput:narrow(self.outputDimension, offset, outputSize)
-      
+
       local currentGradInput = module:updateGradInput(currentInput, currentGradOutput)
-        
+
       self.gradInput:select(self.inputDimension,i):copy(currentGradInput)
       offset = offset + outputSize
    end
@@ -62,17 +62,17 @@ function Parallel:accGradParameters(input, gradOutput, scale)
    local nModule=input:size(self.inputDimension)
 
    local offset = 1
-   for i=1,nModule do 
+   for i=1,nModule do
       local module = self.modules[i]
       local currentOutput = module.output
       local outputSize = currentOutput:size(self.outputDimension)
-      
+
       module:accGradParameters(
           input:select(self.inputDimension,i),
           gradOutput:narrow(self.outputDimension, offset,outputSize),
           scale
       )
-        
+
       offset = offset + outputSize
    end
 end
@@ -81,16 +81,16 @@ function Parallel:accUpdateGradParameters(input, gradOutput, lr)
    local nModule=input:size(self.inputDimension)
 
    local offset = 1
-   for i=1,nModule do 
+   for i=1,nModule do
       local module = self.modules[i];
       local currentOutput = module.output
       module:accUpdateGradParameters(
-      
+
           input:select(self.inputDimension,i),
           gradOutput:narrow(self.outputDimension, offset,
                             currentOutput:size(self.outputDimension)),
           lr)
-        
+
       offset = offset + currentOutput:size(self.outputDimension)
    end
 end

--- a/Reshape.lua
+++ b/Reshape.lua
@@ -35,9 +35,9 @@ function Reshape:updateOutput(input)
       self._input:copy(input)
       input = self._input
    end
-   
+
    if (self.batchMode == false) or (
-         (self.batchMode == nil) and 
+         (self.batchMode == nil) and
          (input:nElement() == self.nelement and input:size(1) ~= 1)
       ) then
       self.output:view(input, self.size)
@@ -55,7 +55,7 @@ function Reshape:updateGradInput(input, gradOutput)
       self._gradOutput:copy(gradOutput)
       gradOutput = self._gradOutput
    end
-   
+
    self.gradInput:viewAs(gradOutput, input)
    return self.gradInput
 end

--- a/SpatialAveragePooling.lua
+++ b/SpatialAveragePooling.lua
@@ -83,11 +83,11 @@ function SpatialAveragePooling:updateGradInput(input, gradOutput)
 end
 
 function SpatialAveragePooling:__tostring__()
-   local s = string.format('%s(%d,%d,%d,%d', torch.type(self),
+   local s = string.format('%s(%dx%d, %d,%d', torch.type(self),
                             self.kW, self.kH, self.dW, self.dH)
    if (self.padW or self.padH) and (self.padW ~= 0 or self.padH ~= 0) then
-      s = s .. ',' .. self.padW .. ','.. self.padH
+      s = s .. ', ' .. self.padW .. ','.. self.padH
    end
    s = s .. ')'
-   return s 
+   return s
 end

--- a/SpatialConvolutionLocal.lua
+++ b/SpatialConvolutionLocal.lua
@@ -66,14 +66,14 @@ end
 
 local function viewWeight(self)
    self.weight = self.weight:view(self.oH * self.oW, self.nOutputPlane, self.nInputPlane * self.kH * self.kW)
-   if self.gradWeight and self.gradWeight:dim() > 0 then 
+   if self.gradWeight and self.gradWeight:dim() > 0 then
       self.gradWeight = self.gradWeight:view(self.oH * self.oW, self.nOutputPlane, self.nInputPlane * self.kH * self.kW)
    end
 end
 
 local function unviewWeight(self)
    self.weight = self.weight:view(self.oH, self.oW, self.nOutputPlane, self.nInputPlane, self.kH, self.kW)
-   if self.gradWeight and self.gradWeight:dim() > 0 then 
+   if self.gradWeight and self.gradWeight:dim() > 0 then
       self.gradWeight = self.gradWeight:view(self.oH, self.oW, self.nOutputPlane, self.nInputPlane, self.kH, self.kW)
    end
 end
@@ -81,12 +81,12 @@ end
 local function checkInputSize(self, input)
    if input:nDimension() == 3 then
       if input:size(1) ~= self.nInputPlane or input:size(2) ~= self.iH or input:size(3) ~= self.iW then
-         error(string.format('Given input size: (%dx%dx%d) inconsistent with expected input size: (%dx%dx%d).', 
+         error(string.format('Given input size: (%dx%dx%d) inconsistent with expected input size: (%dx%dx%d).',
                              input:size(1), input:size(2), input:size(3), self.nInputPlane, self.iH, self.iW))
       end
    elseif input:nDimension() == 4 then
       if input:size(2) ~= self.nInputPlane or input:size(3) ~= self.iH or input:size(4) ~= self.iW then
-         error(string.format('Given input size: (%dx%dx%dx%d) inconsistent with expected input size: (batchsize x%dx%dx%d).', 
+         error(string.format('Given input size: (%dx%dx%dx%d) inconsistent with expected input size: (batchsize x%dx%dx%d).',
                               input:size(1), input:size(2), input:size(3), input:size(4), self.nInputPlane, self.iH, self.iW))
       end
    else
@@ -100,12 +100,12 @@ local function checkOutputSize(self, input, output)
    end
    if output:nDimension() == 3 then
       if output:size(1) ~= self.nOutputPlane or output:size(2) ~= self.oH or output:size(3) ~= self.oW then
-         error(string.format('Given output size: (%dx%dx%d) inconsistent with expected output size: (%dx%dx%d).', 
+         error(string.format('Given output size: (%dx%dx%d) inconsistent with expected output size: (%dx%dx%d).',
                              output:size(1), output:size(2), output:size(3), self.nOutputPlane, self.oH, self.oW))
       end
    elseif output:nDimension() == 4 then
       if output:size(2) ~= self.nOutputPlane or output:size(3) ~= self.oH or output:size(4) ~= self.oW then
-         error(string.format('Given output size: (%dx%dx%dx%d) inconsistent with expected output size: (batchsize x%dx%dx%d).', 
+         error(string.format('Given output size: (%dx%dx%dx%d) inconsistent with expected output size: (batchsize x%dx%dx%d).',
                               output:size(1), output:size(2), output:size(3), output:size(4), self.nOutputPlane, self.oH, self.oW))
       end
    else

--- a/SpatialConvolutionMM.lua
+++ b/SpatialConvolutionMM.lua
@@ -2,7 +2,7 @@ local SpatialConvolutionMM, parent = torch.class('nn.SpatialConvolutionMM', 'nn.
 
 function SpatialConvolutionMM:__init(nInputPlane, nOutputPlane, kW, kH, dW, dH, padW, padH)
    parent.__init(self)
-   
+
    dW = dW or 1
    dH = dH or 1
 
@@ -36,7 +36,7 @@ function SpatialConvolutionMM:reset(stdv)
       end)
       self.bias:apply(function()
          return torch.uniform(-stdv, stdv)
-      end)  
+      end)
    else
       self.weight:uniform(-stdv, stdv)
       self.bias:uniform(-stdv, stdv)

--- a/SpatialFractionalMaxPooling.lua
+++ b/SpatialFractionalMaxPooling.lua
@@ -153,7 +153,7 @@ function SpatialFractionalMaxPooling:clearState()
 end
 
 function SpatialFractionalMaxPooling:__tostring__()
-   return string.format('%s(%d,%d,%d,%d)', torch.type(self),
+   return string.format('%s(%dx%d, %d,%d)', torch.type(self),
                         self.outW and self.outW or self.ratioW,
                         self.outH and self.outH or self.ratioH,
                         self.poolSizeW, self.poolSizeH)

--- a/SpatialMaxPooling.lua
+++ b/SpatialMaxPooling.lua
@@ -5,7 +5,7 @@ function SpatialMaxPooling:__init(kW, kH, dW, dH, padW, padH)
 
    dW = dW or kW
    dH = dH or kH
-   
+
    self.kW = kW
    self.kH = kH
    self.dW = dW
@@ -66,10 +66,10 @@ function SpatialMaxPooling:empty()
 end
 
 function SpatialMaxPooling:__tostring__()
-   local s =  string.format('%s(%d,%d,%d,%d', torch.type(self),
+   local s =  string.format('%s(%dx%d, %d,%d', torch.type(self),
                             self.kW, self.kH, self.dW, self.dH)
    if (self.padW or self.padH) and (self.padW ~= 0 or self.padH ~= 0) then
-      s = s .. ',' .. self.padW .. ','.. self.padH
+      s = s .. ', ' .. self.padW .. ','.. self.padH
    end
    s = s .. ')'
 

--- a/SpatialMaxUnpooling.lua
+++ b/SpatialMaxUnpooling.lua
@@ -1,46 +1,46 @@
 local SpatialMaxUnpooling, parent = torch.class('nn.SpatialMaxUnpooling', 'nn.Module')
 
 function SpatialMaxUnpooling:__init(poolingModule)
-  parent.__init(self)
-  assert(torch.type(poolingModule)=='nn.SpatialMaxPooling', 'Argument must be a nn.SPatialMaxPooling module')
-  assert(poolingModule.kH==poolingModule.dH and poolingModule.kW==poolingModule.dW, "The size of pooling module's kernel must be equal to its stride")
-  self.pooling = poolingModule
+   parent.__init(self)
+   assert(torch.type(poolingModule)=='nn.SpatialMaxPooling', 'Argument must be a nn.SPatialMaxPooling module')
+   assert(poolingModule.kH==poolingModule.dH and poolingModule.kW==poolingModule.dW, "The size of pooling module's kernel must be equal to its stride")
+   self.pooling = poolingModule
 
-  poolingModule.updateOutput = function(pool, input)
-    local dims = input:dim()
-    pool.iheight = input:size(dims-1)
-    pool.iwidth = input:size(dims)
-    return nn.SpatialMaxPooling.updateOutput(pool, input)
-  end
+   poolingModule.updateOutput = function(pool, input)
+      local dims = input:dim()
+      pool.iheight = input:size(dims-1)
+      pool.iwidth = input:size(dims)
+      return nn.SpatialMaxPooling.updateOutput(pool, input)
+   end
 end
 
 function SpatialMaxUnpooling:setParams()
-  self.indices = self.pooling.indices
-  self.oheight = self.pooling.iheight
-  self.owidth = self.pooling.iwidth
+   self.indices = self.pooling.indices
+   self.oheight = self.pooling.iheight
+   self.owidth = self.pooling.iwidth
 end
 
 function SpatialMaxUnpooling:updateOutput(input)
-  self:setParams()
-  input.THNN.SpatialMaxUnpooling_updateOutput(
-    input:cdata(),
-    self.output:cdata(),
-    self.indices:cdata(),
-    self.owidth, self.oheight
-  )
-  return self.output
+   self:setParams()
+   input.THNN.SpatialMaxUnpooling_updateOutput(
+   input:cdata(),
+   self.output:cdata(),
+   self.indices:cdata(),
+   self.owidth, self.oheight
+   )
+   return self.output
 end
 
 function SpatialMaxUnpooling:updateGradInput(input, gradOutput)
-  self:setParams()
-  input.THNN.SpatialMaxUnpooling_updateGradInput(
-    input:cdata(),
-    gradOutput:cdata(),
-    self.gradInput:cdata(),
-    self.indices:cdata(),
-    self.owidth, self.oheight
-  )
-  return self.gradInput
+   self:setParams()
+   input.THNN.SpatialMaxUnpooling_updateGradInput(
+   input:cdata(),
+   gradOutput:cdata(),
+   self.gradInput:cdata(),
+   self.indices:cdata(),
+   self.owidth, self.oheight
+   )
+   return self.gradInput
 end
 
 function SpatialMaxUnpooling:empty()

--- a/SpatialReflectionPadding.lua
+++ b/SpatialReflectionPadding.lua
@@ -46,6 +46,6 @@ end
 
 function SpatialReflectionPadding:__tostring__()
   return torch.type(self) ..
-      string.format('(l=%d,r=%d,t=%d,b=%d)', self.pad_l, self.pad_r,
+      string.format('(l=%d, r=%d, t=%d, b=%d)', self.pad_l, self.pad_r,
                     self.pad_t, self.pad_b)
 end

--- a/SpatialReplicationPadding.lua
+++ b/SpatialReplicationPadding.lua
@@ -45,7 +45,7 @@ function SpatialReplicationPadding:updateGradInput(input, gradOutput)
 end
 
 function SpatialReplicationPadding:__tostring__()
-  return torch.type(self) ..
-      string.format('(l=%d,r=%d,t=%d,b=%d)', self.pad_l, self.pad_r,
-                    self.pad_t, self.pad_b)
+   return torch.type(self) ..
+   string.format('(l=%d, r=%d, t=%d, b=%d)', self.pad_l, self.pad_r,
+   self.pad_t, self.pad_b)
 end

--- a/SpatialZeroPadding.lua
+++ b/SpatialZeroPadding.lua
@@ -58,7 +58,7 @@ function SpatialZeroPadding:updateOutput(input)
 end
 
 function SpatialZeroPadding:updateGradInput(input, gradOutput)
-   if input:dim() == 3 then 
+   if input:dim() == 3 then
       self.gradInput:resizeAs(input):zero()
       -- crop gradInput if necessary
       local cg_input = self.gradInput
@@ -98,7 +98,7 @@ end
 
 
 function SpatialZeroPadding:__tostring__()
-  return torch.type(self) ..
-      string.format('(l=%d,r=%d,t=%d,b=%d)', self.pad_l, self.pad_r,
-                    self.pad_t, self.pad_b)
+   return torch.type(self) ..
+   string.format('(l=%d, r=%d, t=%d, b=%d)', self.pad_l, self.pad_r,
+   self.pad_t, self.pad_b)
 end

--- a/VolumetricAveragePooling.lua
+++ b/VolumetricAveragePooling.lua
@@ -42,11 +42,11 @@ function VolumetricAveragePooling:empty()
 end
 
 function VolumetricAveragePooling:__tostring__()
-   local s =  string.format('%s(%d,%d,%d,%d,%d,%d', torch.type(self),
+   local s =  string.format('%s(%dx%dx%d, %d,%d,%d', torch.type(self),
                             self.kT, self.kW, self.kH, self.dT, self.dW, self.dH)
    if (self.padT or self.padW or self.padH) and
       (self.padT ~= 0 or self.padW ~= 0 or self.padH ~= 0) then
-      s = s .. ',' .. self.padT.. ',' .. self.padW .. ','.. self.padH
+      s = s .. ', ' .. self.padT.. ',' .. self.padW .. ','.. self.padH
    end
    s = s .. ')'
 

--- a/VolumetricConvolution.lua
+++ b/VolumetricConvolution.lua
@@ -64,14 +64,14 @@ end
 -- function to re-view the weight layout in a way that would make the MM ops happy
 local function viewWeight(self)
    self.weight = self.weight:view(self.nOutputPlane, self.nInputPlane * self.kT * self.kH * self.kW)
-   if self.gradWeight and self.gradWeight:dim() > 0 then 
+   if self.gradWeight and self.gradWeight:dim() > 0 then
       self.gradWeight = self.gradWeight:view(self.nOutputPlane, self.nInputPlane * self.kT * self.kH * self.kW)
    end
 end
 
 local function unviewWeight(self)
    self.weight = self.weight:view(self.nOutputPlane, self.nInputPlane, self.kT, self.kH, self.kW)
-   if self.gradWeight and self.gradWeight:dim() > 0 then 
+   if self.gradWeight and self.gradWeight:dim() > 0 then
       self.gradWeight = self.gradWeight:view(self.nOutputPlane, self.nInputPlane, self.kT, self.kH, self.kW)
    end
 end

--- a/VolumetricMaxPooling.lua
+++ b/VolumetricMaxPooling.lua
@@ -78,11 +78,11 @@ function VolumetricMaxPooling:read(file, version)
 end
 
 function VolumetricMaxPooling:__tostring__()
-   local s =  string.format('%s(%d,%d,%d,%d,%d,%d', torch.type(self),
+   local s =  string.format('%s(%dx%dx%d, %d,%d,%d', torch.type(self),
                             self.kT, self.kW, self.kH, self.dT, self.dW, self.dH)
    if (self.padT or self.padW or self.padH) and
       (self.padT ~= 0 or self.padW ~= 0 or self.padH ~= 0) then
-      s = s .. ',' .. self.padT.. ',' .. self.padW .. ','.. self.padH
+      s = s .. ', ' .. self.padT.. ',' .. self.padW .. ','.. self.padH
    end
    s = s .. ')'
 


### PR DESCRIPTION
Better `__tostring()__` for *pooling* modules
Fixing code formatting (Vim took care of that)