### PR TITLE
fix for nn.Index backprop

### DIFF
--- a/Index.lua
+++ b/Index.lua
@@ -3,7 +3,7 @@ local Index, parent = torch.class('nn.Index', 'nn.Module')
 function Index:__init(dimension)
     parent.__init(self)
     self.dimension = dimension
-    self.gradInput = {self.gradInput}
+    self.gradInput = {self.gradInput, self.gradInput:clone()}
 end
 
 function Index:updateOutput(input)
@@ -17,6 +17,7 @@ function Index:updateGradInput(input, gradOutput)
     local t = input[1]
     local index = input[2]
 
+    self.gradInput[2]:resizeAs(index):zero()
     local gradInput = self.gradInput[1] -- no gradient for the index variable
     gradInput:resizeAs(t):zero()
     gradInput:indexAdd(self.dimension, index, gradOutput)


### PR DESCRIPTION
:backward() was not working when having a nested nn.Index() as there was no gradInput corresponding to the second argument (== the index).