### PR TITLE
nn.Index.clearState destroys gradInput

### DIFF
--- a/Index.lua
+++ b/Index.lua
@@ -23,3 +23,8 @@ function Index:updateGradInput(input, gradOutput)
     return self.gradInput
 end
 
+
+function Index:clearState()
+    self.gradInput[1]:set()
+    self.output:set()
+end


### PR DESCRIPTION
Hi, I found another clearState issue again
```lua
local m = nn.Index(1)

local tensor = torch.Tensor(10, 3)
local indices = torch.LongTensor{ 2,3,4}

print( m.gradInput )  -- a table of 1 tensor
m:clearState()
print( m.gradInput ) -- an empty table

m:forward({tensor, indices})
m:backward({tensor,indices}, torch.rand(3,3)) 
-- error: Index.lua:21: attempt to index local 'gradInput' (a nil value)
```

so I add a specialized version for nn.Index