### PR TITLE
Unsqueeze reuse same state tensors

### DIFF
--- a/Unsqueeze.lua
+++ b/Unsqueeze.lua
@@ -18,7 +18,7 @@ end
 function Unsqueeze:updateOutput(input)
    _assertTensor(input)
    local actualPos = self:_getActualPosition(input)
-   self.output = nn.utils.addSingletonDimension(input, actualPos)
+   nn.utils.addSingletonDimension(self.output, input, actualPos)
    return self.output
 end
 
@@ -27,7 +27,7 @@ function Unsqueeze:updateGradInput(input, gradOutput)
    _assertTensor(gradOutput)
    assert(input:nElement() == gradOutput:nElement())
 
-   self.gradInput = gradOutput:view(input:size())
+   self.gradInput:view(gradOutput, input:size())
    return self.gradInput
 end
 

--- a/test.lua
+++ b/test.lua
@@ -5577,6 +5577,18 @@ function nntest.addSingletonDimension()
 
    mytester:assertError(function() nn.utils.addSingletonDimension(tensor, dims + 2) end,
                         "invalid dimension not detected")
+
+   -- passing output tensor as argument
+   local resultArg = torch.Tensor()
+   local resultR = nn.utils.addSingletonDimension(resultArg, tensor, dim)
+   mytester:eq(resultArg:size():totable(), resultSize,
+               'wrong content for random singleton dimention '..
+               'when the result is passed as argument')
+   mytester:eq(resultArg, result, 'wrong content for random singleton dimention '..
+               'when the result is passed as argument')
+
+   mytester:eq(resultR == resultArg, true,
+               'new tensor is created when it should use the provided tensor')
 end
 
 function nntest.SpatialReflectionPadding()

--- a/utils.lua
+++ b/utils.lua
@@ -130,13 +130,22 @@ function nn.utils.recursiveAdd(t1, val, t2)
    return t1, t2
 end
 
-function nn.utils.addSingletonDimension(t, dim)
+function nn.utils.addSingletonDimension(...)
+  local view, t, dim
+  if select('#',...) < 3 then
+    t, dim = select(1,...)
+  else
+    view, t, dim = select(1,...)
+    assert(torch.isTensor(view),
+           "output tensor expected, got " .. type(view))
+  end
+
   assert(torch.isTensor(t), "input tensor expected")
-  local dim = dim or 1
+  dim = dim or 1
   assert(dim > 0 and dim <= (t:dim() + 1), "invalid dimension: " .. dim
              .. '. Tensor is of ' .. t:dim() .. ' dimensions.')
 
-  local view = t.new()
+  view = view or t.new()
   local size = torch.LongStorage(t:dim() + 1)
   local stride = torch.LongStorage(t:dim() + 1)
 


### PR DESCRIPTION
Extend `nn.utils.addSingletonDimension` to accept a result tensor as argument.
Add tests for the new case.