### PR TITLE
SparseLinear: gradInput should be a table by default

### DIFF
--- a/SparseLinear.lua
+++ b/SparseLinear.lua
@@ -22,7 +22,7 @@ function SparseLinear:__init(inputSize, outputSize, doGradInput)
    self.formatted_input = nil
 
    -- state
-   self.gradInput:resize(inputSize)
+   self.gradInput = {}
    self.output:resize(outputSize)
 
    self:reset()


### PR DESCRIPTION
Making gradInput an empty table by default in the SparseLinear module.

It's unnecessary to allocate a tensor since updateGradInput will do that if necessary (that is, if in legacy mode).