### PR TITLE
Fix optim example to use the correct tensor type for the label

### DIFF
--- a/doc/training.md
+++ b/doc/training.md
@@ -149,7 +149,7 @@ rather larger dataset into multiple minibatches, of around 32-512 examples each.
 ```lua
 local batchSize = 128
 local batchInputs = torch.Tensor(batchSize, inputs)
-local batchLabels = torch.ByteTensor(batchSize)
+local batchLabels = torch.DoubleTensor(batchSize)
 
 for i=1,batchSize do
   local input = torch.randn(2)     -- normally distributed example in 2d


### PR DESCRIPTION
I love the quality of the documentation here. Thanks!

One small correction that tripped me up. I was getting:

```
/Users/home/torch/install/bin/luajit: /Users/home/torch/install/share/lua/5.1/nn/THNN.lua:109: bad argument #3 to 'v' (cannot convert 'struct THByteTensor *' to 'struct THDoubleTensor *')
stack traceback:
	[C]: in function 'v'
	/Users/home/torch/install/share/lua/5.1/nn/THNN.lua:109: in function 'MSECriterion_updateOutput'
	/Users/home/torch/install/share/lua/5.1/nn/MSECriterion.lua:14: in function 'forward'
	example.lua:42: in function 'opfunc'
	/Users/home/torch/install/share/lua/5.1/optim/sgd.lua:44: in function 'sgd'
	example.lua:48: in main chunk
	[C]: in function 'dofile'
	...home/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:145: in main chunk
	[C]: at 0x010088d1f0
```

The composed snippets that were causing this error for me were:

```
require 'nn'

local model = nn.Sequential();  -- make a multi-layer perceptron
local inputs = 2; local outputs = 1; local HUs = 20; -- parameters
model:add(nn.Linear(inputs, HUs))
model:add(nn.Tanh())
model:add(nn.Linear(HUs, outputs))

local criterion = nn.MSECriterion()

local batchSize = 128
local batchInputs = torch.Tensor(batchSize, inputs)
local batchLabels = torch.ByteTensor(batchSize)

for i=1,batchSize do
  local input = torch.randn(2)     -- normally distributed example in 2d
  local label = 1
  if input[1]*input[2]>0 then     -- calculate label for XOR function
    label = -1;
  end
  batchInputs[i]:copy(input)
  batchLabels[i] = label
end

local params, gradParams = model:getParameters()

local optimState = {learningRate=0.01}

require 'optim'

for epoch=1,50 do
  -- local function we give to optim
  -- it takes current weights as input, and outputs the loss
  -- and the gradient of the loss with respect to the weights
  -- gradParams is calculated implicitly by calling 'backward',
  -- because the models weight and bias gradient tensors
  -- are simply views onto gradParams
  local function feval(params)
    gradParams:zero()

    local outputs = model:forward(batchInputs)
    local loss = criterion:forward(outputs, batchLabels)
    local dloss_doutput = criterion:backward(outputs, batchLabels)
    model:backward(batchInputs, dloss_doutput)

    return loss,gradParams
  end
  optim.sgd(feval, params, optimState)
end

x = torch.Tensor(2)
x[1] =  0.5; x[2] =  0.5; print(model:forward(x))
x[1] =  0.5; x[2] = -0.5; print(model:forward(x))
x[1] = -0.5; x[2] =  0.5; print(model:forward(x))
x[1] = -0.5; x[2] = -0.5; print(model:forward(x))
```