### PR TITLE
delete an assertion in batchnormalization

### DIFF
--- a/BatchNormalization.lua
+++ b/BatchNormalization.lua
@@ -125,7 +125,6 @@ end
 local function backward(self, input, gradOutput, scale, gradInput, gradWeight, gradBias)
    self:checkInputDim(input)
    self:checkInputDim(gradOutput)
-   assert(self.train == true, 'should be in training mode when self.train is true')
    assert(self.save_mean and self.save_std, 'must call :updateOutput() first')
 
    input, gradOutput = makeContiguous(self, input, gradOutput)


### PR DESCRIPTION
Hi all,

This assertion is not really necessary and it prevents doing back-propagation to input (computing the derivative of loss w.r.t. the input image).