### PR TITLE
A container for applying a single module to all table elements

### DIFF
--- a/MapTable.lua
+++ b/MapTable.lua
@@ -1,0 +1,99 @@
+local MapTable, parent = torch.class('nn.MapTable', 'nn.Container')
+
+function MapTable:__init(module, shared)
+   parent.__init(self)
+   self.shared = shared or {'weight', 'bias', 'gradWeight', 'gradBias'}
+   self.output = {}
+   self.gradInput = {}
+   self:add(module)
+end
+
+function MapTable:_extend(n)
+   self.modules[1] = self.module
+   for i = 2, n do
+      if not self.modules[i] then
+         self.modules[i] = self.module:clone(table.unpack(self.shared))
+      end
+   end
+end
+
+function MapTable:resize(n)
+   self:_extend(n)
+   for i = n + 1, #self.modules do
+      self.modules[i] = nil
+   end
+end
+
+function MapTable:add(module)
+   assert(not self.module, 'Single module required')
+   self.module = module
+   self.modules[1] = self.module
+   return self
+end
+
+function MapTable:updateOutput(input)
+   self.output = {}
+   self:_extend(#input)
+   for i = 1, #input do
+      self.output[i] = self:rethrowErrors(self.modules[i], i, 'updateOutput', input[i])
+   end
+   return self.output
+end
+
+function MapTable:updateGradInput(input, gradOutput)
+   self.gradInput = {}
+   self:_extend(#input)
+   for i = 1, #input do
+      self.gradInput[i] = self:rethrowErrors(self.modules[i], i, 'updateGradInput', input[i], gradOutput[i])
+   end
+   return self.gradInput
+end
+
+function MapTable:accGradParameters(input, gradOutput, scale)
+   scale = scale or 1
+   self:_extend(#input)
+   for i = 1, #input do
+      self:rethrowErrors(self.modules[i], i, 'accGradParameters', input[i], gradOutput[i], scale)
+   end
+end
+
+function MapTable:accUpdateGradParameters(input, gradOutput, lr)
+   lr = lr or 1
+   self:_extend(#input)
+   for i = 1, #input do
+      self:rethrowErrors(self.modules[i], i, 'accUpdateGradParameters', input[i], gradOutput[i], lr)
+   end
+end
+
+function MapTable:zeroGradParameters()
+    if self.module then
+        self.module:zeroGradParameters()
+    end
+end
+
+function MapTable:updateParameters(learningRate)
+    if self.module then
+        self.module:updateParameters(learningRate)
+    end
+end
+
+function MapTable:clearState()
+   for i = 2, #self.modules do
+      self.modules[i] = nil
+   end
+   parent.clearState(self)
+end
+
+function MapTable:__tostring__()
+   local tab = '  '
+   local line = '\n'
+   local extlast = '      '
+   local str = torch.type(self)
+   if self.module then
+      str = str .. ' {' .. line .. tab
+      str = str .. tostring(self.module):gsub(line, line .. tab .. extlast) .. line .. '}'
+   else
+      str = str .. ' { }'
+   end
+   return str
+end

--- a/doc/table.md
+++ b/doc/table.md
@@ -7,6 +7,7 @@ This allows one to build very rich architectures:
   * `table` Container Modules encapsulate sub-Modules:
     * [`ConcatTable`](#nn.ConcatTable): applies each member module to the same input     [`Tensor`](https://github.com/torch/torch7/blob/master/doc/tensor.md#tensor) and outputs a `table`;
     * [`ParallelTable`](#nn.ParallelTable): applies the `i`-th member module to the `i`-th input and outputs a `table`;
+    * [`MapTable`](#nn.MapTable): applies a single module to every input and outputs a `table`;
   * Table Conversion Modules convert between `table`s and `Tensor`s or `table`s:
     * [`SplitTable`](#nn.SplitTable): splits a `Tensor` into a `table` of `Tensor`s;
     * [`JoinTable`](#nn.JoinTable): joins a `table` of `Tensor`s into a `Tensor`;
@@ -162,6 +163,57 @@ which gives the output:
 -0.1657
 -0.7383
 [torch.Tensor of dimension 3]
+```
+
+
+<a name="nn.MapTable"></a>
+## MapTable ##
+
+```lua
+module = nn.MapTable(m, share)
+```
+
+`MapTable` is a container for a single module which will be applied to all input elements. The member module is cloned as necessary to process all input elements. Call `resize(n)` to set the number of clones manually or call `clearState()` to discard all clones.
+
+Optionally, the module can be initialized with the contained module and with a list of parameters that are shared across all clones. By default, these parameters are `weight`, `bias`, `gradWeight` and `gradBias`.
+
+```
++----------+         +-----------+
+| {input1, +---------> {member,  |
+|          |         |           |
+|  input2, +--------->  clone,   |
+|          |         |           |
+|  input3} +--------->  clone}   |
++----------+         +-----------+
+```
+
+### Example
+
+```lua
+map = nn.MapTable()
+map:add(nn.Linear(10, 3))
+
+x1 = torch.rand(10)
+x2 = torch.rand(10)
+y = map:forward{x1, x2}
+
+for i, k in pairs(y) do print(i, k) end
+```
+
+which gives the output:
+
+```lua
+1
+ 0.0345
+ 0.8695
+ 0.6502
+[torch.DoubleTensor of size 3]
+
+2
+ 0.0269
+ 0.4953
+ 0.2691
+[torch.DoubleTensor of size 3]
 ```
 
 

--- a/init.lua
+++ b/init.lua
@@ -142,6 +142,7 @@ require('nn.MixtureTable')
 require('nn.CriterionTable')
 require('nn.FlattenTable')
 require('nn.NarrowTable')
+require('nn.MapTable')
 
 require('nn.Criterion')
 require('nn.MSECriterion')


### PR DESCRIPTION
This module can be useful when dealing with multi-dimensional mini-batches, for
example when training recurrent neural networks (time X batch_size X elements).
It simply clones the contained module as necessary and applies each clone to the
respective input element.