### PR TITLE
Cuda bug

### DIFF
--- a/LookupTable.lua
+++ b/LookupTable.lua
@@ -15,7 +15,7 @@ end
 
 function LookupTable:backCompatibility()
    self._count = self._count or torch.IntTensor()
-   self._input = self._input or torch.LongTensor()
+   self._input = self._input and self._input:long() or torch.LongTensor()
 
    if not self.shouldScaleGradByFreq then
       self.shouldScaleGradByFreq = false
@@ -82,6 +82,10 @@ function LookupTable:accGradParameters(input, gradOutput, scale)
        gradOutput = self._gradOutput
    end
 
+   if gradOutput:type() == 'torch.CudaTensor' then
+      input = input:cuda()
+      self._count = self._count:cuda()
+   end
    self.gradWeight.THNN.LookupTable_accGradParameters(
       input:cdata(),
       gradOutput:cdata(),


### PR DESCRIPTION
This fixes a type bug where `nn.LookupTable(5, 6):forward(torch.ones(5))` works fine but `nn.LookupTable(5, 6):cuda():forward(torch.ones(5))` doesn't.