### PR TITLE
remove L1Penalty.clearState

### DIFF
--- a/L1Penalty.lua
+++ b/L1Penalty.lua
@@ -40,8 +40,3 @@ function L1Penalty:updateGradInput(input, gradOutput)
 
     return self.gradInput 
 end
-
-function L1Penalty:clearState()
-   if self.loss then self.loss:set() end
-   return parent.clearState(self)
-end


### PR DESCRIPTION
Calling L1Penalty's clearState resulted on an error.
The loss being a scalar, it has no .set method.

```
local loss = m*input:norm(1) 
self.loss = loss  
```
The default Module.clearState should be ok, so I simply removed the L1Penalty's override.