### PR TITLE
added support for negative lenghts to Narrow

### DIFF
--- a/Narrow.lua
+++ b/Narrow.lua
@@ -11,15 +11,23 @@ function Narrow:__init(dimension,offset,length)
 end
 
 function Narrow:updateOutput(input)
-   local output=input:narrow(self.dimension,self.index,self.length)
+   local length = self.length
+   if length < 0 then
+      length = input:size(self.dimension) - self.index + self.length + 2
+   end
+   local output=input:narrow(self.dimension,self.index,length)
    self.output = self.output:typeAs(output)
    self.output:resizeAs(output):copy(output)
    return self.output
 end
 
 function Narrow:updateGradInput(input, gradOutput)
+   local length = self.length
+   if length < 0 then
+      length = input:size(self.dimension) - self.index + self.length + 2
+   end
    self.gradInput = self.gradInput:typeAs(input)
    self.gradInput:resizeAs(input):zero()
-   self.gradInput:narrow(self.dimension,self.index,self.length):copy(gradOutput)
+   self.gradInput:narrow(self.dimension,self.index,length):copy(gradOutput)
    return self.gradInput
 end


### PR DESCRIPTION
Imagine you would like to chop off ten pixels off of two sides of an image, whose size is unknown. To make this feasible, I changed the Narrow module such that it accepts negative lengths and behaves as follows.

```
th> a = torch.rand(1, 5, 6)

th> a
(1,.,.) = 
  0.4982  0.6585  0.4621  0.9703  0.7528  0.6298
  0.5106  0.2586  0.6974  0.5139  0.2741  0.0780
  0.5161  0.2279  0.6495  0.0238  0.0226  0.7178
  0.1969  0.4823  0.2021  0.7990  0.2389  0.1396
  0.6029  0.0335  0.0230  0.5429  0.8701  0.8451
[torch.DoubleTensor of size 1x5x6]

th> nn.Narrow(2, 2, -1):forward(a)
(1,.,.) = 
  0.5106  0.2586  0.6974  0.5139  0.2741  0.0780
  0.5161  0.2279  0.6495  0.0238  0.0226  0.7178
  0.1969  0.4823  0.2021  0.7990  0.2389  0.1396
  0.6029  0.0335  0.0230  0.5429  0.8701  0.8451
[torch.DoubleTensor of size 1x4x6]

th> nn.Narrow(2, 2, -2):forward(a)
(1,.,.) = 
  0.5106  0.2586  0.6974  0.5139  0.2741  0.0780
  0.5161  0.2279  0.6495  0.0238  0.0226  0.7178
  0.1969  0.4823  0.2021  0.7990  0.2389  0.1396
[torch.DoubleTensor of size 1x3x6]

th> nn.Narrow(3, 2, -2):forward(a)
(1,.,.) = 
  0.6585  0.4621  0.9703  0.7528
  0.2586  0.6974  0.5139  0.2741
  0.2279  0.6495  0.0238  0.0226
  0.4823  0.2021  0.7990  0.2389
  0.0335  0.0230  0.5429  0.8701
[torch.DoubleTensor of size 1x5x4]
```

Thank you!