### PR TITLE
Change display order in VolumetricFullConvolution

### DIFF
--- a/VolumetricFullConvolution.lua
+++ b/VolumetricFullConvolution.lua
@@ -151,15 +151,15 @@ end
 
 function VolumetricFullConvolution:__tostring__()
    local s = string.format('%s(%d -> %d, %dx%dx%d', torch.type(self),
-   self.nInputPlane, self.nOutputPlane, self.kW, self.kH, self.kT)
-   if self.dW ~= 1 or self.dH ~= 1 or self.dT ~= 1 or self.padW ~= 0 or self.padH ~= 0 or self.padT ~= 0 then
-      s = s .. string.format(', %d,%d,%d', self.dW, self.dH, self.dT)
+   self.nInputPlane, self.nOutputPlane, self.kT, self.kW, self.kH)
+   if self.dT ~= 1 or self.dW ~= 1 or self.dH ~= 1 or self.padT ~= 0 or self.padW ~= 0 or self.padH ~= 0 then
+      s = s .. string.format(', %d,%d,%d', self.dT, self.dW, self.dH)
    end
-   if (self.padW or self.padH or self.padT) and (self.padW ~= 0 or self.padH ~= 0 or self.padT ~= 0) then
-      s = s .. ', ' .. self.padW .. ',' .. self.padH .. ',' .. self.padT
+   if (self.padT or self.padW or self.padH) and (self.padT ~= 0 or self.padW ~= 0 or self.padH ~= 0) then
+      s = s .. ', ' .. self.padT .. ',' .. self.padW .. ',' .. self.padH
    end
-   if (self.adjW or self.adjH or self.adjT) and (self.adjW ~= 0 or self.adjH ~= 0 or self.adjT ~= 0) then
-      s = s .. ', ' .. self.adjW .. ',' .. self.adjH .. ',' .. self.adjT
+   if (self.adjT or self.adjW or self.adjH) and (self.adjT ~= 0 or self.adjW ~= 0 or self.adjH ~= 0) then
+      s = s .. ', ' .. self.adjT .. ',' .. self.adjW .. ',' .. self.adjH
    end
    return s .. ')'
 end


### PR DESCRIPTION
Ideally while displaying the *kernel* (and likewise for *padding*, etc.), it should be of the format `kT x kW x kH`, as in the [doc](https://github.com/torch/nn/blob/master/doc/convolution.md#nn.VolumetricFullConvolution) or normal [VolumetricConvolution](https://github.com/kmul00/nn/blob/master/VolumetricConvolution.lua#L184-L194).

Here it was of the format `kW x kH x kT`. This caused confusion to me while creating a model and thought it might to others as well.