### PR TITLE
Cuda bug

### DIFF
--- a/LookupTable.lua
+++ b/LookupTable.lua
@@ -14,8 +14,8 @@ function LookupTable:__init(nIndex, nOutput, paddingValue)
 end
 
 function LookupTable:backCompatibility()
-   self._count = self._count or torch.IntTensor()
-   self._input = self._input or torch.LongTensor()
+   self._count = self._count:int() or torch.IntTensor()
+   self._input = self._input:long() or torch.LongTensor()
 
    if not self.shouldScaleGradByFreq then
       self.shouldScaleGradByFreq = false


### PR DESCRIPTION
This fixes a type bug where `nn.LookupTable(5, 6):forward(torch.ones(5))` works fine but `nn.LookupTable(5, 6):cuda():forward(torch.ones(5))` doesn't.