### PR TITLE
Adding an optional extra input to SpatialFull- and VolumetricFull- convolution.

### DIFF
--- a/VolumetricFullConvolution.lua
+++ b/VolumetricFullConvolution.lua
@@ -36,6 +36,7 @@ function VolumetricFullConvolution:__init(nInputPlane, nOutputPlane,
    self.bias = torch.Tensor(self.nOutputPlane)
    self.gradBias = torch.Tensor(self.nOutputPlane)
 
+   self.ones = torch.Tensor()
    self.finput = torch.Tensor()
    self.fgradInput = torch.Tensor()
 
@@ -72,6 +73,10 @@ local function makeContiguous(self, input, gradOutput)
    return input, gradOutput
 end
 
+local function calculateAdj(targetSize, ker, pad, stride)
+  return (targetSize + 2 * pad - ker) % stride
+end
+
 function VolumetricFullConvolution:backCompatibility()
    -- Transpose the weight when loading from an old version
    if not self.adjW then
@@ -91,9 +96,26 @@ end
 function VolumetricFullConvolution:updateOutput(input)
    self:backCompatibility()
 
-   input = makeContiguous(self, input)
-   input.THNN.VolumetricFullConvolution_updateOutput(
-      input:cdata(),
+  local inputTensor = input
+  local adjT, adjW, adjH = self.adjT, self.adjW, self.adjH
+
+  -- The input can be a table where the second element indicates the target
+  -- output size, in which case the adj factors are computed automatically
+  if type(inputTensor) == 'table' then
+    inputTensor = input[1]
+    local targetTensor = input[2]
+    local tDims = targetTensor:dim()
+    local tT = targetTensor:size(tDims-2)
+    local tH = targetTensor:size(tDims-1)
+    local tW = targetTensor:size(tDims)
+    adjT = calculateAdj(tT, self.kT, self.padT, self.dT)
+    adjW = calculateAdj(tW, self.kW, self.padW, self.dW)
+    adjH = calculateAdj(tH, self.kH, self.padH, self.dH)
+  end
+
+   inputTensor = makeContiguous(self, inputTensor)
+   inputTensor.THNN.VolumetricFullConvolution_updateOutput(
+      inputTensor:cdata(),
       self.output:cdata(),
       self.weight:cdata(),
       self.bias:cdata(),
@@ -101,7 +123,7 @@ function VolumetricFullConvolution:updateOutput(input)
       self.fgradInput:cdata(),
       self.dT, self.dW, self.dH,
       self.padT, self.padW, self.padH,
-      self.adjT, self.adjW, self.adjH
+      adjT, adjW, adjH
    )
 
    return self.output
@@ -110,9 +132,30 @@ end
 function VolumetricFullConvolution:updateGradInput(input, gradOutput)
    self:backCompatibility()
 
-   input, gradOutput = makeContiguous(self, input, gradOutput)
-   input.THNN.VolumetricFullConvolution_updateGradInput(
-      input:cdata(),
+    local inputTensor = input
+    local adjT, adjW, adjH = self.adjT, self.adjW, self.adjH
+
+    -- The input can be a table where the second element indicates the target
+    -- output size, in which case the adj factors are computed automatically
+    if type(inputTensor) == 'table' then
+      inputTensor = input[1]
+      local targetTensor = input[2]
+      local tDims = targetTensor:dim()
+      local tT = targetTensor:size(tDims-2)
+      local tH = targetTensor:size(tDims-1)
+      local tW = targetTensor:size(tDims)
+      adjT = calculateAdj(tT, self.kT, self.padT, self.dT)
+      adjW = calculateAdj(tW, self.kW, self.padW, self.dW)
+      adjH = calculateAdj(tH, self.kH, self.padH, self.dH)
+      -- Momentarily extract the gradInput tensor
+      if type(self.gradInput) == 'table' then
+        self.gradInput = self.gradInput[1]
+      end
+    end
+
+   inputTensor, gradOutput = makeContiguous(self, inputTensor, gradOutput)
+   inputTensor.THNN.VolumetricFullConvolution_updateGradInput(
+      inputTensor:cdata(),
       gradOutput:cdata(),
       self.gradInput:cdata(),
       self.weight:cdata(),
@@ -120,17 +163,45 @@ function VolumetricFullConvolution:updateGradInput(input, gradOutput)
       self.fgradInput:cdata(),
       self.dT, self.dW, self.dH,
       self.padT, self.padW, self.padH,
-      self.adjT, self.adjW, self.adjH
+      adjT, adjW, adjH
    )
+
+    if type(input) == 'table' then
+     -- Create a zero tensor to be expanded and used as gradInput[2].
+      self.zeroScalar = self.zeroScalar or input[2].new(1):zero()
+      self.ones:resize(input[2]:dim()):fill(1)
+      local zeroTensor =  self.zeroScalar
+          :view(table.unpack(self.ones:totable()))
+          :expandAs(input[2])
+      self.gradInput = {self.gradInput, zeroTensor}
+    end
+
    return self.gradInput
 end
 
 function VolumetricFullConvolution:accGradParameters(input, gradOutput, scale)
    self:backCompatibility()
 
-   input, gradOutput = makeContiguous(self, input, gradOutput)
-   input.THNN.VolumetricFullConvolution_accGradParameters(
-      input:cdata(),
+  local inputTensor = input
+  local adjT, adjW, adjH = self.adjT, self.adjW, self.adjH
+
+  -- The input can be a table where the second element indicates the target
+  -- output size, in which case the adj factors are computed automatically
+  if type(inputTensor) == 'table' then
+    inputTensor = input[1]
+    local targetTensor = input[2]
+    local tDims = targetTensor:dim()
+    local tT = targetTensor:size(tDims-2)
+    local tH = targetTensor:size(tDims-1)
+    local tW = targetTensor:size(tDims)
+    adjT = calculateAdj(tT, self.kT, self.padT, self.dT)
+    adjW = calculateAdj(tW, self.kW, self.padW, self.dW)
+    adjH = calculateAdj(tH, self.kH, self.padH, self.dH)
+  end
+
+   inputTensor, gradOutput = makeContiguous(self, inputTensor, gradOutput)
+   inputTensor.THNN.VolumetricFullConvolution_accGradParameters(
+      inputTensor:cdata(),
       gradOutput:cdata(),
       self.gradWeight:cdata(),
       self.gradBias:cdata(),
@@ -138,7 +209,7 @@ function VolumetricFullConvolution:accGradParameters(input, gradOutput, scale)
       self.fgradInput:cdata(),
       self.dT, self.dW, self.dH,
       self.padT, self.padW, self.padH,
-      self.adjT, self.adjW, self.adjH,
+      adjT, adjW, adjH,
       scale or 1
    )
 end

--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -420,7 +420,9 @@ module = nn.SpatialFullConvolution(nInputPlane, nOutputPlane, kW, kH, [dW], [dH]
 ```
 
 Applies a 2D full convolution over an input image composed of several input planes. The `input` tensor in
-`forward(input)` is expected to be a 3D or 4D tensor.
+`forward(input)` is expected to be a 3D or 4D tensor. Note that instead of setting `adjW` and `adjH`, SpatialFullConvolution also accepts a table input with two tensors: `{convInput, sizeTensor}` where `convInput` is the standard input on which the full convolution
+is applied, and the size of `sizeTensor` is used to set the size of the output. Using the two-input version of forward
+will ignore the `adjW` and `adjH` values used to construct the module.
 
 Other frameworks call this operation "In-network Upsampling", "Fractionally-strided convolution", "Backwards Convolution," "Deconvolution", or "Upconvolution."
 
@@ -898,7 +900,8 @@ module = nn.VolumetricFullConvolution(nInputPlane, nOutputPlane, kT, kW, kH, [dT
 ```
 
 Applies a 3D full convolution over an input image composed of several input planes. The `input` tensor in
-`forward(input)` is expected to be a 4D or 5D tensor.
+`forward(input)` is expected to be a 4D or 5D tensor. Note that instead of setting `adjT`, `adjW` and `adjH`, VolumetricFullConvolution also accepts a table input with two tensors: `{convInput, sizeTensor}` where `convInput` is the standard input on which the full convolution is applied, and the size of `sizeTensor` is used to set the size of the output. Using the two-input version of forward
+will ignore the `adjT`, `adjW` and `adjH` values used to construct the module.
 
 The parameters are the following:
 * `nInputPlane`: The number of expected input planes in the image given into `forward()`.


### PR DESCRIPTION
This can used to dynamically set the output size, as an alternative to using the adj terms, which has the downside to be fixed at construction time and makes the output size of these modules depend on the size of the input tensor. This is convenient for conv->rev-conv networks, as the input of the conv can be used as extra input to the rev-conv to go back to the same size exactly.

There is no downside to using the extra input, as there is effectively no gradient flowing back from this input, since this commit in nngraph: https://github.com/torch/nngraph/commit/2c66c0d9ceed8fdfd4f0230a4d0d38f6d9fbcee0
which detects that gradOutput is an expanded zero tensor and skips it.