### PR TITLE
Sparse Linear now does sparse updates from the last input

### DIFF
--- a/lib/THNN/generic/THNN.h
+++ b/lib/THNN/generic/THNN.h
@@ -355,6 +355,19 @@ TH_API void THNN_(SparseLinear_accGradParameters)(
           THTensor *bias,
           real weightDecay,
           real scale);
+TH_API void THNN_(SparseLinear_zeroGradParameters)(
+          THNNState *state,
+          THTensor *gradWeight,
+          THTensor *gradBias,
+          THTensor *lastInput);
+TH_API void THNN_(SparseLinear_updateParameters)(
+          THNNState *state,
+          THTensor *weight,
+          THTensor *bias,
+          THTensor *gradWeight,
+          THTensor *gradBias,
+          THTensor *lastInput,
+          real learningRate);
 TH_API void THNN_(SparseLinear_legacyUpdateOutput)(
           THNNState *state,
           THTensor *input,
@@ -371,12 +384,12 @@ TH_API void THNN_(SparseLinear_legacyAccGradParameters)(
           THTensor *bias,
           real weightDecay,
           real scale);
-TH_API void THNN_(SparseLinear_zeroGradParameters)(
+TH_API void THNN_(SparseLinear_legacyZeroGradParameters)(
           THNNState *state,
           THTensor *gradWeight,
           THTensor *gradBias,
           THTensor *lastInput);
-TH_API void THNN_(SparseLinear_updateParameters)(
+TH_API void THNN_(SparseLinear_legacyUpdateParameters)(
           THNNState *state,
           THTensor *weight,
           THTensor *bias,
@@ -384,7 +397,6 @@ TH_API void THNN_(SparseLinear_updateParameters)(
           THTensor *gradBias,
           THTensor *lastInput,
           real learningRate);
-TH_API void THNN_(SparseLinear_cudaClearState)(THNNState *state);
 
 TH_API void THNN_(Sqrt_updateOutput)(
           THNNState *state,


### PR DESCRIPTION
See dicussion @ #698 

Speeds up updateGradParameters and zeroGradParameters when one forward/backward update has been run by keeping track of the immediately previous input.

The follow snippet

    local nn = require('nn')
    local sys = require('sys')

    local model = nn.SparseLinear(65536, 256)

    local input = torch.rand(5, 2)
    input:select(2, 1):mul(65536):ceil()

    sys.tic()
    local output = model:forward(input)
    sys.toc(true)

    local gradOutput = torch.rand(output:size())

    sys.tic()
    local gradInput = model:backward(input, gradOutput)
    sys.toc(true)

    sys.tic()
    model:updateParameters(1e-3)
    sys.toc(true)

    sys.tic()
    model:zeroGradParameters()
    sys.toc(true)

 gives us

    0.00010514259338379	
    6.2942504882812e-05	
    5.6028366088867e-05	
    4.6968460083008e-05