### PR TITLE
Dice coefficients in torch

### DIFF
--- a/BCECriterion.lua
+++ b/BCECriterion.lua
@@ -37,6 +37,7 @@ function BCECriterion:updateOutput(input, target)
     local output
 
     buffer:resizeAs(input)
+    buffer:zero()
 
     if weights ~= nil and target:dim() ~= 1 then
         weights = self.weights:view(1, target:size(2)):expandAs(target)

--- a/DICECriterion.lua
+++ b/DICECriterion.lua
@@ -1,0 +1,96 @@
+--[[
+	Author: Olalekan Ogunmolu, July 2016
+			patlekano@gmail.com
+]]
+
+local DICECriterion, parent = torch.class('nn.DICECriterion', 'nn.Criterion')
+
+local eps = 1e-12
+
+function DICECriterion:_init(weights)
+	parent._init(self)
+
+	if weights then
+	   assert(weights:dim() == 1, "weights input should be 1-D Tensor")
+	   self.weights = weights
+	end
+
+end
+
+function DICECriterion:updateOutput(input, target)
+
+	assert(input:nElement() == target:nElement(), "input and target size mismatch")
+
+	local weights = self.weights
+
+	local numerator, denom, common, output
+
+	if weights ~= nil and target:dim() ~= 1 then
+	      weights = self.weights:view(1, target:size(2)):expandAs(target)
+	end
+
+	-- compute numerator: 2 * |X n Y|   ; eps for numeric stability
+	common = torch.eq(input, target)  --find logical equivalence between both
+	common:mul(2)
+	numerator = torch.sum(common)
+
+	-- compute denominator: |X| + |Y|
+	denom = input:nElement() + target:nElement() + eps
+
+	output = numerator/denom
+
+	self.output = -output
+
+	return self.output
+end
+
+function DICECriterion:updateGradInput(input, target)
+	--[[ 
+								2 * |X| * |Y|   
+	    		Gradient = 	 ----------------------
+	   	 						|X|*(|X| + |Y|)^2
+	    ]]
+
+	assert(input:nElement() == target:nElement(), "inputs and target size mismatch")
+	self.buffer = self.buffer or input.new()
+
+	local buffer = self.buffer
+	local weights = self.weights
+	local gradInput = self.gradInput --or input.new()
+	local numerator, denom, den_term2, output
+
+	if weights ~= nil and target:dim() ~= 1 then
+	    weights = self.weights:view(1, target:size(2)):expandAs(target)
+	end
+
+	buffer:resizeAs(input)
+	-- compute |X| + |Y| + eps 
+	buffer:add(input:nElement()):add(target:nElement()):add(eps)
+	-- compute (|X| + |Y| + eps)^2 + eps
+	buffer:cmul(buffer):add(eps)
+	-- compute |X|(|X| + |Y| + eps)^2 + eps
+	buffer:mul(input:nElement())
+
+	gradInput:resizeAs(input)	
+	-- compute 2 * |X| * |Y|  
+	gradInput:add(input:nElement()):mul(target:nElement()):mul(2)
+
+	-- compute quotient
+	gradInput:cdiv(buffer)
+
+	if weights ~= nil then
+	    gradInput:cmul(weights)
+	end
+
+	if self.sizeAverage then
+	    gradInput:div(target:nElement())
+	end
+
+	return gradInput
+end
+
+function DICECriterion:accGradParameters(input, gradOutput)
+end
+
+function DICECriterion:reset()
+end

--- a/DICECriterion.lua
+++ b/DICECriterion.lua
@@ -5,7 +5,7 @@
 
 local DICECriterion, parent = torch.class('nn.DICECriterion', 'nn.Criterion')
 
-local eps = 1e-12
+local eps = 1
 
 function DICECriterion:_init(weights)
 	parent._init(self)
@@ -31,8 +31,8 @@ function DICECriterion:updateOutput(input, target)
 
 	-- compute numerator: 2 * |X n Y|   ; eps for numeric stability
 	common = torch.eq(input, target)  --find logical equivalence between both
-	common:mul(2)
 	numerator = torch.sum(common)
+	numerator = numerator * 2
 
 	-- compute denominator: |X| + |Y|
 	denom = input:nElement() + target:nElement() + eps
@@ -57,7 +57,6 @@ function DICECriterion:updateGradInput(input, target)
 	local buffer = self.buffer
 	local weights = self.weights
 	local gradInput = self.gradInput --or input.new()
-	local numerator, denom, den_term2, output
 
 	if weights ~= nil and target:dim() ~= 1 then
 	    weights = self.weights:view(1, target:size(2)):expandAs(target)

--- a/DICECriterion.lua
+++ b/DICECriterion.lua
@@ -1,4 +1,13 @@
 --[[
+		Computes the Sorensen-dice coefficient of similarity given two samples. 
+		The quotient of similarity is defined as:
+
+   		 	    Q =     2 * (X n Y)
+         		     -------------------
+        		      sum_i(X) + sum_i(Y)
+		where X and Y are the in the two samples; 
+		(X n Y) denote the intersection where the elements of X and Y are equal.
+
 	Author: Olalekan Ogunmolu, July 2016
 			patlekano@gmail.com
 ]]
@@ -29,12 +38,12 @@ function DICECriterion:updateOutput(input, target)
 	      weights = self.weights:view(1, target:size(2)):expandAs(target)
 	end
 
-	-- compute numerator: 2 * |X n Y|   ; eps for numeric stability
-	common = torch.eq(input, target)  --find logical equivalence between both
+	-- compute 2 * (X intersection Y)
+	common = torch.eq(input, target)  		--find logical equivalence between both
 	numerator = torch.sum(common)
 	numerator = numerator * 2
 
-	-- compute denominator: |X| + |Y|
+	-- compute denominator: sum_i(X) + sum_i(Y)
 	denom = input:nElement() + target:nElement() + eps
 
 	output = numerator/denom
@@ -46,9 +55,9 @@ end
 
 function DICECriterion:updateGradInput(input, target)
 	--[[ 
-								2 * |X| * |Y|   
-	    		Gradient = 	 ----------------------
-	   	 						|X|*(|X| + |Y|)^2
+								      2 * sum_i(X) * sum_i(Y)  
+	    		Gradient = 	    ---------------------------------
+	   	 						sum_i(X)*(sum_i(X) + sum_i(Y))^2
 	    ]]
 
 	assert(input:nElement() == target:nElement(), "inputs and target size mismatch")
@@ -56,22 +65,26 @@ function DICECriterion:updateGradInput(input, target)
 
 	local buffer = self.buffer
 	local weights = self.weights
-	local gradInput = self.gradInput --or input.new()
+	local gradInput = self.gradInput 
 
 	if weights ~= nil and target:dim() ~= 1 then
 	    weights = self.weights:view(1, target:size(2)):expandAs(target)
 	end
 
 	buffer:resizeAs(input)
-	-- compute |X| + |Y| + eps 
+    buffer:zero()
+
+	-- compute sum_i(X) + sum_i(Y) + eps 
 	buffer:add(input:nElement()):add(target:nElement()):add(eps)
-	-- compute (|X| + |Y| + eps)^2 + eps
+	-- compute (sum_i(X) + sum_i(Y) + eps )^2 + eps
 	buffer:cmul(buffer):add(eps)
-	-- compute |X|(|X| + |Y| + eps)^2 + eps
+	-- compute sum_i(X)*(sum_i(X) + sum_i(Y) + eps )^2 + eps
 	buffer:mul(input:nElement())
 
 	gradInput:resizeAs(input)	
-	-- compute 2 * |X| * |Y|  
+	gradInput:zero()
+
+	-- compute 2 * sum_i(X) * sum_i(Y)
 	gradInput:add(input:nElement()):mul(target:nElement()):mul(2)
 
 	-- compute quotient

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This package provides an easy and modular way to build and train simple or compl
    * [Criterions](doc/criterion.md#nn.Criterions): a list of all criterions, including [`Criterion`](doc/criterion.md#nn.Criterion), the abstract class;
    * [`MSECriterion`](doc/criterion.md#nn.MSECriterion): the Mean Squared Error criterion used for regression;
    * [`ClassNLLCriterion`](doc/criterion.md#nn.ClassNLLCriterion): the Negative Log Likelihood criterion used for classification;
+   * [`DICECriterion`](doc/criterion.md#nn.DICECriterion): the Sørensen–Dice index, used for comparing the similarity of two samples;
  * Additional documentation:
    * [Overview](doc/overview.md#nn.overview.dok) of the package essentials including modules, containers and training;
    * [Training](doc/training.md#nn.traningneuralnet.dok): how to train a neural network using [optim](https://github.com/torch/optim);

--- a/doc/criterion.md
+++ b/doc/criterion.md
@@ -8,6 +8,8 @@ target, they compute a gradient according to a given loss function.
     * [`BCECriterion`](#nn.BCECriterion): binary cross-entropy for [`Sigmoid`](transfer.md#nn.Sigmoid) (two-class version of [`ClassNLLCriterion`](#nn.ClassNLLCriterion));
     * [`ClassNLLCriterion`](#nn.ClassNLLCriterion): negative log-likelihood for [`LogSoftMax`](transfer.md#nn.LogSoftMax) (multi-class);
     * [`CrossEntropyCriterion`](#nn.CrossEntropyCriterion): combines [`LogSoftMax`](transfer.md#nn.LogSoftMax) and [`ClassNLLCriterion`](#nn.ClassNLLCriterion);
+    * [`ClassSimplexCriterion`](#nn.ClassSimplexCriterion): A simplex embedding criterion for classification;
+    * [`DICECriterion`](criterion.md#nn.DICECriterion): A criterion for comparing the similarity of two samples;
     * [`ClassSimplexCriterion`](#nn.ClassSimplexCriterion): A simplex embedding criterion for classification.
     * [`MarginCriterion`](#nn.MarginCriterion): two class margin-based loss;
     * [`SoftMarginCriterion`](#nn.SoftMarginCriterion): two class softmargin-based loss;
@@ -210,6 +212,54 @@ end
 ```
 
 This criterion also provides two helper functions `getPredictions(input)` and `getTopPrediction(input)` that return the raw predictions and the top prediction index respectively, given an input sample.
+
+<a name="nn.DICECriterion"></a>
+## DICECriterion ##
+
+```lua
+criterion = nn.DICECriterion()
+```
+
+The [Sørensen–Dice index](https://en.wikipedia.org/wiki/Sørensen–Dice_coefficient) measures the degree of similarity between two sample sets. Geiven targets `X` and `Y` in  two sample datasets, the quotient of similarity is calculated as
+
+```lua
+    Q =       2 * |X n Y|
+            --------------
+              |X| + |Y|
+```
+
+where |X| and |Y| are the numbers of elements in the two samples. 
+The resulting quotient is a measure of the similarity between the two samples.
+It ranges between 0 and 1. If it is 1, the two images are perfectly similar. Otherwise, 
+they are perfectly dissimilar.
+
+The input tensor and output tensor are expected to be of the same size when calling [`forward(input, target)`](#nn.CriterionForward) and [`backward(input, target)`](#nn.CriterionBackward).
+
+Example
+-------
+```lua
+require 'torch'
+require 'nn'
+
+local dice = nn.DICECriterion
+
+inputs = torch.FloatTensor(1, 5)
+preds  = torch.FloatTensor(1, 5)
+
+inputs = torch.range(1, 5)
+preds  = inputs:clone()
+
+loss = dice:forward(preds, inputs)
+df_do = dice:backward(preds, inputs)
+
+print('loss', loss)
+```
+
+Prints 
+
+```bash
+  loss  -0.9999999999999  
+```
 
 <a name="nn.DistKLDivCriterion"></a>
 ## DistKLDivCriterion ##

--- a/doc/criterion.md
+++ b/doc/criterion.md
@@ -223,12 +223,13 @@ criterion = nn.DICECriterion()
 The [Sørensen–Dice index](https://en.wikipedia.org/wiki/Sørensen–Dice_coefficient) measures the degree of similarity between two sample sets. Geiven targets `X` and `Y` in  two sample datasets, the quotient of similarity is calculated as
 
 ```lua
-    Q =       2 * |X n Y|
-            --------------
-              |X| + |Y|
+    Q =           2 * (X n Y)
+              -------------------
+              sum_i(X) + sum_i(Y)
 ```
 
-where |X| and |Y| are the numbers of elements in the two samples. 
+where X and Y are the two samples. 
+X n Y denote the intersection where the elements of X and Y are equal.
 The resulting quotient is a measure of the similarity between the two samples.
 It ranges between 0 and 1. If it is 1, the two images are perfectly similar. Otherwise, 
 they are perfectly dissimilar.

--- a/test.lua
+++ b/test.lua
@@ -1318,6 +1318,13 @@ function nntest.MSECriterion()
    criterionJacobianTest(cri, input, target)
 end
 
+function nntest.DICECriterion()
+   local input = torch.rand(10)
+   local target = input:clone():add(torch.rand(10))
+   local cri = nn.DICECriterion()
+   criterionJacobianTest(cri, input, target)
+end
+
 function nntest.ClassSimplexCriterion()
    local nClasses = torch.random(3,15)
    local input = torch.rand(nClasses)


### PR DESCRIPTION
This implements the [Sorensen's DICE Criterion](https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient#Difference_from_Jaccard). 

I have made comments in the `criterion.md` doc file and provided a unit test example as well. 

Hopefully it helps someone in the near future.

Example usage:

```lua

require 'torch'
require 'nn'

local dice = nn.DICECriterion

inputs = torch.FloatTensor(1, 5)
preds  = torch.FloatTensor(1, 5)

inputs = torch.range(1, 5)
preds  = inputs:clone()

loss = dice:forward(preds, inputs)
df_do = dice:backward(preds, inputs)

print('loss', loss)
```

Prints 

```bash
	loss	-0.9999999999999	
```

Example 2:
```lua
require 'cutorch'
input = torch.FloatTensor(3, 64, 64)
pred  = torch.FloatTensor(3, 64, 64)

input:fill(111)
pred:fill(111)

loss_img = dice:forward(pred, input)
df_do 	 = dice:backward(pred, input)

print('loss_img', loss_img)
```

Prints 

```bash
	loss_img	-1	
```