### PR TITLE
Add gradInput nil check for SplitTable

### DIFF
--- a/SplitTable.lua
+++ b/SplitTable.lua
@@ -31,11 +31,13 @@ end
 function SplitTable:updateGradInput(input, gradOutput)
    local dimension = self:_getPositiveDimension(input)
    local slices = input:size(dimension)
-   self.gradInput:resizeAs(input)
+   if self.gradInput then
+      self.gradInput:resizeAs(input)
 
-   for i=1,slices do 
-      local currentGradInput = gradOutput[i];        
-      self.gradInput:select(dimension,i):copy(currentGradInput)
+      for i=1,slices do 
+         local currentGradInput = gradOutput[i];        
+         self.gradInput:select(dimension,i):copy(currentGradInput)
+      end
    end
    return self.gradInput
 end


### PR DESCRIPTION
There are cases when self.gradInput is nil in SplitTable, e.g., when it is the very bottom of the network. A check is necessary to avoid exceptions.