### PR TITLE
HardTanh does not use inclusive bounds in inplace mode

### DIFF
--- a/lib/THNN/generic/HardTanh.c
+++ b/lib/THNN/generic/HardTanh.c
@@ -85,7 +85,7 @@ void THNN_(HardTanh_updateGradInput)(
     if (inplace)
     {
       TH_TENSOR_APPLY2(real, gradOutput, real, input,
-        if (*input_data < min_val || *input_data > max_val)
+        if (*input_data <= min_val || *input_data >= max_val)
           *gradOutput_data = 0;
       );
     }

--- a/test.lua
+++ b/test.lua
@@ -381,6 +381,19 @@ function nntest.HardTanh()
    local ferr, berr = jac.testIO(module, input)
    mytester:asserteq(ferr, 0, torch.typename(module) .. ' - i/o forward err ')
    mytester:asserteq(berr, 0, torch.typename(module) .. ' - i/o backward err ')
+
+   -- test inclusive bounds -- HardTahn(1,inf) should behave like Threshold(1)
+   local input = torch.Tensor({1})
+   local gradOutput = torch.Tensor({1})
+   local gradOutputClone = gradOutput:clone()
+   local module = nn.HardTanh(1, math.huge, true)
+   local tanhGradInput = module:backward(input, gradOutput)
+
+   local input = input:clone()
+   local gradOutput = gradOutputClone
+   local module  = nn.Threshold(1, 0, true)
+   local threshGradInput = module:backward(input, gradOutput)
+   mytester:assertTensorEq(tanhGradInput, threshGradInput, 0.000001, 'HardTanh gradInput')
 end
 
 function nntest.Clamp()


### PR DESCRIPTION
HardTanh does not use inclusive bounds in inplace mode, which makes it
inconsistent with the cuda version, as well as Threshold, ReLU, etc.

Note this doesn't fix torch7 issue #734 (https://github.com/torch/torch7/issues/734), but the inconsistency was causing issues on trivial with tests between the cuda and non-cuda versions of HardTanh.