### PR TITLE
Fix Jacobian.testIO for modules that don't have gradInput

### DIFF
--- a/Jacobian.lua
+++ b/Jacobian.lua
@@ -322,7 +322,7 @@ function nn.Jacobian.testIO(module,input, minval, maxval)
 
    local errf = fo - fo2
    local errb = bo - bo2
-   return errf:abs():max(), errb:abs():max()
+   return errf:abs():max(), errb:numel() == 0 and 0 or errb:abs():max()
 end
 
 function nn.Jacobian.testAllUpdate(module, input, weight, gradWeight)
@@ -340,7 +340,7 @@ function nn.Jacobian.testAllUpdate(module, input, weight, gradWeight)
    maccgp:accGradParameters(input, gradOutput)
    maccgp:updateParameters(lr)
    errors["accGradParameters"] = (weightc-maccgp[gradWeight]*lr-maccgp[weight]):norm()
-   
+
    -- accUpdateGradParameters
    local maccugp = module:clone()
    maccugp:forward(input)
@@ -365,7 +365,7 @@ function nn.Jacobian.testAllUpdate(module, input, weight, gradWeight)
    local err = (weightc-maccgp[gradWeight]*(lr*2)-macsh1[weight]):norm()
    err = err + (weightc-maccgp[gradWeight]*(lr*2)-macsh2[weight]):norm()
    errors["accGradParameters [shared]"] = err
-   
+
    -- shared, accUpdateGradParameters
    local macshu1 = module:clone()
    local macshu2 = module:clone()


### PR DESCRIPTION
Some modules, such as LookupTable, don't have gradInput tensors. This
change allows nn.Jacobian.testIO to be called on such modules.