### PR TITLE
Use torch.tic instead of os.time for seeding

### DIFF
--- a/test.lua
+++ b/test.lua
@@ -5819,7 +5819,7 @@ else
    sjac = nn.SparseJacobian
    function nn.test(tests, seed)
       -- randomize stuff
-      local seed = seed or os.time()
+      local seed = seed or (1e5 * torch.tic())
       print('Seed: ', seed)
       math.randomseed(seed)
       torch.manualSeed(seed)


### PR DESCRIPTION
For tracking down flaky tests (bugs/timeouts that occur stochastically depending on randomly chosen inputs) I sometimes start tens or hundreds of runs of the tests at once (within a few seconds). Since os.time() has second precision, this usually gives me only very few really different seeds - with torch.tic() many more different seeds can be generated in a short time window. 