### PR TITLE
Adding hyper-parameter lambda to GradientReversal module

### DIFF
--- a/GradientReversal.lua
+++ b/GradientReversal.lua
@@ -1,4 +1,14 @@
-local GradientReversal = torch.class('nn.GradientReversal', 'nn.Module')
+local GradientReversal, parent = torch.class('nn.GradientReversal', 'nn.Module')
+
+function GradientReversal:__init(lambda)
+   lambda = lambda or 1
+   parent.__init(self)
+   self.lambda = lambda
+end
+
+function GradientReversal:setLambda(lambda)
+  self.lambda = lambda
+end
 
 function GradientReversal:updateOutput(input)
    self.output:set(input)
@@ -8,6 +18,6 @@ end
 function GradientReversal:updateGradInput(input, gradOutput)
    self.gradInput:resizeAs(gradOutput)
    self.gradInput:copy(gradOutput)
-   self.gradInput:mul(-1)
+   self.gradInput:mul(-self.lambda)
    return self.gradInput
 end

--- a/doc/simple.md
+++ b/doc/simple.md
@@ -1313,6 +1313,13 @@ criterion = nn.MSECriterion()  -- To measure reconstruction error
 <a name="nn.GradientReversal"></a>
 ## GradientReversal ##
 
-`module` = `nn.GradientReversal()`
+```lua
+module = nn.GradientReversal([lambda = 1])
+```
+This module preserves the input, but takes the gradient from the subsequent layer, multiplies it by `-lambda` and passes it to the preceding layer. This can be used to maximise an objective function whilst using gradient descent, as described in "Domain-Adversarial Training of Neural Networks" (http://arxiv.org/abs/1505.07818).
 
-This module preserves the input, but reverses the gradient. This can be used to maximise an objective function whilst using gradient descent, as in "Domain-Adversarial Training of Neural Networks" (http://arxiv.org/abs/1505.07818).
+One can also call:
+```lua
+module:setLambda(lambda)
+```
+to set the hyper-parameter `lambda` dynamically during training.


### PR DESCRIPTION
Added the hyper-parameter lambda for the Gradient Reversal Layer as described in the original paper.

This allows the user to control how much gradient one would like to propagate back to the preceding layers, and it is also possible to set different values for lambda at various stages during training, which is also adopted in the original paper.