### PR TITLE
Improve error handling

### DIFF
--- a/Concat.lua
+++ b/Concat.lua
@@ -9,7 +9,7 @@ end
 function Concat:updateOutput(input)
    local outs = {}
    for i=1,#self.modules do
-      local currentOutput = self.modules[i]:updateOutput(input)
+      local currentOutput = self:rethrowErrors(self.modules[i], i, 'updateOutput', input)
       outs[i] = currentOutput
       if i == 1 then
          self.size:resize(currentOutput:dim()):copy(currentOutput:size())
@@ -34,7 +34,7 @@ function Concat:updateGradInput(input, gradOutput)
    local offset = 1
    for i,module in ipairs(self.modules) do
       local currentOutput = module.output
-      local currentGradInput = module:updateGradInput(input, gradOutput:narrow(self.dimension, offset, currentOutput:size(self.dimension)))
+      local currentGradInput = self:rethrowErrors(module, i, 'updateGradInput', gradOutput:narrow(self.dimension, offset, currentOutput:size(self.dimension)))
 
       if currentGradInput then -- if the module does not produce a gradInput (for example first layer), then ignore it and move on.
          if i==1 then
@@ -53,7 +53,7 @@ function Concat:accGradParameters(input, gradOutput, scale)
    local offset = 1
    for i,module in ipairs(self.modules) do
       local currentOutput = module.output
-      module:accGradParameters(
+      self:rethrowErrors(module, i, 'accGradParameters',
           input,
           gradOutput:narrow(self.dimension, offset, currentOutput:size(self.dimension)),
           scale)
@@ -67,7 +67,7 @@ function Concat:backward(input, gradOutput, scale)
    local offset = 1
    for i,module in ipairs(self.modules) do
       local currentOutput = module.output
-      local currentGradInput = module:backward(input, gradOutput:narrow(self.dimension, offset, currentOutput:size(self.dimension)), scale)
+      local currentGradInput = self:rethrowErrors(module, i, 'backward', input, gradOutput:narrow(self.dimension, offset, currentOutput:size(self.dimension)), scale)
       if currentGradInput then -- if the module does not produce a gradInput (for example first layer), then ignore it and move on.
          if i==1 then
             self.gradInput:copy(currentGradInput)
@@ -84,7 +84,7 @@ function Concat:accUpdateGradParameters(input, gradOutput, lr)
    local offset = 1
    for i,module in ipairs(self.modules) do
       local currentOutput = module.output
-      module:accUpdateGradParameters(
+      self:rethrowErrors(module, i, 'accUpdateGradParameters',
           input,
           gradOutput:narrow(self.dimension, offset, currentOutput:size(self.dimension)),
           lr)

--- a/Container.lua
+++ b/Container.lua
@@ -20,6 +20,56 @@ function Container:size()
     return #self.modules
 end
 
+-- Check if passing arguments through xpcall is supported in this Lua interpreter.
+local _, XPCALL_ARGS = xpcall(function(x) return x ~= nil end, function() end, 1)
+local TRACEBACK_WARNING = "WARNING: If you see a stack trace below, it doesn't point to the place where this error occured. Please use only the one above."
+-- module argument can be retrieved with moduleIndex, but code is cleaner when
+-- it has to be specified anyway.
+function Container:rethrowErrors(module, moduleIndex, funcName, ...)
+   assert(module == self.modules[moduleIndex],
+          "mismatch between moduleIndex and self.modules in rethrowErrors")
+   local function handleError(err)
+      local err_lines = err:split('\n')
+      -- This will be executed only in the first container that handles the error.
+      if err_lines[#err_lines] ~= TRACEBACK_WARNING then
+         local traceback = debug.traceback()
+         -- Remove this handler from the stack
+         local _, first_line_end = traceback:find('^.-\n')
+         local _, second_line_end = traceback:find('^.-\n.-\n')
+         traceback = traceback:sub(1, first_line_end) .. traceback:sub(second_line_end+1)
+         err = err .. '\n' .. traceback .. '\n\n' .. TRACEBACK_WARNING
+      else
+         -- Remove file path. +1 for newline character.
+         local first_line_end = #err_lines[1] + 1
+         err = err:sub(first_line_end+1)
+      end
+      local msg = string.format('In %d module of %s:',
+                              moduleIndex, torch.type(self))
+      -- Preceding newline has to be here, because Lua will prepend a file path.
+      err = '\n' .. msg .. '\n' .. err
+      return err
+   end
+
+   -- Lua 5.1 doesn't support passing arguments through xpcall, so they have to
+   -- be passed via a closure. This incurs some overhead, so it's better not to
+   -- make it the default.
+   local ok, ret, noret
+   if not XPCALL_ARGS then
+      local args = {...}
+      local unpack = unpack or table.unpack
+      ok, ret, noret = xpcall(function()
+                                 return module[funcName](module, unpack(args))
+                              end,
+                              handleError)
+   else
+      ok, ret, noret = xpcall(module[funcName], handleError, module, ...)
+   end
+   assert(noret == nil, "rethrowErrors supports only one return argument")
+
+   if not ok then error(ret) end
+   return ret
+end
+
 function Container:applyToModules(func)
     for _, module in ipairs(self.modules) do
         func(module)

--- a/DepthConcat.lua
+++ b/DepthConcat.lua
@@ -29,7 +29,7 @@ end
 function DepthConcat:updateOutput(input)
    local outs = {}
    for i=1,#self.modules do
-      local currentOutput = self.modules[i]:updateOutput(input)
+      local currentOutput = self:rethrowErrors(self.modules[i], i, 'updateOutput', input)
       outs[i] = currentOutput
       if i == 1 then
          self.size:resize(currentOutput:dim()):copy(currentOutput:size())
@@ -62,7 +62,7 @@ function DepthConcat:updateGradInput(input, gradOutput)
    for i,module in ipairs(self.modules) do
       local currentOutput = module.output
       local gradOutputWindow = self:windowNarrow(gradOutput, currentOutput, offset)
-      local currentGradInput = module:updateGradInput(input, gradOutputWindow)
+      local currentGradInput = self:rethrowErrors(module, i, 'updateGradInput', input, gradOutputWindow)
       if i==1 then
          self.gradInput:copy(currentGradInput)
       else
@@ -79,7 +79,7 @@ function DepthConcat:accGradParameters(input, gradOutput, scale)
    for i,module in ipairs(self.modules) do
       local currentOutput = module.output
       local gradOutputWindow = self:windowNarrow(gradOutput, currentOutput, offset)
-      module:accGradParameters(input, gradOutputWindow, scale)
+      self:rethrowErrors(module, i, 'accGradParameters', input, gradOutputWindow, scale)
       offset = offset + currentOutput:size(self.dimension)
    end
 end
@@ -92,7 +92,7 @@ function DepthConcat:backward(input, gradOutput, scale)
    for i,module in ipairs(self.modules) do
       local currentOutput = module.output
       local gradOutputWindow = self:windowNarrow(gradOutput, currentOutput, offset)
-      local currentGradInput = module:backward(input, gradOutputWindow)
+      local currentGradInput = self:rethrowErrors(module, i, 'backward', input, gradOutputWindow)
       if i==1 then
          self.gradInput:copy(currentGradInput)
       else
@@ -108,7 +108,7 @@ function DepthConcat:accUpdateGradParameters(input, gradOutput, lr)
    for i,module in ipairs(self.modules) do
       local currentOutput = module.output
       local gradOutputWindow = self:windowNarrow(gradOutput, currentOutput, offset)
-      module:accUpdateGradParameters(input, gradOutputWindow, lr)
+      self:rethrowErrors(module, i, 'accUpdateGradParameters', input, gradOutputWindow, lr)
       offset = offset + currentOutput:size(self.dimension)
    end
 end

--- a/Parallel.lua
+++ b/Parallel.lua
@@ -15,7 +15,7 @@ function Parallel:updateOutput(input)
 
    for i=1,nModule do
       local currentInput = input:select(self.inputDimension,i)
-      local currentOutput = self.modules[i]:updateOutput(currentInput)
+      local currentOutput = self:rethrowErrors(self.modules[i], i, 'updateOutput', currentInput)
       table.insert(outputs, currentOutput)
       local outputSize = currentOutput:size(self.outputDimension)
 
@@ -50,7 +50,7 @@ function Parallel:updateGradInput(input, gradOutput)
       local outputSize = currentOutput:size(self.outputDimension)
       local currentGradOutput = gradOutput:narrow(self.outputDimension, offset, outputSize)
 
-      local currentGradInput = module:updateGradInput(currentInput, currentGradOutput)
+      local currentGradInput = self:rethrowErrors(module, i, 'updateGradInput', currentInput, currentGradOutput)
 
       self.gradInput:select(self.inputDimension,i):copy(currentGradInput)
       offset = offset + outputSize
@@ -67,11 +67,10 @@ function Parallel:accGradParameters(input, gradOutput, scale)
       local currentOutput = module.output
       local outputSize = currentOutput:size(self.outputDimension)
 
-      module:accGradParameters(
+      self:rethrowErrors(module, i, 'accGradParameters',
           input:select(self.inputDimension,i),
           gradOutput:narrow(self.outputDimension, offset,outputSize),
-          scale
-      )
+          scale)
 
       offset = offset + outputSize
    end
@@ -84,8 +83,7 @@ function Parallel:accUpdateGradParameters(input, gradOutput, lr)
    for i=1,nModule do
       local module = self.modules[i];
       local currentOutput = module.output
-      module:accUpdateGradParameters(
-
+      self:rethrowErrors(module, i, 'accUpdateGradParameters',
           input:select(self.inputDimension,i),
           gradOutput:narrow(self.outputDimension, offset,
                             currentOutput:size(self.outputDimension)),

--- a/ParallelTable.lua
+++ b/ParallelTable.lua
@@ -9,14 +9,14 @@ end
 
 function ParallelTable:updateOutput(input)
    for i=1,#self.modules do
-      self.output[i] = self.modules[i]:updateOutput(input[i])
+      self.output[i] = self:rethrowErrors(self.modules[i], i, 'updateOutput', input[i])
    end
    return self.output
 end
 
 function ParallelTable:updateGradInput(input, gradOutput)
    for i,module in ipairs(self.modules) do
-      self.gradInput[i]= module:updateGradInput(input[i], gradOutput[i])
+      self.gradInput[i] = self:rethrowErrors(module, i, 'updateGradInput', input[i], gradOutput[i])
    end
    return self.gradInput
 end
@@ -24,14 +24,14 @@ end
 function ParallelTable:accGradParameters(input, gradOutput, scale)
    scale = scale or 1
    for i,module in ipairs(self.modules) do
-      module:accGradParameters(input[i], gradOutput[i], scale)
+      self:rethrowErrors(module, i, 'accGradParameters', input[i], gradOutput[i], scale)
    end
 end
 
 function ParallelTable:accUpdateGradParameters(input, gradOutput, lr)
    lr = lr or 1
    for i,module in ipairs(self.modules) do
-      module:accUpdateGradParameters(input[i], gradOutput[i], lr)
+      self:rethrowErrors(module, i, 'accUpdateGradParameters', input[i], gradOutput[i], lr)
    end
 end
 

--- a/Sequential.lua
+++ b/Sequential.lua
@@ -41,7 +41,7 @@ end
 function Sequential:updateOutput(input)
    local currentOutput = input
    for i=1,#self.modules do
-      currentOutput = self.modules[i]:updateOutput(currentOutput)
+      currentOutput = self:rethrowErrors(self.modules[i], i, 'updateOutput', currentOutput)
    end
    self.output = currentOutput
    return currentOutput
@@ -52,10 +52,10 @@ function Sequential:updateGradInput(input, gradOutput)
    local currentModule = self.modules[#self.modules]
    for i=#self.modules-1,1,-1 do
       local previousModule = self.modules[i]
-      currentGradOutput = currentModule:updateGradInput(previousModule.output, currentGradOutput)
+      currentGradOutput = self:rethrowErrors(currentModule, i+1, 'updateGradInput', previousModule.output, currentGradOutput)
       currentModule = previousModule
    end
-   currentGradOutput = currentModule:updateGradInput(input, currentGradOutput)
+   currentGradOutput = self:rethrowErrors(currentModule, 1, 'updateGradInput', input, currentGradOutput)
    self.gradInput = currentGradOutput
    return currentGradOutput
 end
@@ -67,12 +67,12 @@ function Sequential:accGradParameters(input, gradOutput, scale)
    local currentModule = self.modules[#self.modules]
    for i=#self.modules-1,1,-1 do
       local previousModule = self.modules[i]
-      currentModule:accGradParameters(previousModule.output, currentGradOutput, scale)
+      self:rethrowErrors(currentModule, i+1, 'accGradParameters', previousModule.output, currentGradOutput, scale)
       currentGradOutput = currentModule.gradInput
       currentModule = previousModule
    end
 
-   currentModule:accGradParameters(input, currentGradOutput, scale)
+   self:rethrowErrors(currentModule, 1, 'accGradParameters', input, currentGradOutput, scale)
 end
 
 function Sequential:backward(input, gradOutput, scale)
@@ -81,11 +81,11 @@ function Sequential:backward(input, gradOutput, scale)
    local currentModule = self.modules[#self.modules]
    for i=#self.modules-1,1,-1 do
       local previousModule = self.modules[i]
-      currentGradOutput = currentModule:backward(previousModule.output, currentGradOutput, scale)
+      currentGradOutput = self:rethrowErrors(currentModule, i+1, 'backward', previousModule.output, currentGradOutput, scale)
       currentModule.gradInput = currentGradOutput
       currentModule = previousModule
    end
-   currentGradOutput = currentModule:backward(input, currentGradOutput, scale)
+   currentGradOutput = self:rethrowErrors(currentModule, 1, 'backward', input, currentGradOutput, scale)
    self.gradInput = currentGradOutput
    return currentGradOutput
 end
@@ -95,12 +95,12 @@ function Sequential:accUpdateGradParameters(input, gradOutput, lr)
    local currentModule = self.modules[#self.modules]
    for i=#self.modules-1,1,-1 do
       local previousModule = self.modules[i]
-      currentModule:accUpdateGradParameters(previousModule.output, currentGradOutput, lr)
+      self:rethrowErrors(currentModule, i+1, 'accUpdateGradParameters', previousModule.output, currentGradOutput, lr)
       currentGradOutput = currentModule.gradInput
       currentModule = previousModule
    end
 
-   currentModule:accUpdateGradParameters(input, currentGradOutput, lr)
+   self:rethrowErrors(currentModule, 1, 'accUpdateGradParameters', input, currentGradOutput, lr)
 end
 
 


### PR DESCRIPTION
When an error occurs in some module, all containers up to the topmost one will be printed. This should make network debugging much easier.

Error messages look like this after these changes:
```
/Users/adampaszke/torch/install/bin/luajit:
In nn.Sequential (2):
In nn.Sequential (6):
/Users/adampaszke/torch/install/share/lua/5.1/nn/Linear.lua:55: size mismatch, m1: [1 x 10], m2: [20 x 10] at /Users/adampaszke/torch/pkg/torch/lib/TH/generic/THTensorMath.c:706
stack traceback:
        [C]: in function 'error'
        .../adampaszke/torch/install/share/lua/5.1/nn/Container.lua:34: in function 'callAndRethrow'
        ...adampaszke/torch/install/share/lua/5.1/nn/Sequential.lua:45: in function 'forward'
        test.lua:21: in main chunk
        [C]: in function 'dofile'
        ...szke/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:145: in main chunk
        [C]: at 0x010e36abc0
```

Because of how this works, top of a stack trace will be a bit malformed (it won't point to where the error happened), but actually you can easily reconstruct an execution path from information that has been printed at the top.