### PR TITLE
Quiet require in interpreter

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -183,4 +183,9 @@ require('nn.SparseJacobian')
 require('nn.hessian')
 require('nn.test')
 
+local nnMetaTable = {
+   __tostring = function() return 'Neural Network package' end,
+}
+setmetatable(nn, nnMetaTable)
+
 return nn


### PR DESCRIPTION
Prevent `require 'nn'` to print all the list of modules in the `nn` package when issued in the interpreter.

```
atcold@AlfMAC2 ~/Work/GitHub/nn [silent*]$ th
 
  ______             __   |  Torch7                                         
 /_  __/__  ________/ /   |  Scientific computing for Lua. 
  / / / _ \/ __/ __/ _ \  |  Type ? for help                                
 /_/  \___/_/  \__/_//_/  |  https://github.com/torch         
                          |  http://torch.ch                  

th> require 'nn'
Neural Network package
                                                                      [0.0389s]
th> 
```
I could add `Type browse('nn') to read the documentation`.