### PR TITLE
Add optional pretty print for containers

### DIFF
--- a/Concat.lua
+++ b/Concat.lua
@@ -93,22 +93,24 @@ function Concat:accUpdateGradParameters(input, gradOutput, lr)
 end
 
 function Concat:__tostring__()
+   local r = function(s) return s end
+   if nn.config.prettyPrint then r = require('trepl.colorize').red end
    local tab = '  '
    local line = '\n'
-   local next = '  |`-> '
-   local ext = '  |    '
+   local next = r '  |`-> '
+   local ext = r '  |    '
    local extlast = '       '
-   local last = '   ... -> '
-   local str = torch.type(self)
-   str = str .. ' {' .. line .. tab .. 'input'
+   local last = r '   ... -> '
+   local str = r(torch.type(self))
+   str = str .. r ' {' .. line .. tab .. r 'input'
    for i=1,#self.modules do
       if i == #self.modules then
-         str = str .. line .. tab .. next .. '(' .. i .. '): ' .. tostring(self.modules[i]):gsub(line, line .. tab .. extlast)
+         str = str .. line .. tab .. next .. r '(' .. i .. r '): ' .. tostring(self.modules[i]):gsub(line, line .. tab .. extlast)
       else
-         str = str .. line .. tab .. next .. '(' .. i .. '): ' .. tostring(self.modules[i]):gsub(line, line .. tab .. ext)
+         str = str .. line .. tab .. next .. r '(' .. i .. r '): ' .. tostring(self.modules[i]):gsub(line, line .. tab .. ext)
       end
    end
-   str = str .. line .. tab .. last .. 'output'
-   str = str .. line .. '}'
+   str = str .. line .. tab .. last .. r 'output'
+   str = str .. line .. r '}'
    return str
 end

--- a/Parallel.lua
+++ b/Parallel.lua
@@ -96,22 +96,24 @@ function Parallel:accUpdateGradParameters(input, gradOutput, lr)
 end
 
 function Parallel:__tostring__()
+   local g = function(s) return s end
+   if nn.config.prettyPrint then g = require('trepl.colorize').green end
    local tab = '  '
    local line = '\n'
-   local next = '  |`-> '
-   local ext = '  |    '
+   local next = g '  |`-> '
+   local ext = g '  |    '
    local extlast = '       '
-   local last = '   ... -> '
-   local str = torch.type(self)
-   str = str .. ' {' .. line .. tab .. 'input'
+   local last = g '   ... -> '
+   local str = g(torch.type(self))
+   str = str .. g ' {' .. line .. tab .. g 'input'
    for i=1,#self.modules do
       if i == #self.modules then
-         str = str .. line .. tab .. next .. '(' .. i .. '): ' .. tostring(self.modules[i]):gsub(line, line .. tab .. extlast)
+         str = str .. line .. tab .. next .. g '(' .. i .. g '): ' .. tostring(self.modules[i]):gsub(line, line .. tab .. extlast)
       else
-         str = str .. line .. tab .. next .. '(' .. i .. '): ' .. tostring(self.modules[i]):gsub(line, line .. tab .. ext)
+         str = str .. line .. tab .. next .. g '(' .. i .. g '): ' .. tostring(self.modules[i]):gsub(line, line .. tab .. ext)
       end
    end
-   str = str .. line .. tab .. last .. 'output'
-   str = str .. line .. '}'
+   str = str .. line .. tab .. last .. g 'output'
+   str = str .. line .. g '}'
    return str
 end

--- a/Sequential.lua
+++ b/Sequential.lua
@@ -105,18 +105,20 @@ end
 
 
 function Sequential:__tostring__()
+   local b = function(s) return s end
+   if nn.config.prettyPrint then b = require('trepl.colorize').blue end
    local tab = '  '
    local line = '\n'
-   local next = ' -> '
-   local str = 'nn.Sequential'
-   str = str .. ' {' .. line .. tab .. '[input'
+   local next = b ' -> '
+   local str = b 'nn.Sequential'
+   str = str .. b ' {' .. line .. tab .. b '[input'
    for i=1,#self.modules do
-      str = str .. next .. '(' .. i .. ')'
+      str = str .. next .. b '(' .. i .. b ')'
    end
-   str = str .. next .. 'output]'
+   str = str .. next .. b 'output]'
    for i=1,#self.modules do
-      str = str .. line .. tab .. '(' .. i .. '): ' .. tostring(self.modules[i]):gsub(line, line .. tab)
+      str = str .. line .. tab .. b '(' .. i .. b '): ' .. tostring(self.modules[i]):gsub(line, line .. tab)
    end
-   str = str .. line .. '}'
+   str = str .. line .. b '}'
    return str
 end

--- a/init.lua
+++ b/init.lua
@@ -165,4 +165,7 @@ require('nn.SparseJacobian')
 require('nn.hessian')
 require('nn.test')
 
+nn.config = {}
+nn.config.prettyPrint = true
+
 return nn


### PR DESCRIPTION
Sometimes (see #683's *GoogLeNet*) it becomes a little messy playing with `nn.Sequential()`, `nn.Concat()` and `nn.Parallel()`. So, I thought that some colour coding would help everyone.
Pretty print can be disabled (when redirecting the std output to file, for example) by setting `nn.config.prettyPrint` to `false`.

```lua
require 'nn'
c = nn.Parallel(1,2)
for i = 1, 3 do
   local t = nn.Sequential()
   t:add(nn.Linear(4, 2))
   t:add(nn.Reshape(2, 1))
   c:add(t)
end
split = nn.Concat(2)
split:add(c)
block = nn.Sequential()
block:add(nn.View(-1))
block:add(nn.Linear(12, 4))
block:add(nn.View(2, 2))
split:add(block)

print(split)
nn.config.prettyPrint = false
print(split)
pred = split:forward(torch.randn(3, 4))
```

![screenshot 2016-03-04 15 26 51](https://cloud.githubusercontent.com/assets/2119355/13539309/96c1b6be-e21d-11e5-96a1-7f05e48cfe6c.png)