### PR TITLE
add assert to improve error handling

### DIFF
--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -105,6 +105,7 @@ local function unviewWeight(self)
 end
 
 function SpatialConvolution:updateOutput(input)
+   assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    backCompatibility(self)
    viewWeight(self)
    input = makeContiguous(self, input)
@@ -124,6 +125,7 @@ function SpatialConvolution:updateOutput(input)
 end
 
 function SpatialConvolution:updateGradInput(input, gradOutput)
+   assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    if self.gradInput then
       backCompatibility(self)
       viewWeight(self)
@@ -145,6 +147,7 @@ function SpatialConvolution:updateGradInput(input, gradOutput)
 end
 
 function SpatialConvolution:accGradParameters(input, gradOutput, scale)
+   assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    scale = scale or 1
    backCompatibility(self)
    input, gradOutput = makeContiguous(self, input, gradOutput)

--- a/SpatialConvolutionMM.lua
+++ b/SpatialConvolutionMM.lua
@@ -67,6 +67,7 @@ local function makeContiguous(self, input, gradOutput)
 end
 
 function SpatialConvolutionMM:updateOutput(input)
+   assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    self.finput = self.finput or input.new()
    self.fgradInput = self.fgradInput or input.new()
    -- backward compatibility
@@ -91,6 +92,7 @@ function SpatialConvolutionMM:updateOutput(input)
 end
 
 function SpatialConvolutionMM:updateGradInput(input, gradOutput)
+   assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    if self.gradInput then
       input, gradOutput = makeContiguous(self, input, gradOutput)
       input.THNN.SpatialConvolutionMM_updateGradInput(
@@ -109,6 +111,7 @@ function SpatialConvolutionMM:updateGradInput(input, gradOutput)
 end
 
 function SpatialConvolutionMM:accGradParameters(input, gradOutput, scale)
+   assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    scale = scale or 1
    input, gradOutput = makeContiguous(self, input, gradOutput)
    assert((self.bias and self.gradBias) or (self.bias == nil and self.gradBias == nil))


### PR DESCRIPTION
If you require cutorch and nn but forget cunn and call a module that uses THNN it will throw a non-obvious error `Error attempt to index field 'THNN' (a nil value)` eg https://github.com/soumith/imagenet-multiGPU.torch/issues/69, have seen this issue pop up several times. I added the assert to convolution and convolutionMM, but in general would be good to add this to other modules too.