### PR TITLE
Reuse same state tensors on forward/backward

### DIFF
--- a/DotProduct.lua
+++ b/DotProduct.lua
@@ -48,8 +48,8 @@ function DotProduct:updateGradInput(input, gradOutput)
 
    if not_batch then
       -- unbatch gradInput
-      self.gradInput[1] = gw1:select(1,1)
-      self.gradInput[2] = gw2:select(1,1)
+      self.gradInput[1]:set(gw1:select(1,1))
+      self.gradInput[2]:set(gw2:select(1,1))
    end
 
    return self.gradInput

--- a/Max.lua
+++ b/Max.lua
@@ -29,9 +29,9 @@ function Max:updateOutput(input)
    local dimension = self:_getPositiveDimension(input)
    torch.max(self._output, self._indices, input, dimension)
    if input:dim() > 1 then
-     self.output = self._output:select(dimension, 1)
+     self.output:set(self._output:select(dimension, 1))
    else
-     self.output = self._output
+     self.output:set(self._output)
    end
    return self.output
 end

--- a/Min.lua
+++ b/Min.lua
@@ -29,9 +29,9 @@ function Min:updateOutput(input)
    local dimension = self:_getPositiveDimension(input)
    torch.min(self._output, self._indices, input, dimension)
    if input:dim() > 1 then
-     self.output = self._output:select(dimension, 1)
+     self.output:set(self._output:select(dimension, 1))
    else
-     self.output = self._output
+     self.output:set(self._output)
    end
    return self.output
 end

--- a/Normalize.lua
+++ b/Normalize.lua
@@ -42,7 +42,7 @@ function Normalize:updateOutput(input)
   end
   self._output:cdiv(input, self.norm:view(-1,1):expandAs(input))
 
-  self.output = self._output:view(input_size)
+  self.output:view(self._output, input_size)
   return self.output
 end
 
@@ -111,7 +111,7 @@ function Normalize:updateGradInput(input, gradOutput)
   end
   self._gradInput:cdiv(self.cross:expand(n,d))
 
-  self.gradInput = self._gradInput:view(input_size)
+  self.gradInput:view(self._gradInput, input_size)
   return self.gradInput
 end
 

--- a/PartialLinear.lua
+++ b/PartialLinear.lua
@@ -48,7 +48,7 @@ function PartialLinear:parameters()
 end  -- should return only the relevant partition?
 
 function PartialLinear:updateOutput(input)
-   self.output = self.network:forward{input, self.partition}
+   self.output:set(self.network:forward{input, self.partition})
    if self.bias then
       self.output:add(
          self.bias:index(2, self.partition:long()):expandAs(self.output)
@@ -64,7 +64,7 @@ end
 function PartialLinear:updateGradInput(input, gradOutput)
    if self.gradInput then
       self.network:updateGradInput({input, self.partition}, gradOutput)
-      self.gradInput = self.network.gradInput[1]
+      self.gradInput:set(self.network.gradInput[1])
    end
    return self.gradInput
 end

--- a/Replicate.lua
+++ b/Replicate.lua
@@ -34,7 +34,7 @@ function Replicate:updateOutput(input)
       end
       st[i+offset] = input:stride(i)
    end
-   self.output = input.new(input:storage(),input:storageOffset(),sz,st)
+   self.output:set(input:storage(),input:storageOffset(),sz,st)
    return self.output
 end
 

--- a/Sum.lua
+++ b/Sum.lua
@@ -29,7 +29,7 @@ function Sum:updateOutput(input)
         self.output:div(input:size(dimension))
     end
     if self.output:nDimension() > 1 then
-        self.output = self.output:select(dimension, 1)
+        self.output:set(self.output:select(dimension, 1))
     end
     return self.output
 end


### PR DESCRIPTION
Do not create new `output`/`gradInput` tensors at every function call of `forward`/`backward`, as discussed in https://github.com/torch/nn/pull/712.

`nn.Unsqueeze` is missing in this PR, because we need to change the behaviour of `addSingletonDimension` to accept a result tensor (as done by `torch.view`). Will change both in a separate PR.