### PR TITLE
add argument passing to module typing shortcuts

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -130,16 +130,16 @@ function Module:type(type, tensorCache)
    return self
 end
 
-function Module:float()
-   return self:type('torch.FloatTensor')
+function Module:float(...)
+   return self:type('torch.FloatTensor',...)
 end
 
-function Module:double()
-   return self:type('torch.DoubleTensor')
+function Module:double(...)
+   return self:type('torch.DoubleTensor',...)
 end
 
-function Module:cuda()
-   return self:type('torch.CudaTensor')
+function Module:cuda(...)
+   return self:type('torch.CudaTensor',...)
 end
 
 function Module:reset()

--- a/doc/module.md
+++ b/doc/module.md
@@ -232,19 +232,19 @@ nn.utils.recursiveType({mlp1, mlp2}, 'torch.FloatTensor')
 ```
 
 <a name="nn.Module.float"></a>
-### float() ###
+### float([tensorCache]) ###
 
-Convenience method for calling [module:type('torch.FloatTensor')](#nn.Module.type)
+Convenience method for calling [module:type('torch.FloatTensor'[, tensorCache])](#nn.Module.type)
 
 <a name="nn.Module.double"></a>
-### double() ###
+### double([tensorCache]) ###
 
-Convenience method for calling [module:type('torch.DoubleTensor')](#nn.Module.type)
+Convenience method for calling [module:type('torch.DoubleTensor'[, tensorCache])](#nn.Module.type)
 
 <a name="nn.Module.cuda"></a>
-### cuda() ###
+### cuda([tensorCache]) ###
 
-Convenience method for calling [module:type('torch.CudaTensor')](#nn.Module.type)
+Convenience method for calling [module:type('torch.CudaTensor'[, tensorCache])](#nn.Module.type)
 
 <a name="nn.statevars.dok"></a>
 ### State Variables ###


### PR DESCRIPTION
Hi all.
Until now, to change the type of modules sharing parameters, you had to do:

```
m1 = nn.Linear(5,5)
m2 = m1:clone('weight', 'gradWeight')

t = {}
newType = 'torch.CudaTensor'
m1:type(newType, t)
m2:type(newType, t)
```

The following code did not work : 

```
t = {}
m1:cuda(t)
m2:cuda(t)
```

I propose to change the shortcut functions signature so that the previous code work.

Clément.