### PR TITLE
Select table consistency and small test change

### DIFF
--- a/SelectTable.lua
+++ b/SelectTable.lua
@@ -7,12 +7,11 @@ function SelectTable:__init(index)
 end
 
 function SelectTable:updateOutput(input)
-   assert(math.abs(self.index) <= #input, "arg 1 table idx out of range")
-   if self.index < 0 then
-      self.output = input[#input + self.index + 1]
-   else
-      self.output = input[self.index]
-   end
+   -- handle negative indices
+   local index = self.index < 0 and #input + self.index + 1 or self.index
+
+   assert(input[index], "index does not exist in the input table")
+   self.output = input[index]
 
    return self.output
 end

--- a/test.lua
+++ b/test.lua
@@ -6120,21 +6120,18 @@ end
 
 mytester:add(nntest)
 
-if not nn then
-   require 'nn'
-   jac = nn.Jacobian
-   sjac = nn.SparseJacobian
-   mytester:run()
-else
-   jac = nn.Jacobian
-   sjac = nn.SparseJacobian
-   function nn.test(tests, seed)
-      -- randomize stuff
-      local seed = seed or (1e5 * torch.tic())
-      print('Seed: ', seed)
-      math.randomseed(seed)
-      torch.manualSeed(seed)
-      mytester:run(tests)
-      return mytester
-   end
+jac = nn.Jacobian
+sjac = nn.SparseJacobian
+function nn.test(tests, seed)
+   -- Limit number of threads since everything is small
+   local nThreads = torch.getnumthreads()
+   torch.setnumthreads(1)
+   -- randomize stuff
+   local seed = seed or (1e5 * torch.tic())
+   print('Seed: ', seed)
+   math.randomseed(seed)
+   torch.manualSeed(seed)
+   mytester:run(tests)
+   torch.setnumthreads(nThreads)
+   return mytester
 end


### PR DESCRIPTION
This PR contains 3 things:
* Make `SelectTable` forward pass consistent with the backward wrt to the `index` computation and the assertion. The following sample will now work (it used to fail because in this case `#input == 0`):
```lua
require 'nn'

local mod = nn.SelectTable(5)
local input = {}
input[5] = 2

mod:forward(input)
```
* With the current `test.lua` file, it is not possible to do `luajit test.lua` even though there is some code in there trying do support this. Since `torch7` does not allow this way to run the tests (only calling `torch.test()` from lua is allowed), I removed the associated code here. @soumith if you think we should support this way to run the tests, let me know and I will fix it instead.
* Force the tests to run using only a single thread. This leads to a huge speedup for machines with multiple cores because trying to use all cores for small operations is very slow.