### PR TITLE
add makeContiguous to LogSoftMax

### DIFF
--- a/LogSoftMax.lua
+++ b/LogSoftMax.lua
@@ -1,6 +1,24 @@
 local LogSoftMax = torch.class('nn.LogSoftMax', 'nn.Module')
 
+local function makeContiguous(self, input, gradOutput)
+   if not input:isContiguous() then
+      self._input = self._input or input.new()
+      self._input:resizeAs(input):copy(input)
+      input = self._input
+   end
+   if gradOutput then
+      if not gradOutput:isContiguous() then
+         self._gradOutput = self._gradOutput or gradOutput.new()
+         self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
+         gradOutput = self._gradOutput
+      end
+   end
+   return input, gradOutput
+end
+
 function LogSoftMax:updateOutput(input)
+   input = makeContiguous(self, input)
+
    input.THNN.LogSoftMax_updateOutput(
       input:cdata(),
       self.output:cdata()
@@ -9,6 +27,8 @@ function LogSoftMax:updateOutput(input)
 end
 
 function LogSoftMax:updateGradInput(input, gradOutput)
+   input, gradOutput = makeContiguous(self, input, gradOutput)
+
    input.THNN.LogSoftMax_updateGradInput(
       input:cdata(),
       gradOutput:cdata(),


### PR DESCRIPTION
As [LogSoftMax's backward returns an wrong gradInput while the gradOutput is not contiguous.](https://github.com/torch/nn/issues/832)
I think we need makeContiguous for input and gradOutput to fix this.