### PR TITLE
Update convolution.md

### DIFF
--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -903,7 +903,7 @@ columns or rows of the input image might be lost. It is up to the user to
 add proper padding in images.
 
 If the input image is a 4D tensor `nInputPlane x time x height x width`, the output image size
-will be `nOutputPlane x otime x owidth x oheight` where
+will be `nOutputPlane x otime x oheight x owidth` where
 ```lua
 otime  = floor((time  + 2*padT - kT) / dT + 1)
 owidth  = floor((width  + 2*padW - kW) / dW + 1)


### PR DESCRIPTION
In the description of VolumetricConvolution, the order of output dimensions is mistaken. Since input is `nInputPlane x time x height x width` make sense the output also is `nOutputPlane x otime x oheight x owidth` which indeed is the case and not `nOutputPlane x otime x owidth x oheight` as mistakenly posted. This can be checked e.g. by running the following code to see that the layer doesn't flip the width and height dimension orders:

require 'nn'
--make a volumetric layer
from=2
to=3
kT=1
kW=1
kH=1
m=nn.VolumetricConvolution(from,to,kT,kW,kH)
--make a tensor
d=torch.rand(from,7,11,13)
o=m:forward(d)
print(d:size(),o:size())

Cheers!