### PR TITLE
[DistKLDivCriterion] Add assertions on target size

### DIFF
--- a/DistKLDivCriterion.lua
+++ b/DistKLDivCriterion.lua
@@ -6,6 +6,9 @@ function DistKLDivCriterion:__init()
 end
 
 function DistKLDivCriterion:updateOutput(input, target)
+   assert(input:dim() == target:dim() and
+      torch.LongTensor(input:size()):eq(torch.LongTensor(target:size())):all(),
+      'input and target should have the same size')
    self.output_tensor = self.output_tensor or input.new(1)
    input.THNN.DistKLDivCriterion_updateOutput(
       input:cdata(),
@@ -18,6 +21,9 @@ function DistKLDivCriterion:updateOutput(input, target)
 end
 
 function DistKLDivCriterion:updateGradInput(input, target)
+   assert(input:dim() == target:dim() and
+      torch.LongTensor(input:size()):eq(torch.LongTensor(target:size())):all(),
+      'input and target should have the same size')
    input.THNN.DistKLDivCriterion_updateGradInput(
       input:cdata(),
       target:cdata(),


### PR DESCRIPTION
In contrast to many other criterions, `DistKLDivCriterion` requires the size of `target` to be the same as that of `input` (for obvious reasons). In case you do this wrong (which can easily happen), there is currently no informative error message but only a failure in the CUDA-code. This diff adds assertions on the `input` and `target` size.