### PR TITLE
add CMaxTable class

### DIFF
--- a/CMaxTable.lua
+++ b/CMaxTable.lua
@@ -1,0 +1,33 @@
+local CMaxTable, parent = torch.class('nn.CMaxTable', 'nn.Module')
+
+function CMaxTable:__init()
+   parent.__init(self)
+   self.gradInput = {}
+   self.maxIdx = torch.Tensor()
+end
+
+function CMaxTable:updateOutput(input)
+   self.output:resizeAs(input[1]):copy(input[1])
+   self.maxIdx:resizeAs(input[1]):fill(1)
+   for i=2,#input do
+      local mask = torch.gt(input[i], self.output)
+      self.maxIdx:maskedFill(mask, i)
+      self.output:maskedCopy(mask, input[i][mask])
+   end
+   return self.output
+end
+
+function CMaxTable:updateGradInput(input, gradOutput)
+   for i=1,#input do
+      self.gradInput[i] = torch.Tensor()
+      self.gradInput[i]:resizeAs(input[i]):fill(0.0)
+      local mask = torch.eq(self.maxIdx, i)
+      self.gradInput[i]:maskedCopy(mask, gradOutput[mask])
+   end
+
+   for i=#input+1, #self.gradInput do
+       self.gradInput[i] = nil
+   end
+
+   return self.gradInput
+end

--- a/CMinTable.lua
+++ b/CMinTable.lua
@@ -1,0 +1,33 @@
+local CMinTable, parent = torch.class('nn.CMinTable', 'nn.Module')
+
+function CMinTable:__init()
+   parent.__init(self)
+   self.gradInput = {}
+   self.minIdx = torch.Tensor()
+end
+
+function CMinTable:updateOutput(input)
+   self.output:resizeAs(input[1]):copy(input[1])
+   self.minIdx:resizeAs(input[1]):fill(1)
+   for i=2,#input do
+      local mask = torch.lt(input[i], self.output)
+      self.minIdx:maskedFill(mask, i)
+      self.output:maskedCopy(mask, input[i][mask])
+   end
+   return self.output
+end
+
+function CMinTable:updateGradInput(input, gradOutput)
+   for i=1,#input do
+      self.gradInput[i] = torch.Tensor()
+      self.gradInput[i]:resizeAs(input[i]):fill(0.0)
+      local mask = torch.eq(self.minIdx, i)
+      self.gradInput[i]:maskedCopy(mask, gradOutput[mask])
+   end
+
+   for i=#input+1, #self.gradInput do
+       self.gradInput[i] = nil
+   end
+
+   return self.gradInput
+end

--- a/doc/table.md
+++ b/doc/table.md
@@ -23,6 +23,8 @@ This allows one to build very rich architectures:
     * [`CSubTable`](#nn.CSubTable): substraction of input `Tensor`s;
     * [`CMulTable`](#nn.CMulTable): multiplication of input `Tensor`s;
     * [`CDivTable`](#nn.CDivTable): division of input `Tensor`s;
+    * [`CMaxTable`](#nn.CMaxTable): max of input `Tensor`s;
+    * [`CMinTable`](#nn.CMinTable): min of input `Tensor`s;
   * `Table` of Criteria:
     * [`CriterionTable`](#nn.CriterionTable): wraps a [Criterion](criterion.md#nn.Criterion) so that it can accept a `table` of inputs.
 
@@ -1212,3 +1214,30 @@ m = nn.CDivTable()
 [torch.DoubleTensor of dimension 5]
 ```
 
+<a name="nn.CMaxTable"></a>
+## CMaxTable ##
+
+Takes a `table` of `Tensor`s and outputs the max of all of them.
+
+```lua
+m = nn.CMaxTable()
+=m:forward({{torch.Tensor{1,2,3}, torch.Tensor{3,2,1}})
+ 3
+ 2
+ 3
+[torch.DoubleTensor of size 3]
+```
+
+<a name="nn.CMinTable"></a>
+## CMinTable ##
+
+Takes a `table` of `Tensor`s and outputs the min of all of them.
+
+```lua
+m = nn.CMinTable()
+=m:forward({{torch.Tensor{1,2,3}, torch.Tensor{3,2,1}})
+ 1
+ 2
+ 1
+[torch.DoubleTensor of size 3]
+```

--- a/init.lua
+++ b/init.lua
@@ -53,6 +53,8 @@ require('nn.CAddTable')
 require('nn.CDivTable')
 require('nn.CMulTable')
 require('nn.CSubTable')
+require('nn.CMaxTable')
+require('nn.CMinTable')
 
 require('nn.Euclidean')
 require('nn.WeightedEuclidean')

--- a/test.lua
+++ b/test.lua
@@ -4730,6 +4730,36 @@ function nntest.Copy()
    mytester:assert(torch.type(output) == 'torch.FloatTensor', 'copy forward type err')
 end
 
+function nntest.CMaxTable()
+   local input1 = torch.Tensor{{1,3},{2,4}}
+   local input2 = torch.Tensor{{4,2},{3,1}}
+   local input = {input1, input2}
+   local module = nn.CMaxTable()
+   local err1 = torch.add(module:forward(input), -1, torch.Tensor{{4,3},{3,4}})
+   mytester:assertalmosteq(err1:abs():max(), 0, 1e-15, "CMaxTable forward call")
+   local gradOutputs = torch.Tensor{5,6,7,8}
+   local gradInputs = module:backward(input, gradOutputs)
+   local err2 = torch.add(gradInputs[1], -1, torch.Tensor{{0,6},{0,8}})
+   local err3 = torch.add(gradInputs[2], -1, torch.Tensor{{5,0},{7,0}})
+   mytester:assertalmosteq(err2:abs():max(), 0, 1e-15, "CMaxTable backward call")
+   mytester:assertalmosteq(err3:abs():max(), 0, 1e-15, "CMaxTable backward call")
+end
+
+function nntest.CMinTable()
+   local input1 = torch.Tensor{{1,3},{2,4}}
+   local input2 = torch.Tensor{{4,2},{3,1}}
+   local input = {input1, input2}
+   local module = nn.CMinTable()
+   local err1 = torch.add(module:forward(input), -1, torch.Tensor{{1,2},{2,1}})
+   mytester:assertalmosteq(err1:abs():max(), 0, 1e-15, "CMinTable forward call")
+   local gradOutputs = torch.Tensor{5,6,7,8}
+   local gradInputs = module:backward(input, gradOutputs)
+   local err2 = torch.add(gradInputs[1], -1, torch.Tensor{{5,0},{7,0}})
+   local err3 = torch.add(gradInputs[2], -1, torch.Tensor{{0,6},{0,8}})
+   mytester:assertalmosteq(err2:abs():max(), 0, 1e-15, "CMinTable backward call")
+   mytester:assertalmosteq(err3:abs():max(), 0, 1e-15, "CMinTable backward call")
+end
+
 function nntest.JoinTable()
    local tensor = torch.rand(3,4,5)
    local input = {tensor, tensor}


### PR DESCRIPTION
This is analogous to the other table layers, but only with a max, rather than add or multiply operation. I couldn't think of a good way to implement this to work with arbitrary sized tensors using existing layers, so I thought this might be helpful.

If you think it makes sense to include this feature, I'll add documentation and tests, I just wanted to check whether this feature makes sense before going ahead with that.

Sample usage:
```
th> a = torch.range(1,6):double():resize(3,2)
                                                                      [0.0003s]	
th> b = torch.Tensor(3,2):fill(3.5):double()
                                                                      [0.0002s]	
th> a
 1  2
 3  4
 5  6
[torch.DoubleTensor of size 3x2]

                                                                      [0.0003s]	
th> b
 3.5000  3.5000
 3.5000  3.5000
 3.5000  3.5000
[torch.DoubleTensor of size 3x2]

                                                                      [0.0003s]	
th> nn.CMaxTable():forward({a,b})
 3.5000  3.5000
 3.5000  4.0000
 5.0000  6.0000
[torch.DoubleTensor of size 3x2]
```