### PR TITLE
Add MaskedSelect.lua module to replicate torch.maskedSelect behaviour.

### DIFF
--- a/MaskedSelect.lua
+++ b/MaskedSelect.lua
@@ -1,0 +1,71 @@
+local unpack = unpack or table.unpack
+
+local MaskedSelect, parent = torch.class('nn.MaskedSelect', 'nn.Module')
+
+--[[ Sets the provided mask value for the module. ]]
+function MaskedSelect:__init()
+  parent.__init(self)
+  self._maskIndices = torch.LongTensor()
+  self._maskIndexBuffer = torch.LongTensor()
+  self._maskIndexBufferCPU = torch.FloatTensor()
+  self._gradBuffer = torch.Tensor()
+  self._gradMask = torch.ByteTensor()
+end
+
+--[[ Performs maskedSelect operation. ]]
+function MaskedSelect:updateOutput(input)
+  local input, mask = unpack(input)
+  self.output:maskedSelect(input, mask)
+  return self.output
+end
+
+--[[ Reverse maps unmasked gradOutput back to gradInput. ]]
+function MaskedSelect:updateGradInput(input, gradOutput)
+  local input, mask = unpack(input)
+  if input:type() == 'torch.CudaTensor' then
+    self._maskIndexBufferCPU:range(1, mask:nElement()):resize(mask:size())
+    self._maskIndexBuffer:resize(
+      self._maskIndexBufferCPU:size()):copy(self._maskIndexBufferCPU)
+  else
+    self._maskIndexBuffer:range(1, mask:nElement()):resize(mask:size())
+  end
+  self._maskIndices:maskedSelect(self._maskIndexBuffer, mask)
+  self._gradBuffer:resize(input:nElement()):zero()
+  self._gradBuffer:scatter(1, self._maskIndices, gradOutput)
+  self._gradBuffer:resize(input:size())
+  self.gradInput = {self._gradBuffer,
+                    self._gradMask:resize(mask:size()):fill(0)}
+  return self.gradInput
+end
+
+function MaskedSelect:type(type, tensorCache)
+  if not type then
+    return self._type
+  end
+  self._gradBuffer = self._gradBuffer:type(type)
+  self.gradInput = self.gradInput:type(type)
+  self.output = self.output:type(type)
+
+  -- These casts apply when switching between cuda/non-cuda types
+  if type ~= 'torch.CudaTensor' then
+    self._maskIndexBuffer = self._maskIndexBuffer:long()
+    self._maskIndices = self._maskIndices:long()
+    self._gradMask = self._gradMask:byte()
+  elseif  type == 'torch.CudaTensor' then
+    self._maskIndexBuffer = self._maskIndexBuffer:cuda()
+    self._maskIndices = self._maskIndices:cuda()
+    self._gradMask = self._gradMask:cuda()
+  end
+  self._type = type
+  return self
+end
+
+function MaskedSelect:clearState()
+  return nn.utils.clear(self, {'output',
+                               'gradInput',
+                               '_maskIndexBuffer',
+                               '_maskIndexBufferCPU',
+                               '_maskIndices',
+                               '_gradBuffer',
+                               '_gradMask'})
+end

--- a/doc/simple.md
+++ b/doc/simple.md
@@ -21,6 +21,7 @@ Simple Modules are used for various tasks like adapting Tensor methods and provi
     * [View](#nn.View) : a [view](https://github.com/torch/torch7/blob/master/doc/tensor.md#result-viewresult-tensor-sizes) of the inputs ;
     * [Contiguous](#nn.Contiguous) : [contiguous](https://github.com/torch/torch7/blob/master/doc/tensor.md#tensor-contiguous) of the inputs ;
     * [Select](#nn.Select) : a [select](https://github.com/torch/torch7/blob/master/doc/tensor.md#tensor-selectdim-index) over a given dimension ;
+    * [MaskedSelect](#nn.MaskedSelect) : a [masked select](https://github.com/torch/torch7/blob/master/doc/tensor.md#tensor-maskedselect-index) module performs the torch.maskedSelect operation ;
     * [Index](#nn.Index) : a [index](https://github.com/torch/torch7/blob/master/doc/tensor.md#tensor-indexdim-index) over a given dimension ;
     * [Squeeze](#nn.Squeeze) : [squeezes](https://github.com/torch/torch7/blob/master/doc/tensor.md#tensor-squeezedim) the input;
     * [Unsqueeze](#nn.Unsqueeze) : unsqueeze the input, i.e., insert singleton dimension;  
@@ -901,6 +902,49 @@ for i = 1, 10000 do     -- Train for a few iterations
    mlp:updateParameters(0.01)
    print(err)
 end
+```
+
+<a name="nn.MaskedSelect"></a>
+## MaskedSelect ##
+
+```lua
+module = nn.MaskedSelect()
+```
+
+Performs a [torch.MaskedSelect](https://github.com/torch/torch7/blob/master/doc/tensor.md#tensor-maskedselectmask) on a Tensor.  The mask is supplied as a tabular argument with the input on the forward and backward passes.
+
+Example:
+
+```lua
+ms = nn.MaskedSelect()
+mask = torch.ByteTensor({{1, 0}, {0, 1}})
+input = torch.DoubleTensor({{10, 20}, {30, 40}})
+print(input)
+print(mask)
+out = ms:forward({input, mask})
+print(out)
+gradIn = ms:backward({input, mask}, out)
+print(gradIn[1])
+```
+
+Gives the output:
+
+```lua
+10  20
+30  40
+[torch.DoubleTensor of size 2x2]
+
+1  0
+0  1
+[torch.ByteTensor of size 2x2]
+
+10
+40
+[torch.DoubleTensor of size 2]
+
+10  0
+0  40
+[torch.DoubleTensor of size 2x2]
 ```
 
 <a name="nn.Index"></a>

--- a/init.lua
+++ b/init.lua
@@ -33,6 +33,7 @@ require('nn.Transpose')
 require('nn.BatchNormalization')
 require('nn.Padding')
 require('nn.GradientReversal')
+require('nn.MaskedSelect')
 
 require('nn.Copy')
 require('nn.Min')

--- a/test.lua
+++ b/test.lua
@@ -1306,6 +1306,24 @@ function nntest.MarginRankingCriterion()
 
 end
 
+function nntest.MaskedSelect()
+   local input = torch.randn(4, 5)
+   local mask = torch.ByteTensor(4, 5):bernoulli()
+   local module = nn.MaskedSelect()
+   local out = module:forward({input, mask})
+   local err = out:dist(input:maskedSelect(mask))
+   mytester:assertlt(err, 1e-15, torch.typename(module) .. ' - forward err ')
+
+   local gradOut = torch.Tensor({20, 80})
+   input = torch.Tensor({{10, 20}, {30, 40}})
+   local inTarget = torch.Tensor({{20, 0}, {0, 80}})
+   local mask = torch.ByteTensor({{1, 0}, {0, 1}})
+   local module = nn.MaskedSelect()
+   module:forward({input, mask})
+   local gradIn = module:backward({input, mask}, gradOut)
+   mytester:assertTensorEq(inTarget, gradIn[1], 1e-15, torch.typename(module) .. ' - backward err ')
+end
+
 function nntest.ParallelCriterion()
    local input = {torch.rand(2,10), torch.randn(2,10)}
    local target = {torch.IntTensor{1,8}, torch.randn(2,10)}


### PR DESCRIPTION
Add MaskedSelect module which emulates the bahaviour of torch.Tensor():maskedSelect().

e.g.
```
> ms = nn.MaskedSelect()
> mask = torch.randn(2,2):bernoulli():byte()
> input = torch.randn(2,2)
> =mask
 0  0
 1  0
[torch.ByteTensor of size 2x2]

> =input
 0.6046  1.3675
 0.2091 -1.9718
[torch.DoubleTensor of size 2x2]

> out = ms:forward({input, mask})
> =out
 0.2091
[torch.DoubleTensor of size 1]

>  gradIn = ms:backward({input, mask}, out)
> =gradIn
{
  1 : DoubleTensor - size: 2x2
  2 : ByteTensor - size: 2x2
}
> return gradIn[1]
 0.0000  0.0000
 0.2091  0.0000
[torch.DoubleTensor of size 2x2]

> return gradIn[2]
 0  0
 0  0
[torch.ByteTensor of size 2x2]

```