### PR TITLE
Removed missing link from documentation

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -76,8 +76,7 @@ mlp:add( nn.Linear(25, 1) ) -- 1 output
 
 Of course, `Sequential` and `Concat` can contains other
 `Sequential` or `Concat`, allowing you to try the craziest neural
-networks you ever dreamt of! See the [[#nn.Modules|complete list of
-available modules]].
+networks you ever dreamt of!
 
 <a name="nn.overview.training"></a>
 ### Training a neural network ###


### PR DESCRIPTION
The documentation file overview.md has a broken link to `complete list of available modules`. Since no such consolidated list appears in the documentation files, I removed the link. The link may be added back only when we have such a consolidated list of modules in the documentation.