### PR TITLE
Use stable loss and gradient for MultiLabelSoftMarginCriterion

### DIFF
--- a/MultiLabelSoftMarginCriterion.lua
+++ b/MultiLabelSoftMarginCriterion.lua
@@ -8,7 +8,7 @@
 -- and with weights:
 -- l(x,y) = - sum_i weights[i] (y[i] * log(p[i]) + (1 - y[i]) * log (1 - p[i]))
 --
---
+-- This uses the stable form of the loss and gradients.
 --]]
 
 
@@ -16,28 +16,46 @@ local MultiLabelSoftMarginCriterion, parent =
 torch.class('nn.MultiLabelSoftMarginCriterion', 'nn.Criterion')
 
 
-function MultiLabelSoftMarginCriterion:__init(weights)
+function MultiLabelSoftMarginCriterion:__init(weights, sizeAverage)
     parent.__init(self)
-    self.lsm = nn.Sigmoid()
-    self.nll = nn.BCECriterion(weights)
+    if sizeAverage ~= nil then
+        self.sizeAverage = sizeAverage
+    else
+        self.sizeAverage = true
+    end
+    self.sigmoid = nn.Sigmoid()
 end
 
 function MultiLabelSoftMarginCriterion:updateOutput(input, target)
-    input = input:nElement() == 1 and input or input:squeeze()
-    target = target:nElement() == 1 and target or target:squeeze()
-    self.lsm:updateOutput(input)
-    self.nll:updateOutput(self.lsm.output, target)
-    self.output = self.nll.output
+    local input_size = input:size()
+    local x = input:view(input:nElement())
+    local t = target:view(target:nElement())
+
+    self.sigmoid:updateOutput(x)
+
+    local indicator = x:ge(0):typeAs(x)
+    self.output = torch.sum(
+        torch.log(1 + torch.exp(x - torch.cmul(x, indicator):mul(2))) 
+        - torch.cmul(x, t - indicator)
+        )
+    
+    if self.sizeAverage then
+        self.output = self.output / input:nElement()
+    end
+    
     return self.output
 end
 
 function MultiLabelSoftMarginCriterion:updateGradInput(input, target)
-    local size = input:size()
-    input = input:nElement() ==1 and input or input:squeeze()
-    target = target:nElement() == 1 and target or target:squeeze()
-    self.nll:updateGradInput(self.lsm.output, target)
-    self.lsm:updateGradInput(input, self.nll.gradInput)
-    self.gradInput:view(self.lsm.gradInput, size)
+    local t = target:view(target:nElement())
+
+    self.gradInput = self.sigmoid.output - t
+    self.gradInput:resizeAs(input)
+
+    if self.sizeAverage then
+        self.gradInput:div(target:nElement())
+    end
+
     return self.gradInput
 end
 

--- a/MultiLabelSoftMarginCriterion.lua
+++ b/MultiLabelSoftMarginCriterion.lua
@@ -23,22 +23,35 @@ function MultiLabelSoftMarginCriterion:__init(weights, sizeAverage)
     else
         self.sizeAverage = true
     end
+    if weights ~= nil then
+        assert(weights:dim() == 1, "weights input should be 1-D Tensor")
+        self.weights = weights
+    end
     self.sigmoid = nn.Sigmoid()
 end
 
 function MultiLabelSoftMarginCriterion:updateOutput(input, target)
     local input_size = input:size()
+    local weights = self.weights
+    if weights ~= nil and target:dim() ~= 1 then
+        weights = self.weights:view(1, target:size(2)):expandAs(target)
+    end
+
     local x = input:view(input:nElement())
     local t = target:view(target:nElement())
-
+    
     self.sigmoid:updateOutput(x)
 
     local indicator = x:ge(0):typeAs(x)
-    self.output = torch.sum(
-        torch.log(1 + torch.exp(x - torch.cmul(x, indicator):mul(2))) 
+    local buffer = torch.log(1 + torch.exp(x - torch.cmul(x, indicator):mul(2))) 
         - torch.cmul(x, t - indicator)
-        )
-    
+
+    if weights ~= nil then
+        buffer:cmul(weights:reshape(weights:nElement()))
+    end
+
+    self.output = torch.sum(buffer)
+
     if self.sizeAverage then
         self.output = self.output / input:nElement()
     end
@@ -47,15 +60,24 @@ function MultiLabelSoftMarginCriterion:updateOutput(input, target)
 end
 
 function MultiLabelSoftMarginCriterion:updateGradInput(input, target)
+    local weights = self.weights
+    if weights ~= nil and target:dim() ~= 1 then
+        weights = self.weights:view(1, target:size(2)):expandAs(target)
+    end
+
     local t = target:view(target:nElement())
 
     self.gradInput = self.sigmoid.output - t
     self.gradInput:resizeAs(input)
 
+    if weights ~= nil then
+        self.gradInput:cmul(weights)
+    end
+
     if self.sizeAverage then
         self.gradInput:div(target:nElement())
     end
-
+    
     return self.gradInput
 end
 

--- a/MultiLabelSoftMarginCriterion.lua
+++ b/MultiLabelSoftMarginCriterion.lua
@@ -47,7 +47,7 @@ function MultiLabelSoftMarginCriterion:updateOutput(input, target)
         - torch.cmul(x, t - indicator)
 
     if weights ~= nil then
-        buffer:cmul(weights:reshape(weights:nElement()))
+        buffer:cmul(weights:resize(weights:nElement()))
     end
 
     self.output = torch.sum(buffer)


### PR DESCRIPTION
This replaces the earlier MultiLabelSoftMarginCriterion consisting of a Sigmoid, followed by a BCE for loss and gradient computation. The earlier structure led to instability due to numerical precision. 

The new code combines these two steps and uses a more stable form of the loss and gradient.

This addresses issue **https://github.com/torch/nn/issues/949**.
