### PR TITLE
View reuses the same internal tensors

### DIFF
--- a/View.lua
+++ b/View.lua
@@ -26,8 +26,6 @@ end
 function View:__init(...)
    parent.__init(self)
    self:resetSize(...)
-   self.output = nil
-   self.gradInput = nil
    self.numInputDims = nil
 end
 
@@ -79,15 +77,15 @@ end
 function View:updateOutput(input)
    local bsz = batchsize(input, self.size, self.numInputDims, self.numElements)
    if bsz then
-      self.output = input:view(bsz, table.unpack(self.size:totable()))
+      self.output:view(input, bsz, table.unpack(self.size:totable()))
    else
-      self.output = input:view(self.size)
+      self.output:view(input, self.size)
    end
    return self.output
 end
 
 function View:updateGradInput(input, gradOutput)
-   self.gradInput = gradOutput:view(input:size())
+   self.gradInput:view(gradOutput, input:size())
    return self.gradInput
 end
 


### PR DESCRIPTION
Currently, every `forward`/`backward` creates a new tensor (which shares the same storage). 
This PR allows to keep track of the module's `output`/`gradInput`, as the tensor pointers won't change at every forward/backward pass.

I think that this behaviour should be enforced for all `nn` modules. If you agree, I can send a PR fixing this behaviour in other modules.