### PR TITLE
nn.Select support for negative indices

### DIFF
--- a/Select.lua
+++ b/Select.lua
@@ -7,14 +7,16 @@ function Select:__init(dimension,index)
 end
 
 function Select:updateOutput(input)
-   local output = input:select(self.dimension,self.index);
+   local index = self.index < 0 and input:size(self.dimension) + self.index + 1 or self.index
+   local output = input:select(self.dimension, index);
    self.output:resizeAs(output)
    return self.output:copy(output)
 end
 
 function Select:updateGradInput(input, gradOutput)
+   local index = self.index < 0 and input:size(self.dimension) + self.index + 1 or self.index
    self.gradInput:resizeAs(input)  
    self.gradInput:zero()
-   self.gradInput:select(self.dimension,self.index):copy(gradOutput) 
+   self.gradInput:select(self.dimension,index):copy(gradOutput) 
    return self.gradInput
 end 

--- a/test.lua
+++ b/test.lua
@@ -4616,6 +4616,14 @@ function nntest.SplitTable()
    mytester:asserteq(#module:forward(input), 3, "negative index (minibatch)")
 end
 
+function nntest.Select()
+  -- Test negative Select
+  local input = torch.Tensor{{4,6,7}, {8,0,1}}
+  mytester:asserteq(nn.Select(1,-1):forward(input)[1], 8, "negative index")
+  mytester:asserteq(nn.Select(1,-1):forward(input)[2], 0, "negative index")
+  mytester:asserteq(nn.Select(1,-2):forward(input)[2], 6, "negative index")
+end
+
 function nntest.SelectTable()
    local input = {
       torch.rand(3,4,5), torch.rand(3,4,5),


### PR DESCRIPTION
As nn.SelectTable support negative inputs it seems only natural to also allow nn.Select to support the same.

Just a side note: nn.SelectTable has asserts, should nn.Select have them as well?

I think it's also fine to support this in the Tensor:select function instead.