### PR TITLE
easy individual learning rates for modules

### DIFF
--- a/Module.lua
+++ b/Module.lua
@@ -28,6 +28,9 @@ end
 
 function Module:backward(input, gradOutput, scale)
    scale = scale or 1
+   if self.learningRate ~= nil then
+      scale = scale * self.learningRate
+   end
    self:updateGradInput(input, gradOutput)
    self:accGradParameters(input, gradOutput, scale)
    return self.gradInput


### PR DESCRIPTION
Something we miss from the Caffe world is the ability to easily set individual learning rates for different layers. There are a variety of tricks floating around to freeze weights (by overwriting accGradParameters), or have different learning rates by having different optim calls. These got very messy for us, and difficult to debug, for very complex networks.

What about making this more explicit? After this patch, you would be able to do this:

```lua
require 'nn'

mod = nn.Linear(1,1)
mod.weight:fill(1)
mod.bias:fill(0)
mod.learningRate = 0 -- here lies the change

data = torch.ones(1,1)
grad = torch.ones(1,1)

mod:forward(data)
mod:backward(data,grad)
mod:updateParameters(1)

print(mod.weight) -- outputs 1, because learningRate is 0
```

There is another performance optimization where if learningRate == 0, then you don't have to call accGradParameters. But, that change may be dangerous, so I didn't do it.

Thoughts?