### PR TITLE
Fix SpatialClassNLLCriterion when using OMP

### DIFF
--- a/lib/THNN/generic/SpatialClassNLLCriterion.c
+++ b/lib/THNN/generic/SpatialClassNLLCriterion.c
@@ -102,9 +102,10 @@ void THNN_(SpatialClassNLLCriterion_updateGradInput)(
 
   real normalize = sizeAverage ? *total_weight_data : 1.0f;
 
-  int b,elem;
-#pragma omp parallel for
+  int b;
+  #pragma omp parallel for
   for (b = 0; b < batch_size; b++) {
+    int elem;
     for (elem = 0; elem < map_size; elem++) {
       int cur_target = target_data[b * map_size + elem] - 1;
       THAssert(cur_target >= 0 && cur_target < n_classes);


### PR DESCRIPTION
Although the `b` variable is automatically private, the `elem` loop variable is not private.

Test: change test.lua to run with more than one thread