### PR TITLE
DICE Criterion for measuring similarity between images

### DIFF
--- a/DICECriterion.lua
+++ b/DICECriterion.lua
@@ -1,0 +1,116 @@
+--[[
+	A  statistic used for comparing the similarity of two samples
+	Sorensen's original formula =  2 * |X n Y|
+	                              ------------
+	                                |X| + |Y|
+
+	Note: |X| and |Y| are the numbers of species in the two samples. 
+	The result is the quotient of similarity and ranges between 0 and 1.
+
+	Ref 1: https://en.wikipedia.org/wiki/Sørensen–Dice_coefficient
+	Ref 2: https://github.com/jocicmarko/ultrasound-nerve-segmentation/blob/master/train.py#L19
+
+	Author: Olalekan Ogunmolu, July 2016
+			patlekano@gmail.com
+]]
+
+local DICECriterion, parent = torch.class('nn.DICECriterion', 'nn.Criterion')
+
+local eps = 1e-12
+
+function DICECriterion:_init(weights)
+	parent._init(self)
+
+	if weights then
+	   assert(weights:dim() == 1, "weights input should be 1-D Tensor")
+	   self.weights = weights
+	end
+
+end
+
+function DICECriterion:updateOutput(input, target)
+
+	assert(input:nElement() == target:nElement(), "input and target size mismatch")
+
+	local weights = self.weights
+
+	local numerator, denom, output, common
+
+	numerator = input.new()
+
+	numerator:resizeAs(input)
+
+	if weights ~= nil and target:dim() ~= 1 then
+	      weights = self.weights:view(1, target:size(2)):expandAs(target)
+	end
+
+	numerator:add(input, eps)
+
+	--	compute numerator: 2 * |X n Y|   ; eps for numeric stability
+	common = torch.eq(numerator, target)  --find logical equivalence between both
+	numerator = 2*torch.sum(common)
+
+	-- compute denominator: |X| + |Y|
+	denom = input:nElement() + target:nElement() + eps
+
+	local output = numerator / denom
+	self.output = output
+
+	return self.output
+end
+
+function DICECriterion:updateGradInput(input, target)
+
+	assert(input:nElement() == target:nElement(), "inputs and target size mismatch")
+
+	--[[ 
+			2 * |X| * |Y|   
+	    -------------------
+	   	 |X|*(|X| + |Y|)^2
+	    ]]
+
+	local weights = self.weights
+	local gradInput = self.gradInput or input.new()
+	local numerator, denom, den_term2, output
+
+	if weights ~= nil and target:dim() ~= 1 then
+	    weights = self.weights:view(1, target:size(2)):expandAs(target)
+	end
+
+	gradInput:resizeAs(input)
+
+	gradInput = -1*self:updateOutput(input, target)
+
+	if weights ~= nil then
+	    gradInput:cmul(weights)
+	end
+
+	if self.sizeAverage then
+	    gradInput:div(target:nElement())
+	end
+
+	--	2 * |X| * |Y|   
+	numerator = 2 * input:nElement() * target:nElement()
+
+	--|X|
+	denom = input:nElement()
+
+	--(|X| + |Y|)
+	den_term2 = input:nElement() + target:nElement()
+
+	-- |X| * (|X| + |Y|)^2
+	denom = denom * (den_term2 * den_term2)
+
+	--compute gradients
+	gradInput = numerator / denom
+
+	self.gradInput = gradInput
+
+	return self.gradInput
+end
+
+-- function DICECriterion:accGradParameters(input, gradOutput)
+-- end
+
+-- function DICECriterion:reset()
+-- end

--- a/DICECriterion.lua
+++ b/DICECriterion.lua
@@ -1,11 +1,13 @@
 --[[
-	A  statistic used for comparing the similarity of two samples
-	Sorensen's original formula =  2 * |X n Y|
-	                              ------------
-	                                |X| + |Y|
+	A  statistic used for comparing the similarity of two samples based on 
+	Sorensen's original formula ==> 	 2 * |X n Y|
+	                                	------------
+	                               		 |X| + |Y|
 
-	Note: |X| and |Y| are the numbers of species in the two samples. 
-	The result is the quotient of similarity and ranges between 0 and 1.
+	where |X| and |Y| are the numbers of elements in the two samples. 
+	The resulting quotient is an indicator measure of the similarity between the two samples.
+	It ranges between 0 and 1. If it is 1, the two images are perfectly similar. Otherwise, 
+	they are perfectly dissimilar.
 
 	Ref 1: https://en.wikipedia.org/wiki/Sørensen–Dice_coefficient
 	Ref 2: https://github.com/jocicmarko/ultrasound-nerve-segmentation/blob/master/train.py#L19
@@ -48,8 +50,7 @@ function DICECriterion:updateOutput(input, target)
 	-- compute denominator: |X| + |Y|
 	denom = input:nElement() + target:nElement() + eps
 
-	output = numerator/denom
-	self.output = output
+	self.output = numerator/denom
 
 	return self.output
 end
@@ -67,6 +68,8 @@ function DICECriterion:updateGradInput(input, target)
 	local weights = self.weights
 	local gradInput = self.gradInput or input.new()
 	local numerator, denom, den_term2, output
+
+	gradInput:resizeAs(input)
 
 	if weights ~= nil and target:dim() ~= 1 then
 	    weights = self.weights:view(1, target:size(2)):expandAs(target)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This package provides an easy and modular way to build and train simple or compl
    * [Criterions](doc/criterion.md#nn.Criterions): a list of all criterions, including [`Criterion`](doc/criterion.md#nn.Criterion), the abstract class;
    * [`MSECriterion`](doc/criterion.md#nn.MSECriterion): the Mean Squared Error criterion used for regression;
    * [`ClassNLLCriterion`](doc/criterion.md#nn.ClassNLLCriterion): the Negative Log Likelihood criterion used for classification;
+   * [`DICECriterion`](doc/criterion.md#nn.DICECriterion): the Sørensen–Dice index, used for comparing the similarity of two samples;
  * Additional documentation:
    * [Overview](doc/overview.md#nn.overview.dok) of the package essentials including modules, containers and training;
    * [Training](doc/training.md#nn.traningneuralnet.dok): how to train a neural network using [optim](https://github.com/torch/optim);

--- a/doc/criterion.md
+++ b/doc/criterion.md
@@ -8,7 +8,8 @@ target, they compute a gradient according to a given loss function.
     * [`BCECriterion`](#nn.BCECriterion): binary cross-entropy for [`Sigmoid`](transfer.md#nn.Sigmoid) (two-class version of [`ClassNLLCriterion`](#nn.ClassNLLCriterion));
     * [`ClassNLLCriterion`](#nn.ClassNLLCriterion): negative log-likelihood for [`LogSoftMax`](transfer.md#nn.LogSoftMax) (multi-class);
     * [`CrossEntropyCriterion`](#nn.CrossEntropyCriterion): combines [`LogSoftMax`](transfer.md#nn.LogSoftMax) and [`ClassNLLCriterion`](#nn.ClassNLLCriterion);
-    * [`ClassSimplexCriterion`](#nn.ClassSimplexCriterion): A simplex embedding criterion for classification.
+    * [`ClassSimplexCriterion`](#nn.ClassSimplexCriterion): A simplex embedding criterion for classification;
+    * [`DICECriterion`](criterion.md#nn.DICECriterion): A criterion for comparing the similarity of two samples;
     * [`MarginCriterion`](#nn.MarginCriterion): two class margin-based loss;
     * [`SoftMarginCriterion`](#nn.SoftMarginCriterion): two class softmargin-based loss;
     * [`MultiMarginCriterion`](#nn.MultiMarginCriterion): multi-class margin-based loss;
@@ -210,6 +211,50 @@ end
 ```
 
 This criterion also provides two helper functions `getPredictions(input)` and `getTopPrediction(input)` that return the raw predictions and the top prediction index respectively, given an input sample.
+
+<a name="nn.DICECriterion"></a>
+## DICECriterion ##
+
+```lua
+criterion = nn.DICECriterion()
+```
+
+The [Sørensen–Dice index](https://en.wikipedia.org/wiki/Sørensen–Dice_coefficient) measures the degree of similarity between two sample sets. Geiven targets `X` and `Y` in  two sample datasets, the quotient of similarity is calculated as
+
+```lua
+  Q =   2 * (X n Y)
+      --------------
+          X + Y
+```
+
+Q typically ranges between 0 and 1. The closer Q is to one, the more similar both datasets are and the closer Q is to zero, the less similar the two data samples are.
+
+The input tensor and output tensor are expected to be of the same size when calling [`forward(input, target)`](#nn.CriterionForward) and [`backward(input, target)`](#nn.CriterionBackward).
+
+Example
+-------
+
+```lua
+local dice = nn.DICECriterion
+
+inputs = torch.FloatTensor(1, 5)
+preds  = torch.FloatTensor(1, 5)
+
+inputs = torch.range(1, 5);  preds  = inputs:clone()
+
+loss = dice:forward(preds, inputs)
+df_do = dice:backward(preds, inputs)
+
+print('loss', loss)
+print('df_do', df_do)
+```
+
+Prints
+
+```bash
+loss  0.9999999999999 
+df_do 0.1
+```.
 
 <a name="nn.DistKLDivCriterion"></a>
 ## DistKLDivCriterion ##

--- a/doc/criterion.md
+++ b/doc/criterion.md
@@ -222,12 +222,15 @@ criterion = nn.DICECriterion()
 The [Sørensen–Dice index](https://en.wikipedia.org/wiki/Sørensen–Dice_coefficient) measures the degree of similarity between two sample sets. Geiven targets `X` and `Y` in  two sample datasets, the quotient of similarity is calculated as
 
 ```lua
-  Q =   2 * (X n Y)
-      --------------
-          X + Y
+    Q =       2 * |X n Y|
+            --------------
+              |X| + |Y|
 ```
 
-Q typically ranges between 0 and 1. The closer Q is to one, the more similar both datasets are and the closer Q is to zero, the less similar the two data samples are.
+where |X| and |Y| are the numbers of elements in the two samples. 
+The resulting quotient is a measure of the similarity between the two samples.
+It ranges between 0 and 1. If it is 1, the two images are perfectly similar. Otherwise, 
+they are perfectly dissimilar.
 
 The input tensor and output tensor are expected to be of the same size when calling [`forward(input, target)`](#nn.CriterionForward) and [`backward(input, target)`](#nn.CriterionBackward).
 

--- a/rocks/nn-scm-1.rockspec
+++ b/rocks/nn-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "nn"
 version = "scm-1"
 
 source = {
-   url = "git://github.com/lakehanne/nn.git",
+   url = "git://github.com/torch/nn.git",
 }
 
 description = {

--- a/rocks/nn-scm-1.rockspec
+++ b/rocks/nn-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "nn"
 version = "scm-1"
 
 source = {
-   url = "git://github.com/torch/nn.git",
+   url = "git://github.com/lakehanne/nn.git",
 }
 
 description = {


### PR DESCRIPTION
This implements the [Sorensen's DICE Criterion](https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient#Difference_from_Jaccard). 

I have made comments in the `criterion.md` doc file and provided a unit test example as well. 

Hopefully it helps someone in the near future.

Example usage:

```lua
require 'torch'
require 'nn'

require 'DICECriterion'

local dice = nn.DICECriterion
torch.setdefaulttensortype('torch.FloatTensor')

inputs = torch.FloatTensor(1, 5)
preds  = torch.FloatTensor(1, 5)

inputs = torch.range(1, 5)
preds  = inputs:clone()

print('inputs', inputs)
print('preds', preds)

loss = dice:forward(preds, inputs)
df_do = dice:backward(preds, inputs)

print('loss', loss)
print('df_do', df_do)
```

Prints 

```bash
inputs	 1
 2
 3
 4
 5
[torch.FloatTensor of size 5]

preds	 1
 2
 3
 4
 5
[torch.FloatTensor of size 5]

loss	0.9999999999999	
df_do	0.1	
```

Example 2:
```lua
require 'cutorch'
input = torch.FloatTensor(3, 64, 64)
pred  = torch.FloatTensor(3, 64, 64)

input:fill(111)
pred:fill(111)

input:cuda()
pred:cuda()

loss_img = dice:forward(pred, input)
df_do 	 = dice:backward(pred, input)

print('loss_img', loss_img)
print('df_do', df_do)
```

Prints 

```bash
loss_img	1	
df_do	4.0690104166667e-05	
```