### PR TITLE
Fix for SpatialFullConvolution for table input after clearState

### DIFF
--- a/SpatialFullConvolution.lua
+++ b/SpatialFullConvolution.lua
@@ -140,7 +140,7 @@ function SpatialFullConvolution:updateGradInput(input, gradOutput)
       adjH = calculateAdj(tH, self.kH, self.padH, self.dH)
       -- Momentarily extract the gradInput tensor
       if type(self.gradInput) == 'table' then
-        self.gradInput = self.gradInput[1]
+        self.gradInput = self.gradInput[1] or inputTensor.new()
       end
     end
 


### PR DESCRIPTION
When the input is a `table`, `clearState` will empty `gradInput` by replacing it with an empty table.
This causes the backward pass to fail because `self.gradInput[1]` will be `nil`.

Should I add tests for this particular case in this PR? For the moment there are practically no tests for `clearState`.