### PR TITLE
[LookupTable] Add Max-norm constraints to LookupTable

### DIFF
--- a/LookupTable.lua
+++ b/LookupTable.lua
@@ -3,12 +3,14 @@ local LookupTable, parent = torch.class('nn.LookupTable', 'nn.Module')
 
 LookupTable.__version = 4
 
-function LookupTable:__init(nIndex, nOutput, paddingValue)
+function LookupTable:__init(nIndex, nOutput, paddingValue, maxNorm, normType)
    parent.__init(self)
 
    self.weight = torch.Tensor(nIndex, nOutput)
    self.gradWeight = torch.Tensor(nIndex, nOutput):zero()
    self.paddingValue = paddingValue or 0
+   self.maxNorm = maxNorm or nil
+   self.normType = normType or nil
 
    self:reset()
 end
@@ -28,8 +30,18 @@ function LookupTable:accUpdateOnly()
 end
 
 function LookupTable:setPadding(paddingValue)
-    self.paddingValue = paddingValue
-    return self
+   self.paddingValue = paddingValue
+   return self
+end
+
+function LookupTable:setMaxNorm(maxNorm)
+   self.maxNorm = maxNorm
+   return self
+end
+
+function LookupTable:setNormType(normType)
+   self.normType = normType
+   return self
 end
 
 function LookupTable:scaleGradByFreq()
@@ -55,6 +67,7 @@ end
 
 function LookupTable:updateOutput(input)
    self:backCompatibility()
+   self:renorm(input)
    input = self:makeInputContiguous(input)
    if input:dim() == 1 then
       self.output:index(self.weight, 1, input)
@@ -77,9 +90,9 @@ function LookupTable:accGradParameters(input, gradOutput, scale)
    end
 
    if not gradOutput:isContiguous() then
-       self._gradOutput = self._gradOutput or gradOutput.new()
-       self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
-       gradOutput = self._gradOutput
+      self._gradOutput = self._gradOutput or gradOutput.new()
+      self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
+      gradOutput = self._gradOutput
    end
 
    self.gradWeight.THNN.LookupTable_accGradParameters(
@@ -92,6 +105,28 @@ function LookupTable:accGradParameters(input, gradOutput, scale)
       self.shouldScaleGradByFreq or false,
       self.paddingValue or 0,
       scale or 1
+   )
+end
+
+function LookupTable:renorm(input)
+   if not self.maxNorm then
+      return
+   end
+   -- copy input into _input, so _input is continous.
+   -- The copied _input will be modified in the C code.
+   self._input:resize(input:size()):copy(input)
+   local row_idx = self._input
+   if row_idx:dim() == 2 then
+      row_idx = row_idx:view(-1)
+   elseif row_idx:dim() ~= 1 then
+      error("input must be a vector or matrix")
+   end
+   -- "row_idx" and "weight" will be modified in the C code
+   self.weight.THNN.LookupTable_renorm(
+      row_idx:cdata(),
+      self.weight:cdata(),
+      self.maxNorm,
+      self.normType or 2
    )
 end
 

--- a/lib/THNN/generic/LookupTable.c
+++ b/lib/THNN/generic/LookupTable.c
@@ -116,4 +116,98 @@ void THNN_(LookupTable_accGradParameters)(
   THTensor_(free)(gradOutput);
 }
 
+/*
+ * Keep the norm of weight smaller than maxNorm
+ */
+
+static void THNN_(LookupTable_renormRow)(
+          real *row_data,
+          long stride,
+          real maxNorm,
+          real normType)
+{
+  real norm = 0;
+  real new_norm;
+  long j;
+  for (j=0; j<stride; j++)
+  {
+    if (normType == 1) {
+      norm += fabs(row_data[j]);
+    } else if (normType == 2) {
+      norm += row_data[j] * row_data[j];
+    } else {
+      norm += pow(fabs(row_data[j]), normType);
+    }
+  }
+  norm = pow(norm, 1.0 / normType);
+  if (norm > maxNorm)
+  {
+    new_norm = maxNorm / (norm + 1e-7);
+    for (j=0; j<stride; j++) {
+      row_data[j] *= new_norm;
+    }
+  }
+}
+
+static int THNN_(compare_THIndex)(const void* a, const void* b)
+{
+   return *(const THIndex_t*)a < *(const THIndex_t*)b ? -1 : 1;
+}
+
+void THNN_(LookupTable_renorm)(
+          THNNState *state,
+          THIndexTensor *idx,
+          THTensor *weight,
+          real maxNorm,
+          real normType)
+{
+  if (!THTensor_(isContiguous)(weight))
+    THError("weight must be contiguous");
+  if (!THIndexTensor_(isContiguous)(idx))
+    THError("input must be contiguous");
+  if (THIndexTensor_(nDimension)(idx) != 1)
+    THError("idx must be a vector");
+  if (normType <= 0)
+    THError("non-positive-norm not supported");
+
+  long i;
+  THIndex_t *row_idx = THIndexTensor_(data)(idx);
+  long numel = THIndexTensor_(nElement)(idx);
+
+  long numw = THTensor_(size)(weight, 0);
+  long stride = THTensor_(stride)(weight, 0);
+  real *gw = THTensor_(data)(weight);
+  for (i=0; i<numel; i++)
+    if (row_idx[i] < 1 || row_idx[i] > numw)
+      THError("input out of range");
+  // get unique indices
+  qsort(row_idx, numel, sizeof(THIndex_t), THNN_(compare_THIndex));
+  long ptr = 0;
+  for (i=0; i<numel; i++)
+    if (i == 0 || row_idx[i] != row_idx[i-1])
+      row_idx[ptr++] = row_idx[i];
+  numel = ptr;
+
+#ifdef _OPENMP
+  if (numel > 1000)
+  {
+    // The strategy is to parallelize over the rows that appear in
+    // row_idx, so that thread 1 handles the rows in row_idx[0..numel/nThreads].
+    // This distributes the work evenly to each thread.
+    #pragma omp parallel for private(i)
+    for (i=0; i<numel; i++)
+    {
+      long k = row_idx[i] - 1;
+      THNN_(LookupTable_renormRow)(gw + k*stride, stride, maxNorm, normType);
+    }
+    return;
+  }
+#endif
+  for (i=0; i<numel; i++)
+  {
+    long k = row_idx[i] - 1;
+    THNN_(LookupTable_renormRow)(gw + k*stride, stride, maxNorm, normType);
+  }
+}
+
 #endif

--- a/lib/THNN/generic/THNN.h
+++ b/lib/THNN/generic/THNN.h
@@ -157,6 +157,13 @@ TH_API void THNN_(LookupTable_accGradParameters)(
           int paddingValue,
           real scale);
 
+TH_API void THNN_(LookupTable_renorm)(
+          THNNState *state,            // library's state
+          THIndexTensor *idx,          // vector that contains row indices (modified in function)
+          THTensor *weight,            // 2D tensor whose rows will be renormalized
+          real maxNorm,                // maximum norm
+          real normType);              // the norm type (e.g., normType=2, then it's 2-norm)
+
 TH_API void THNN_(MarginCriterion_updateOutput)(
           THNNState *state,            // library's state
           THTensor *input,             // input tensor

--- a/test.lua
+++ b/test.lua
@@ -4209,6 +4209,43 @@ function nntest.LookupTable()
    end
    local err = padw_sum - padw:sum()
    mytester:assertlt(err,precision, 'padding update error ')
+   -- test whether the weights changes accordingly when maxNorm is not nil
+   local all_index = torch.randperm(totalIndex):int()
+   -- input can have duplicates
+   local input = torch.repeatTensor(all_index:narrow(1,1,nIndex), 2)
+   local maxNorm = math.random()
+   for _, normType in ipairs{1, 2, math.random()} do
+      local module = nn.LookupTable(totalIndex, entry_size, 0, maxNorm, normType)
+      local oriW = module.weight:clone()
+      output = module:updateOutput(input)
+      -- check output is of small norm
+      for j = 1,output:size(1) do
+         local norm = torch.norm(output:select(1, j), normType)
+         if norm > maxNorm then
+            local err = norm - maxNorm;
+            mytester:assertlt(math.abs(err), precision, string.format(
+               'output after renorm exceeds maxNorm=[%f] with normType=[%f]', maxNorm, normType))
+         end
+      end
+      -- check the update of the module.weight
+      for j = 1,totalIndex do
+         local k = all_index[j]
+         if j <= nIndex then -- k is an index in "input"
+            local norm = torch.norm(module.weight:select(1, k), normType)
+            local oriNorm = torch.norm(oriW:select(1, k), normType)
+            if oriNorm > maxNorm then
+               local err = norm - maxNorm
+               mytester:assertlt(math.abs(err), precision, 'unexpected norm after renorm')
+            else
+               local err = norm - oriNorm
+               mytester:assertlt(math.abs(err), precision, 'unpexpected norm after renorm')
+            end
+         else -- k is not an index in "input"
+            local err = module.weight:select(1,k):sum() - oriW:select(1,k):sum()
+            mytester:assertlt(math.abs(err), precision, 'unexpected changes in weight after renorm')
+         end
+      end
+   end
 end
 
 function nntest.AddConstant()


### PR DESCRIPTION
Add the ability to this module to have a fixed maximum norm, i.e., no word embedding (a row in the module weight) can have [normValue]-norm > maxNorm (e.g., 2-norm > 1). The constraint is enforced in the forward pass (rows that are accessed are re-normalized), so that the output always obeys the max-norm constraint.
