### PR TITLE
improving error messages in THNN

### DIFF
--- a/lib/THNN/generic/Abs.c
+++ b/lib/THNN/generic/Abs.c
@@ -17,6 +17,7 @@ void THNN_(Abs_updateGradInput)(
           THTensor *gradOutput,
           THTensor *gradInput)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   THTensor_(resizeAs)(gradInput, input);
   TH_TENSOR_APPLY3(real, gradInput, real, gradOutput, real, input,
     real z = *input_data;

--- a/lib/THNN/generic/AbsCriterion.c
+++ b/lib/THNN/generic/AbsCriterion.c
@@ -10,7 +10,7 @@ void THNN_(AbsCriterion_updateOutput)(
           bool sizeAverage)
 {
   real sum = 0;
-
+  THNN_CHECK_NELEMENT(input, target);
   TH_TENSOR_APPLY2(real, input, real, target,
     sum += fabs(*input_data - *target_data);
   );
@@ -28,6 +28,7 @@ void THNN_(AbsCriterion_updateGradInput)(
           THTensor *gradInput,
           bool sizeAverage)
 {
+  THNN_CHECK_NELEMENT(input, target);
   real norm = (sizeAverage ? 1./((real)THTensor_(nElement)(input)) : 1.);
 
   THTensor_(resizeAs)(gradInput, input);

--- a/lib/THNN/generic/BCECriterion.c
+++ b/lib/THNN/generic/BCECriterion.c
@@ -4,8 +4,13 @@
 
 #define EPS 1e-12
 
-void THNN_(BCECriterion_updateOutput)(THNNState *state, THTensor *input, THTensor *target, THTensor *output, bool sizeAverage, THTensor *weights)
+void THNN_(BCECriterion_updateOutput)(THNNState *state, THTensor *input,
+				      THTensor *target, THTensor *output,
+				      bool sizeAverage, THTensor *weights)
 {
+  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_NELEMENT(input, weights);
+  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
   real sum = 0;
 
   if(weights)
@@ -29,8 +34,13 @@ void THNN_(BCECriterion_updateOutput)(THNNState *state, THTensor *input, THTenso
   THTensor_(set1d)(output, 0, sum);
 }
 
-void THNN_(BCECriterion_updateGradInput)(THNNState *state, THTensor *input, THTensor *target, THTensor *gradInput, bool sizeAverage, THTensor *weights)
+void THNN_(BCECriterion_updateGradInput)(THNNState *state, THTensor *input,
+					 THTensor *target, THTensor *gradInput,
+					 bool sizeAverage, THTensor *weights)
 {
+  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_NELEMENT(input, weights);
+
   real norm = (sizeAverage ? 1./((real)THTensor_(nElement)(input)) : 1.);
 
   THTensor_(resizeAs)(gradInput, input);

--- a/lib/THNN/generic/BatchNormalization.c
+++ b/lib/THNN/generic/BatchNormalization.c
@@ -9,6 +9,7 @@ void THNN_(BatchNormalization_updateOutput)(
   THTensor *save_mean, THTensor *save_std,
   bool train, double momentum, double eps)
 {
+  THTensor_(resizeAs)(output, input);
   long nInput = THTensor_(size)(input, 1);
   long f,n = THTensor_(nElement)(input) / nInput;
 
@@ -70,6 +71,7 @@ void THNN_(BatchNormalization_backward)(
   THTensor *save_mean, THTensor *save_std,
   bool train, double scale, double eps)
 {
+  THNN_CHECK_SHAPE(input, gradOutput);
   long nInput = THTensor_(size)(input, 1);
   long f,n = THTensor_(nElement)(input) / nInput;
 
@@ -97,6 +99,7 @@ void THNN_(BatchNormalization_backward)(
       dotp += (*in_data - mean) * (*gradOut_data););
 
     if (gradInput) {
+      THTensor_(resizeAs)(gradInput, input);      
       THTensor *gradIn = THTensor_(newSelect)(gradInput, 1, f);
 
       if (train) {

--- a/lib/THNN/generic/ClassNLLCriterion.c
+++ b/lib/THNN/generic/ClassNLLCriterion.c
@@ -11,6 +11,8 @@ void THNN_(ClassNLLCriterion_updateOutput)(
           THTensor *weights,
           THTensor *total_weight)
 {
+  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
+  THNN_CHECK_DIM_SIZE(total_weight, 1, 0, 1);
   int n_dims = THTensor_(nDimension)(input);
   int n_classes = THTensor_(size)(input, n_dims - 1);
 
@@ -21,7 +23,9 @@ void THNN_(ClassNLLCriterion_updateOutput)(
     THError("input tensor should be 1D or 2D");
   }
   if (weights && THTensor_(nElement)(weights) != n_classes) {
-    THError("weight tensor should be defined either for all or no classes");
+    THDescBuff s1 = THTensor_(sizeDesc)(weights);
+    THError("weight tensor should be defined either for all %d classes or no classes"
+	    " but got weight tensor of shape: %s", n_classes, s1.str);
   }
 
   input = THTensor_(newContiguous)(input);

--- a/lib/THNN/generic/DistKLDivCriterion.c
+++ b/lib/THNN/generic/DistKLDivCriterion.c
@@ -9,6 +9,9 @@ void THNN_(DistKLDivCriterion_updateOutput)(
           THTensor *output,
           bool sizeAverage)
 {
+  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
+  
   real sum = 0;
 
   TH_TENSOR_APPLY2(real, input, real, target,
@@ -28,6 +31,8 @@ void THNN_(DistKLDivCriterion_updateGradInput)(
           THTensor *gradInput,
           bool sizeAverage)
 {
+  THNN_CHECK_NELEMENT(input, target);
+  
   real norm = (sizeAverage ? 1./((real)THTensor_(nElement)(input)) : 1.);
 
   THTensor_(resizeAs)(gradInput, input);

--- a/lib/THNN/generic/ELU.c
+++ b/lib/THNN/generic/ELU.c
@@ -8,7 +8,7 @@ void THNN_(ELU_updateOutput)(
           THTensor *output,
           real alpha,
           bool inplace)
-{
+{  
   if(inplace) {
     TH_TENSOR_APPLY(real, input,
       if(*input_data <= 0) {
@@ -33,6 +33,7 @@ void THNN_(ELU_updateGradInput)(
           real alpha,
           bool inplace)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   if(inplace) {
     TH_TENSOR_APPLY2(real, gradOutput, real, output,
       if(*output_data <= 0) {

--- a/lib/THNN/generic/HardShrink.c
+++ b/lib/THNN/generic/HardShrink.c
@@ -27,6 +27,7 @@ void THNN_(HardShrink_updateGradInput)(
           THTensor *gradInput,
           real lambda)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   THTensor_(resizeAs)(gradInput, input);
   TH_TENSOR_APPLY3(real, gradInput, real, gradOutput, real, input,
     if (*input_data > lambda || *input_data < -lambda)

--- a/lib/THNN/generic/HardTanh.c
+++ b/lib/THNN/generic/HardTanh.c
@@ -72,6 +72,7 @@ void THNN_(HardTanh_updateGradInput)(
           real max_val,
           bool inplace)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   if (inplace)
     THTensor_(set)(gradInput, gradOutput);
   else

--- a/lib/THNN/generic/L1Cost.c
+++ b/lib/THNN/generic/L1Cost.c
@@ -7,6 +7,7 @@ void THNN_(L1Cost_updateOutput)(
           THTensor *input,
           THTensor *output)
 {
+  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
   accreal sum = 0;
 
   TH_TENSOR_APPLY(real, input, 
@@ -22,6 +23,7 @@ void THNN_(L1Cost_updateGradInput)(
           THTensor *gradOutput,
           THTensor *gradInput)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   THTensor_(resizeAs)(gradInput, input);
   TH_TENSOR_APPLY2(real, gradInput, real, input,
     if (*input_data > 0)

--- a/lib/THNN/generic/LeakyReLU.c
+++ b/lib/THNN/generic/LeakyReLU.c
@@ -34,6 +34,7 @@ void THNN_(LeakyReLU_updateGradInput)(
           real negval,
           bool inplace)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   if (inplace)
   {
     TH_TENSOR_APPLY2(real, gradOutput, real, input,

--- a/lib/THNN/generic/LogSigmoid.c
+++ b/lib/THNN/generic/LogSigmoid.c
@@ -25,6 +25,7 @@ void THNN_(LogSigmoid_updateGradInput)(
           THTensor *gradInput,
           THTensor *buffer)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   THTensor_(resizeAs)(gradInput, buffer);
   TH_TENSOR_APPLY3(real, gradInput, real, gradOutput, real, buffer,
     real z = *buffer_data;

--- a/lib/THNN/generic/LogSoftMax.c
+++ b/lib/THNN/generic/LogSoftMax.c
@@ -63,7 +63,7 @@ void THNN_(LogSoftMax_updateGradInput)(
           THTensor *gradInput,
           THTensor *output)
 {
-
+  THNN_CHECK_SHAPE(input, gradOutput);
   gradOutput = THTensor_(newContiguous)(gradOutput);
   real *gradInput_data, *gradOutput_data, *output_data;
   long nframe = 0, dim = 0;

--- a/lib/THNN/generic/MSECriterion.c
+++ b/lib/THNN/generic/MSECriterion.c
@@ -9,6 +9,9 @@ void THNN_(MSECriterion_updateOutput)(
           THTensor *output,
           bool sizeAverage)
 {
+  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
+
   real sum = 0;
 
   TH_TENSOR_APPLY2(real, input, real, target,
@@ -29,6 +32,8 @@ void THNN_(MSECriterion_updateGradInput)(
           THTensor *gradInput,
           bool sizeAverage)
 {
+  THNN_CHECK_NELEMENT(input, target);
+  
   real norm = (sizeAverage ? 2./((real)THTensor_(nElement)(input)) : 2.);
 
   THTensor_(resizeAs)(gradInput, input);

--- a/lib/THNN/generic/MarginCriterion.c
+++ b/lib/THNN/generic/MarginCriterion.c
@@ -10,6 +10,8 @@ void THNN_(MarginCriterion_updateOutput)(
           bool sizeAverage,
           real margin)
 {
+  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);  
   real sum = 0;
 
   TH_TENSOR_APPLY2(real, input, real, target,
@@ -31,6 +33,7 @@ void THNN_(MarginCriterion_updateGradInput)(
           bool sizeAverage,
           real margin)
 {
+  THNN_CHECK_NELEMENT(input, target);  
   real norm = (sizeAverage ? 1./((real)THTensor_(nElement)(input)) : 1.);
 
   THTensor_(resizeAs)(gradInput, input);

--- a/lib/THNN/generic/MultiLabelMarginCriterion.c
+++ b/lib/THNN/generic/MultiLabelMarginCriterion.c
@@ -2,6 +2,7 @@
 #define TH_GENERIC_FILE "generic/MultiLabelMarginCriterion.c"
 #else
 
+// TODO: improve error messages
 void THNN_(MultiLabelMarginCriterion_updateOutput)(
           THNNState *state,
           THTensor *input,
@@ -15,19 +16,22 @@ void THNN_(MultiLabelMarginCriterion_updateOutput)(
   long t, d, dt, ddt;
   real sum;
 
-  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2, "vector or matrix expected");
+  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2,
+	     "vector or matrix expected");
 
   if (input->nDimension == 1)
   {
     nframe = 1;
     dim = input->size[0];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == dim), 3, "inconsistent target size");
+    THArgCheck((target->nDimension == 1) && (target->size[0] == dim), 3,
+	       "inconsistent target size");
   }
   else
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->nDimension == 2) && (target->size[0] == nframe) && (target->size[1] == dim), 3, "inconsistent target size");
+    THArgCheck((target->nDimension == 2) && (target->size[0] == nframe)
+	       && (target->size[1] == dim), 3, "inconsistent target size");
   }
 
   THArgCheck(THTensor_(minall)(target) >= 0, 3, "target out of range");
@@ -101,21 +105,26 @@ void THNN_(MultiLabelMarginCriterion_updateGradInput)(
   long t, d, dt;
   real g;
 
-  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2, "vector or matrix expected");
+  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2,
+	     "vector or matrix expected");
 
   if (input->nDimension == 1)
   {
     nframe = 1;
     dim = input->size[0];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == dim), 3, "inconsistent target size");
-    THArgCheck((isTarget->nDimension == 1) && (isTarget->size[0] == dim), 3, "inconsistent isTarget size");
+    THArgCheck((target->nDimension == 1) && (target->size[0] == dim), 3,
+	       "inconsistent target size");
+    THArgCheck((isTarget->nDimension == 1) && (isTarget->size[0] == dim), 3,
+	       "inconsistent isTarget size");
   }
   else
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->nDimension == 2) && (target->size[0] == nframe) && (target->size[1] == dim), 3, "inconsistent target size");
-    THArgCheck((isTarget->nDimension == 2) && (isTarget->size[0] == nframe) && (isTarget->size[1] == dim), 3, "inconsistent isTarget size");
+    THArgCheck((target->nDimension == 2) && (target->size[0] == nframe)
+	       && (target->size[1] == dim), 3, "inconsistent target size");
+    THArgCheck((isTarget->nDimension == 2) && (isTarget->size[0] == nframe)
+	       && (isTarget->size[1] == dim), 3, "inconsistent isTarget size");
   }
 
   THArgCheck(THTensor_(minall)(target) >= 0, 3, "target out of range");

--- a/lib/THNN/generic/MultiMarginCriterion.c
+++ b/lib/THNN/generic/MultiMarginCriterion.c
@@ -2,6 +2,7 @@
 #define TH_GENERIC_FILE "generic/MultiMarginCriterion.c"
 #else
 
+// TODO: improve error messages
 void THNN_(MultiMarginCriterion_updateOutput)(
           THNNState *state,
           THTensor *input,
@@ -17,7 +18,8 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   long t, d;
   real sum;
 
-  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2, "vector or matrix expected");
+  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2,
+	     "vector or matrix expected");
 
   if (input->nDimension == 1)
   {
@@ -28,13 +30,15 @@ void THNN_(MultiMarginCriterion_updateOutput)(
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == nframe), 3, "inconsistent target size");
+    THArgCheck((target->nDimension == 1) && (target->size[0] == nframe), 3,
+	       "inconsistent target size");
   }
 
   for (t = 0; t < nframe; t++)
   {
     real idx = THTensor_(get1d)(target, t);
-    THArgCheck((idx >= TH_INDEX_BASE) && (idx < dim + TH_INDEX_BASE), 3, "target out of range");
+    THArgCheck((idx >= TH_INDEX_BASE) && (idx < dim + TH_INDEX_BASE), 3,
+	       "target out of range");
   }
 
   input = THTensor_(newContiguous)(input);
@@ -95,7 +99,8 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   long t, d;
   real g;
 
-  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2, "vector or matrix expected");
+  THArgCheck((input->nDimension == 1) || (input->nDimension == 2), 2,
+	     "vector or matrix expected");
 
   if (input->nDimension == 1)
   {
@@ -106,7 +111,8 @@ void THNN_(MultiMarginCriterion_updateGradInput)(
   {
     nframe = input->size[0];
     dim = input->size[1];
-    THArgCheck((target->nDimension == 1) && (target->size[0] == nframe), 3, "inconsistent target size");
+    THArgCheck((target->nDimension == 1) && (target->size[0] == nframe), 3,
+	       "inconsistent target size");
   }
 
   g = (sizeAverage ? 1./((real)(nframe*dim)) : 1./((real)dim));

--- a/lib/THNN/generic/PReLU.c
+++ b/lib/THNN/generic/PReLU.c
@@ -76,6 +76,7 @@ void THNN_(PReLU_updateGradInput)(
           THTensor *weight,
           THIndex_t nOutputPlane)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   THTensor_(resizeAs)(gradInput, input);
 
   if (nOutputPlane == 0)
@@ -160,6 +161,7 @@ void THNN_(PReLU_accGradParameters)(
           THIndex_t nOutputPlane,
           real scale)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);  
   real *gradWeight_data = THTensor_(data)(gradWeight);
 
   if (nOutputPlane == 0)

--- a/lib/THNN/generic/RReLU.c
+++ b/lib/THNN/generic/RReLU.c
@@ -86,6 +86,7 @@ void THNN_(RReLU_updateGradInput)(
           bool train,
           bool inplace)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   if (train && upper - lower > 1E-6)    // e.g. if upper == lower, RReLU behaves like LeakyReLU
   {
     // multiply the gradient by the noise tensor

--- a/lib/THNN/generic/Sigmoid.c
+++ b/lib/THNN/generic/Sigmoid.c
@@ -21,6 +21,7 @@ void THNN_(Sigmoid_updateGradInput)(
           THTensor *gradInput,
           THTensor *output)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   THTensor_(resizeAs)(gradInput, output);
   TH_TENSOR_APPLY3(real, gradInput, real, gradOutput, real, output,
     real z = *output_data;

--- a/lib/THNN/generic/SmoothL1Criterion.c
+++ b/lib/THNN/generic/SmoothL1Criterion.c
@@ -9,6 +9,9 @@ void THNN_(SmoothL1Criterion_updateOutput)(
           THTensor *output,
           bool sizeAverage)
 {
+  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
+  
   real sum = 0;
   TH_TENSOR_APPLY2(real, input, real, target,
     real z = fabs(*input_data - *target_data);
@@ -28,6 +31,7 @@ void THNN_(SmoothL1Criterion_updateGradInput)(
           THTensor *gradInput,
           bool sizeAverage)
 {
+  THNN_CHECK_NELEMENT(input, target);
   real norm = (sizeAverage ? 1./((real)THTensor_(nElement)(input)) : 1.);
 
   THTensor_(resizeAs)(gradInput, input);

--- a/lib/THNN/generic/SoftMarginCriterion.c
+++ b/lib/THNN/generic/SoftMarginCriterion.c
@@ -9,6 +9,9 @@ void THNN_(SoftMarginCriterion_updateOutput)(
   THTensor *output,
   bool sizeAverage)
 {
+  THNN_CHECK_NELEMENT(input, target);
+  THNN_CHECK_DIM_SIZE(output, 1, 0, 1);
+
   real sum;
 
   sum = 0;
@@ -29,6 +32,7 @@ void THNN_(SoftMarginCriterion_updateGradInput)(
   THTensor *gradInput,
   bool sizeAverage)
 {
+  THNN_CHECK_NELEMENT(input, target);
   real norm = (sizeAverage ? 1./((real)THTensor_(nElement)(input)) : 1.);
 
   THTensor_(resizeAs)(gradInput, input);

--- a/lib/THNN/generic/SoftMax.c
+++ b/lib/THNN/generic/SoftMax.c
@@ -85,6 +85,7 @@ void THNN_(SoftMax_updateGradInput)(
           THTensor *gradInput,
           THTensor *output)
 {
+  THNN_CHECK_SHAPE(input, gradOutput);  
   real *gradInput_data, *gradOutput_data, *output_data;
   long nframe = 0, dim = 0, stride = 0;
   long t;

--- a/lib/THNN/generic/SoftPlus.c
+++ b/lib/THNN/generic/SoftPlus.c
@@ -26,6 +26,7 @@ void THNN_(SoftPlus_updateGradInput)(
           real beta,
           real threshold)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   THTensor_(resizeAs)(gradInput, output);
   
   // d/dx[log(1+exp(k*x))/k] = exp(kx) / (exp(kx) + 1)

--- a/lib/THNN/generic/SoftShrink.c
+++ b/lib/THNN/generic/SoftShrink.c
@@ -27,6 +27,7 @@ void THNN_(SoftShrink_updateGradInput)(
           THTensor *gradInput,
           real lambda)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   THTensor_(resizeAs)(gradInput, input);
   TH_TENSOR_APPLY3(real, gradInput, real, gradOutput, real, input,
     if ((*input_data) > lambda || (*input_data) < -lambda)

--- a/lib/THNN/generic/SpatialAdaptiveMaxPooling.c
+++ b/lib/THNN/generic/SpatialAdaptiveMaxPooling.c
@@ -96,7 +96,8 @@ void THNN_(SpatialAdaptiveMaxPooling_updateOutput)(
   real *indices_data;
 
 
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4 , 2, "3D or 4D (batch mode) tensor expected");
+  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (input->nDimension == 4)
   {

--- a/lib/THNN/generic/SpatialClassNLLCriterion.c
+++ b/lib/THNN/generic/SpatialClassNLLCriterion.c
@@ -4,9 +4,12 @@
 
 #define INITIAL_CHECK                                                            \
   THArgCheck(THIndexTensor_(nDimension)(target) == 3, 3,                         \
-              "only batches of spatial targets supported (3D tensors)");         \
-  THArgCheck(THTensor_(nDimension)(input) == 4, 2,                               \
-              "only batches of spatial inputs supported (4D tensors)");          \
+    "only batches of spatial targets supported (3D tensors)"		         \
+	     " but got targets of dimension: %d",			         \
+	     THIndexTensor_(nDimension)(target));			         \
+  THArgCheck(THTensor_(nDimension)(input) == 4, 2,			         \
+	     "only batches of spatial inputs supported (4D tensors), "	         \
+	     "but got input of dimension: %d", THTensor_(nDimension)(input));    \
   if (weights && THTensor_(nElement)(weights) != THTensor_(size)(input, 1)) {    \
     THError("weight tensor should be defined either for all or no classes");     \
   }                                                                              \

--- a/lib/THNN/generic/SpatialConvolutionLocal.c
+++ b/lib/THNN/generic/SpatialConvolutionLocal.c
@@ -3,10 +3,13 @@
 #else
 
 
-static void THNN_(SpatialConvolutionLocal_updateOutput_frame)(THTensor *input, THTensor *output, THTensor *weight, THTensor *bias, THTensor *finput,
-                                                         int kW, int kH, int dW, int dH, int padW, int padH,
-                                                         long nInputPlane, long inputWidth, long inputHeight,
-                                                         long nOutputPlane, long outputWidth, long outputHeight)
+static void THNN_(SpatialConvolutionLocal_updateOutput_frame)
+     (
+      THTensor *input, THTensor *output,
+      THTensor *weight, THTensor *bias, THTensor *finput,
+      int kW, int kH, int dW, int dH, int padW, int padH,
+      long nInputPlane, long inputWidth, long inputHeight,
+      long nOutputPlane, long outputWidth, long outputHeight)
 {
   long i;
   THTensor *output3d, *finput3d;
@@ -47,6 +50,7 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
     long inputWidth, long inputHeight,
     long outputWidth, long outputHeight)
 {
+  // TODO: add argument checking
   long nInputPlane = THTensor_(size)(weight,2)/(kW*kH);
   long nOutputPlane = THTensor_(size)(weight,1);
 
@@ -88,10 +92,12 @@ void THNN_(SpatialConvolutionLocal_updateOutput)(
 }
 
 
-static void THNN_(SpatialConvolutionLocal_updateGradInput_frame)(THTensor *gradInput, THTensor *gradOutput, THTensor *weight, THTensor *fgradInput,
-                                                            int kW, int kH, int dW, int dH, int padW, int padH, 
-                                                            long nInputPlane, long inputWidth, long inputHeight,
-                                                            long nOutputPlane, long outputWidth, long outputHeight)
+static void THNN_(SpatialConvolutionLocal_updateGradInput_frame)
+     (THTensor *gradInput, THTensor *gradOutput,
+      THTensor *weight, THTensor *fgradInput,
+      int kW, int kH, int dW, int dH, int padW, int padH, 
+      long nInputPlane, long inputWidth, long inputHeight,
+      long nOutputPlane, long outputWidth, long outputHeight)
 {
   THTensor *gradOutput3d, *fgradInput3d;
   gradOutput3d = THTensor_(newWithStorage3d)(gradOutput->storage, gradOutput->storageOffset,
@@ -168,10 +174,12 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
   THTensor_(transpose)(weight, weight, 1, 2);
 }
 
-static void THNN_(SpatialConvolutionLocal_accGradParameters_frame)(THTensor *gradOutput, THTensor *gradWeight, THTensor *gradBias, THTensor *finput, real scale, 
-                                                            int kW, int kH, int dW, int dH, int padW, int padH, 
-                                                            long nInputPlane, long inputWidth, long inputHeight,
-                                                            long nOutputPlane, long outputWidth, long outputHeight)
+static void THNN_(SpatialConvolutionLocal_accGradParameters_frame)
+     (THTensor *gradOutput, THTensor *gradWeight, THTensor *gradBias,
+      THTensor *finput, real scale, 
+      int kW, int kH, int dW, int dH, int padW, int padH, 
+      long nInputPlane, long inputWidth, long inputHeight,
+      long nOutputPlane, long outputWidth, long outputHeight)
 {
    
   THTensor *gradOutput3d, *finput3d;

--- a/lib/THNN/generic/SpatialDilatedConvolution.c
+++ b/lib/THNN/generic/SpatialDilatedConvolution.c
@@ -15,11 +15,17 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
     int padW, int padH,
     int dilationW, int dilationH)
 {
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
-  THArgCheck(weight->nDimension == 4, 4, "weight tensor must be 4D (nOutputPlane,nInputPlane,kH,kW)");
-  THArgCheck(!bias || weight->size[0] == bias->size[0], 4, "nOutputPlane mismatch in weight and bias");
-  THArgCheck(kW > 0 && kH > 0, 8, "kernel size should be greater than zero");
-  THArgCheck(dW > 0 && dH > 0, 10, "stride should be greater than zero");
+  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+		"3D or 4D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(weight->nDimension == 4, 4, weight,
+		"4D weight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
+		"but got: %s");
+  THArgCheck(!bias || weight->size[0] == bias->size[0], 4,
+	     "nOutputPlane mismatch in weight and bias");
+  THArgCheck(kW > 0 && kH > 0, 8,
+	       "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
+  THArgCheck(dW > 0 && dH > 0, 10,
+	     "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
   // Params:
   int nInputPlane = weight->size[1];
@@ -27,12 +33,16 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
 
   int batch = 1;
   if (input->nDimension == 3) {
-    THArgCheck(input->size[0] == nInputPlane, 2, "input channels and nInputPlane dont match");
+    THArgCheck(input->size[0] == nInputPlane, 2,
+	       "input channels %d and nInputPlane %d dont match.",
+	       input->size[0], nInputPlane);
     // Force batch
     batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
   } else {
-    THArgCheck(input->size[1] == nInputPlane, 2, "input channels and nInputPlane dont match");
+    THArgCheck(input->size[1] == nInputPlane, 2,
+	       "input channels %d and nInputPlane %d dont match",
+	       input->size[1], nInputPlane);
   }
 
   long inputWidth   = input->size[3];
@@ -41,7 +51,8 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   long outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
 
   if (outputWidth < 1 || outputHeight < 1)
-    THError("Given input size: (%dx%dx%d). Calculated output size: (%dx%dx%d). Output size is too small",
+    THError("Given input size: (%dx%dx%d). "
+	    "Calculated output size: (%dx%dx%d). Output size is too small",
             nInputPlane,inputHeight,inputWidth,nOutputPlane,outputHeight,outputWidth);
 
   // Batch size + input planes
@@ -142,10 +153,15 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
     int padW, int padH,
     int dilationW, int dilationH)
 {
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
-  THArgCheck(weight->nDimension == 4, 4, "weight tensor must be 4D (nOutputPlane,nInputPlane,kH,kW)");
-  THArgCheck(kW > 0 && kH > 0, 9, "kernel size should be greater than zero");
-  THArgCheck(dW > 0 && dH > 0, 11, "stride should be greater than zero");
+  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+		"3D or 4D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(weight->nDimension == 4, 4, weight,
+		"4D weight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
+		"but got: %s");
+  THArgCheck(kW > 0 && kH > 0, 9,
+	       "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
+  THArgCheck(dW > 0 && dH > 0, 11,
+	     "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
   // Params
   int nInputPlane = weight->size[1];
@@ -156,7 +172,8 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
     // Force batch
     batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
-    THTensor_(resize4d)(gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
+    THTensor_(resize4d)(gradOutput, 1, gradOutput->size[0], gradOutput->size[1],
+			gradOutput->size[2]);
   }
 
   long inputWidth   = input->size[3];
@@ -236,11 +253,17 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
     int dilationW, int dilationH,
     real scale)
 {
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
-  THArgCheck(gradWeight->nDimension == 4, 4, "gradWeight tensor must be 4D (nOutputPlane,nInputPlane,kH,kW)");
-  THArgCheck(!gradBias || gradWeight->size[0] == gradBias->size[0], 4, "nOutputPlane mismatch in gradWeight and gradBias");
-  THArgCheck(kW > 0 && kH > 0, 8, "kernel size should be greater than zero");
-  THArgCheck(dW > 0 && dH > 0, 10, "stride should be greater than zero");
+  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+		"3D or 4D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(gradWeight->nDimension == 4, 4, gradWeight,
+		"4D gradWeight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
+		"but got: %s");
+  THArgCheck(!gradBias || gradWeight->size[0] == gradBias->size[0], 4,
+	     "nOutputPlane mismatch in gradWeight and gradBias");
+  THArgCheck(kW > 0 && kH > 0, 8,
+	       "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
+  THArgCheck(dW > 0 && dH > 0, 10,
+	     "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
 
   // Params
   int nInputPlane = gradWeight->size[1];
@@ -251,7 +274,8 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
     // Force batch
     batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
-    THTensor_(resize4d)(gradOutput, 1, gradOutput->size[0], gradOutput->size[1], gradOutput->size[2]);
+    THTensor_(resize4d)(gradOutput, 1, gradOutput->size[0],
+			gradOutput->size[1], gradOutput->size[2]);
   }
 
   long inputWidth   = input->size[3];

--- a/lib/THNN/generic/SpatialFractionalMaxPooling.c
+++ b/lib/THNN/generic/SpatialFractionalMaxPooling.c
@@ -103,8 +103,8 @@ void THNN_(SpatialFractionalMaxPooling_updateOutput)(
   int widthDim = 2;
 
   long numInputDims = THTensor_(nDimension)(input);
-  THArgCheck(numInputDims == 3 || numInputDims == 4, 2,
-             "3D or 4D (batch mode) tensor expected");
+  THNN_ARGCHECK(numInputDims == 3 || numInputDims == 4, 2, input,
+		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (numInputDims == 4) {
     numBatch = THTensor_(size)(input, 0);
@@ -119,9 +119,11 @@ void THNN_(SpatialFractionalMaxPooling_updateOutput)(
   long inputW = THTensor_(size)(input, widthDim);
 
   THArgCheck(outputH + poolSizeH - 1 < inputH, 7,
-             "poolSizeH too large relative to input height");
+             "poolSizeH (%d) too large relative to input height (%d)",
+	     poolSizeH, inputH);
   THArgCheck(outputW + poolSizeW - 1 < inputW, 6,
-             "poolSizeW too large relative to input width");
+             "poolSizeW (%d) too large relative to input width (%d)",
+	     poolSizeW, inputW);
 
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);

--- a/lib/THNN/generic/SpatialFullConvolution.c
+++ b/lib/THNN/generic/SpatialFullConvolution.c
@@ -73,16 +73,21 @@ void THNN_(SpatialFullConvolution_updateOutput)(
   int nInputPlane = THTensor_(size)(weight,0);
   int nOutputPlane = THTensor_(size)(weight,1);
 
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+		"3D or 4D (batch mode) tensor expected for input, but got: %s")
 
   int batch = 1;
   if (input->nDimension == 3) {
-    THArgCheck(input->size[0] == nInputPlane, 2, "input channels and nInputPlane dont match");
+    THArgCheck(input->size[0] == nInputPlane, 2,
+	       "input channels (%d) and nInputPlane (%d) dont match",
+	       input->size[0], nInputPlane);
     // Force batch
     batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
   } else {
-    THArgCheck(input->size[1] == nInputPlane, 2, "input channels and nInputPlane dont match");
+    THArgCheck(input->size[1] == nInputPlane, 2,
+	       "input channels (%d) and nInputPlane (%d) dont match",
+	       input->size[1], nInputPlane);
   }
 
   long inputWidth   = input->size[3];
@@ -189,10 +194,12 @@ void THNN_(SpatialFullConvolution_updateGradInput)(
     int padW, int padH,
     int adjW, int adjH)
 {
+  // TODO: check gradOutput shape
   int nInputPlane = THTensor_(size)(weight,0);
   int nOutputPlane = THTensor_(size)(weight,1);
 
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   int batch = 1;
   if (input->nDimension == 3) {
@@ -286,7 +293,8 @@ void THNN_(SpatialFullConvolution_accGradParameters)(
   int nInputPlane = THTensor_(size)(gradWeight,0);
   int nOutputPlane = THTensor_(size)(gradWeight,1);
 
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4, 2, "3D or 4D (batch mode) tensor is expected");
+  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   int batch = 1;
   if (input->nDimension == 3) {

--- a/lib/THNN/generic/SpatialMaxUnpooling.c
+++ b/lib/THNN/generic/SpatialMaxUnpooling.c
@@ -49,10 +49,9 @@ void THNN_(SpatialMaxUnpooling_updateOutput)(
   real *indices_data;
 
 
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4 , 2, "3D or 4D (batch mode) tensor expected");
-  if (!THTensor_(isSameSizeAs)(input, indices)){
-    THError("Invalid input size w.r.t current indices size");
-  }
+  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+		"3D or 4D (batch mode) tensor expected for input, but got: %s");
+  THNN_CHECK_SHAPE(input, indices);
 
   if (input->nDimension == 4)
   {
@@ -160,9 +159,7 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
   real *gradOutput_data;
   real *indices_data;
 
-  if (!THTensor_(isSameSizeAs)(input, indices)){
-    THError("Invalid input size w.r.t current indices size");
-  }
+  THNN_CHECK_SHAPE(input, indices);
 
   /* get contiguous gradOutput and indices */
   gradOutput = THTensor_(newContiguous)(gradOutput);
@@ -184,7 +181,8 @@ void THNN_(SpatialMaxUnpooling_updateGradInput)(
   iwidth = input->size[dimw];
 
   if(owidth!=gradOutput->size[dimw] || oheight!=gradOutput->size[dimh]){
-    THError("Inconsistent gradOutput size. oheight= %d, owidth= %d, gradOutput: %dx%d", oheight, owidth,gradOutput->size[dimh],gradOutput->size[dimw]);
+    THError("Inconsistent gradOutput size. oheight= %d, owidth= %d, gradOutput: %dx%d",
+	    oheight, owidth,gradOutput->size[dimh],gradOutput->size[dimw]);
   }
 
   /* get raw pointers */

--- a/lib/THNN/generic/SpatialReflectionPadding.c
+++ b/lib/THNN/generic/SpatialReflectionPadding.c
@@ -67,8 +67,8 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
   real *input_data;
   real *output_data;
 
-  THArgCheck(input->nDimension == 3 ||
-    input->nDimension == 4 , 2, "input must be 3 or 4-dimensional");
+  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (input->nDimension == 4)
   {
@@ -85,7 +85,10 @@ void THNN_(SpatialReflectionPadding_updateOutput)(THNNState *state,
   oheight = iheight + pad_t + pad_b;
   owidth  = iwidth + pad_l + pad_r;
 
-  THArgCheck(owidth >= 1 || oheight >= 1 , 2, "input is too small");
+  THArgCheck(owidth >= 1 || oheight >= 1 , 2,
+	     "input (H: %d, W: %d)is too small."
+	     " Calculated output H: %d W: %d",
+	     iheight, iwidth, oheight, owidth);
 
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);
@@ -212,9 +215,11 @@ void THNN_(SpatialReflectionPadding_updateGradInput)(THNNState *state,
   owidth  = iwidth + pad_l + pad_r;
 
   THArgCheck(owidth == THTensor_(size)(gradOutput, dimw), 3,
-                "gradOutput width unexpected");
+	     "gradOutput width unexpected. Expected: %d, Got: %d",
+	     owidth, THTensor_(size)(gradOutput, dimw));
   THArgCheck(oheight == THTensor_(size)(gradOutput, dimh), 3,
-                "gradOutput height unexpected");
+                "gradOutput height unexpected. Expected: %d, Got: %d",
+	     oheight, THTensor_(size)(gradOutput, dimh));
 
   /* get contiguous gradOutput */
   gradOutput = THTensor_(newContiguous)(gradOutput);

--- a/lib/THNN/generic/SpatialReplicationPadding.c
+++ b/lib/THNN/generic/SpatialReplicationPadding.c
@@ -66,8 +66,8 @@ void THNN_(SpatialReplicationPadding_updateOutput)(THNNState *state,
   real *input_data;
   real *output_data;
 
-  THArgCheck(input->nDimension == 3 || input->nDimension == 4,
-             2, "input must be 3 or 4-dimensional");
+  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   if (input->nDimension == 4)
   {
@@ -84,7 +84,11 @@ void THNN_(SpatialReplicationPadding_updateOutput)(THNNState *state,
   oheight = iheight + pad_t + pad_b;
   owidth  = iwidth + pad_l + pad_r;
 
-  THArgCheck(owidth >= 1 || oheight >= 1 , 2, "input is too small");
+  THArgCheck(owidth >= 1 || oheight >= 1 , 2,
+	     "input (H: %d, W: %d)is too small."
+	     " Calculated output H: %d W: %d",
+	     iheight, iwidth, oheight, owidth);
+
 
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);
@@ -210,9 +214,11 @@ void THNN_(SpatialReplicationPadding_updateGradInput)(THNNState *state,
   owidth  = iwidth + pad_l + pad_r;
 
   THArgCheck(owidth == THTensor_(size)(gradOutput, dimw), 3,
-                "gradOutput width unexpected");
+	     "gradOutput width unexpected. Expected: %d, Got: %d",
+	     owidth, THTensor_(size)(gradOutput, dimw));
   THArgCheck(oheight == THTensor_(size)(gradOutput, dimh), 3,
-                "gradOutput height unexpected");
+                "gradOutput height unexpected. Expected: %d, Got: %d",
+	     oheight, THTensor_(size)(gradOutput, dimh));
 
   /* get contiguous gradOutput */
   gradOutput = THTensor_(newContiguous)(gradOutput);

--- a/lib/THNN/generic/SpatialUpSamplingBilinear.c
+++ b/lib/THNN/generic/SpatialUpSamplingBilinear.c
@@ -9,6 +9,7 @@ void THNN_(SpatialUpSamplingBilinear_updateOutput)(
     THNNState *state,
     THTensor *input,
     THTensor *output){
+  // TODO: check argument shapes
   input = THTensor_(newContiguous)(input);
   output = THTensor_(newContiguous)(output);
   THTensor_(zero)(output);
@@ -68,6 +69,7 @@ void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
     THNNState *state,
     THTensor *gradOutput,
     THTensor *gradInput){
+  // TODO: check argument shapes  
   gradInput = THTensor_(newContiguous)(gradInput);
   gradOutput = THTensor_(newContiguous)(gradOutput);
   THTensor_(zero)(gradInput);

--- a/lib/THNN/generic/SpatialUpSamplingNearest.c
+++ b/lib/THNN/generic/SpatialUpSamplingNearest.c
@@ -8,6 +8,7 @@ void THNN_(SpatialUpSamplingNearest_updateOutput)(
     THTensor *output,
     int scale_factor)
 {
+  // TODO: check argument shapes  
   int dW = scale_factor;
   int dH = scale_factor;
   int xDim = input->nDimension-2;
@@ -74,6 +75,7 @@ void THNN_(SpatialUpSamplingNearest_updateGradInput)(
     THTensor *gradInput,
     int scale_factor)
 {
+  // TODO: check argument shapes  
   int dW = scale_factor;
   int dH = scale_factor;
   int xDim = gradInput->nDimension-2;

--- a/lib/THNN/generic/Sqrt.c
+++ b/lib/THNN/generic/Sqrt.c
@@ -19,6 +19,7 @@ void THNN_(Sqrt_updateGradInput)(
           THTensor *gradInput,
           THTensor *output)
 {
+  THNN_CHECK_SHAPE(output, gradOutput);
   THTensor_(resizeAs)(gradInput, input);
 
   if (output->nDimension == 1 || 

--- a/lib/THNN/generic/Square.c
+++ b/lib/THNN/generic/Square.c
@@ -32,6 +32,7 @@ void THNN_(Square_updateGradInput)(
           THTensor *gradOutput,
           THTensor *gradInput)
 {
+  THNN_CHECK_SHAPE(input, gradOutput);
   THTensor_(resizeAs)(gradInput, input);
 
   if (input->nDimension == 1 || 

--- a/lib/THNN/generic/Tanh.c
+++ b/lib/THNN/generic/Tanh.c
@@ -18,6 +18,7 @@ void THNN_(Tanh_updateGradInput)(
           THTensor *gradInput,
           THTensor *output)
 {
+  THNN_CHECK_SHAPE(output, gradOutput);
   THTensor_(resizeAs)(gradInput, output);
 
   if (output->nDimension == 1 || 

--- a/lib/THNN/generic/TemporalConvolution.c
+++ b/lib/THNN/generic/TemporalConvolution.c
@@ -20,15 +20,20 @@ void THNN_(TemporalConvolution_updateOutput)(
   int dimS = 0; // sequence dimension
   int dimF = 1; // feature dimension
   
-  THArgCheck(input->nDimension == 2 || input->nDimension == 3, 2, "2D or 3D(batch mode) tensor expected");
+  THNN_ARGCHECK(input->nDimension == 2 || input->nDimension == 3, 2, input,
+		"2D or 3D (batch mode) tensor expected for input, but got: %s");
   
   if (input->nDimension == 3) 
   {
     dimS = 1;
     dimF = 2;
   }
-  THArgCheck(input->size[dimF] == inputFrameSize, 2, "invalid input frame size");
-  THArgCheck(input->size[dimS] >= kW, 2, "input sequence smaller than kernel size");
+  THArgCheck(input->size[dimF] == inputFrameSize, 2,
+	     "invalid input frame size. Got: %d, Expected: %d",
+	     input->size[dimF], inputFrameSize);
+  THArgCheck(input->size[dimS] >= kW, 2,
+	     "input sequence smaller than kernel size. Got: %d, Expected: %d",
+	     input->size[dimS], kW);
 
   input = THTensor_(newContiguous)(input);
   outputWindow = THTensor_(new)();

--- a/lib/THNN/generic/Threshold.c
+++ b/lib/THNN/generic/Threshold.c
@@ -36,6 +36,7 @@ void THNN_(Threshold_updateGradInput)(
           real val,
           bool inplace)
 {
+  THNN_CHECK_NELEMENT(input, gradOutput);
   if (inplace)
   {
     TH_TENSOR_APPLY2(real, gradOutput, real, input,

--- a/lib/THNN/generic/VolumetricAveragePooling.c
+++ b/lib/THNN/generic/VolumetricAveragePooling.c
@@ -81,9 +81,8 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
   real *input_data;
   real *output_data;
 
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2,
-    "4D or 5D (batch-mode) tensor expected"
-  );
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   int dimN = 0;
   int dimt = 1;
@@ -98,9 +97,12 @@ void THNN_(VolumetricAveragePooling_updateOutput)(
     dimw++;
   }
 
-  THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH && input->size[dimt] >= kT, 2,
-    "input image smaller than kernel size"
-  );
+  THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH
+	     && input->size[dimt] >= kT, 2,
+	     "input image (T: %d H: %d W: %d) smaller than "
+	     "kernel size (kT: %d kH: %d kW: %d)",
+	     input->size[dimt], input->size[dimh], input->size[dimw],
+	     kT, kH, kW);
 
   /* sizes */
   nslices = input->size[dimN];
@@ -242,6 +244,7 @@ void THNN_(VolumetricAveragePooling_updateGradInput)(
   int dimh = 2;
   int dimw = 3;
 
+  // TODO: gradOutput shape check
   /* get contiguous gradOutput */
   gradOutput = THTensor_(newContiguous)(gradOutput);
 

--- a/lib/THNN/generic/VolumetricConvolution.c
+++ b/lib/THNN/generic/VolumetricConvolution.c
@@ -19,9 +19,8 @@ void THNN_(VolumetricConvolution_updateOutput)(
 {
   THArgCheck(pT != 0 || pW != 0 || pH != 0, 9, "padding not supported by CPU backend");   // sharing signature with CUDA version
 
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2,
-    "4D or 5D (batch-mode) tensor expected"
-  );
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   int dimt = 1;
   int dimh = 2;
@@ -106,15 +105,15 @@ void THNN_(VolumetricConvolution_updateGradInput)(
 {
   THArgCheck(pT != 0 || pW != 0 || pH != 0, 9, "padding not supported by CPU backend");   // sharing signature with CUDA version
 
-  THArgCheck(weight->nDimension == 5, 4,
-    "5D weight tensor is expected (nOutputPlane x nInputPlane x kT x kH x kW)"
-  );
+  THNN_ARGCHECK(weight->nDimension == 5, 4, weight,
+		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+		"expected for weight, but got: %s");
 
   int nOutputPlane = (int)weight->size[0];
 
-  THArgCheck(gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3,
-    "4D or 5D (batch-mode) tensor expected"
-  );
+  THNN_ARGCHECK(gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3,
+		gradOutput,
+		"4D or 5D (batch mode) tensor expected for gradOutput, but got: %s");
 
   int dimPlane = 0;
   if (gradOutput->nDimension == 5)
@@ -175,9 +174,9 @@ void THNN_(VolumetricConvolution_accGradParameters)(
 {
   THArgCheck(pT != 0 || pW != 0 || pH != 0, 9, "padding not supported by CPU backend");   // sharing signature with CUDA version
 
-  THArgCheck(gradWeight->nDimension == 5, 4,
-    "5D gradWeight tensor is expected (nOutputPlane x nInputPlane x kT x kH x kW)"
-  );
+  THNN_ARGCHECK(gradWeight->nDimension == 5, 4, gradWeight,
+		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+		"expected for gradWeight, but got: %s");
 
   int nOutputPlane = (int)gradWeight->size[0];
 

--- a/lib/THNN/generic/VolumetricConvolutionMM.c
+++ b/lib/THNN/generic/VolumetricConvolutionMM.c
@@ -268,9 +268,8 @@ void THNN_(VolumetricConvolutionMM_updateOutput)(
   long outputHeight;
   long outputWidth;
 
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2,
-    "4D or 5D(batch mode) tensor expected"
-  );
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   if (input->nDimension == 5)
   {

--- a/lib/THNN/generic/VolumetricDilatedConvolution.c
+++ b/lib/THNN/generic/VolumetricDilatedConvolution.c
@@ -15,8 +15,11 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
           int padT, int padW, int padH,
           int dilationT, int dilationW, int dilationH)
 {
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected, but got: %d", input->nDimension);
-  THArgCheck(weight->nDimension == 5, 4, "weight tensor must be 5D (nOutputPlane,nInputPlane,kT,kH,kW)");
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(weight->nDimension == 5, 4, weight,
+		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+		"expected for weight, but got: %s");
   THArgCheck(!bias || weight->size[0] == bias->size[0], 4, "nOutputPlane mismatch in weight and bias");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8, "kernel size should be greater than zero");
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 10, "stride should be greater than zero");
@@ -146,9 +149,14 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
           int padT, int padW, int padH,
           int dilationT, int dilationW, int dilationH)
 {
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
-  THArgCheck(gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3, "4D or 5D (batch mode) tensor is expected");
-  THArgCheck(weight->nDimension == 5, 4, "weight tensor must be 5D (nOutputPlane,nInputPlane,kT,kH,kW)");
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3,
+		gradOutput,
+		"4D or 5D (batch mode) tensor expected for gradOutput, but got: %s");
+  THNN_ARGCHECK(weight->nDimension == 5, 4, weight,
+		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+		"expected for weight, but got: %s");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8, "kernel size should be greater than zero");
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 10, "stride should be greater than zero");
 
@@ -246,9 +254,14 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
           int dilationT, int dilationW, int dilationH,
           real scale)
 {
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2, "4D or 5D (batch mode) tensor is expected");
-  THArgCheck(gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3, "4D or 5D (batch mode) tensor is expected");
-  THArgCheck(gradWeight->nDimension == 5, 4, "gradWeight tensor must be 5D (nOutputPlane,nInputPlane,kT,kH,kW)");
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
+  THNN_ARGCHECK(gradOutput->nDimension == 4 || gradOutput->nDimension == 5, 3,
+		gradOutput,
+		"4D or 5D (batch mode) tensor expected for gradOutput, but got: %s");
+  THNN_ARGCHECK(gradWeight->nDimension == 5, 4, gradWeight,
+		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+		"expected for gradWeight, but got: %s");
   THArgCheck(kT > 0 && kW > 0 && kH > 0, 8, "kernel size should be greater than zero");
   THArgCheck(dT > 0 && dW > 0 && dH > 0, 10, "stride should be greater than zero");
   THArgCheck(!gradBias || gradWeight->size[0] == gradBias->size[0], 4, "nOutputPlane mismatch in gradWeight and gradBias");

--- a/lib/THNN/generic/VolumetricDilatedMaxPooling.c
+++ b/lib/THNN/generic/VolumetricDilatedMaxPooling.c
@@ -133,9 +133,8 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
   real *output_data;
   real *indices_data;
 
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2,
-    "4D or 5D (batch-mode) tensor expected"
-  );
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   int dimN = 0;
   int dimt = 1;
@@ -150,9 +149,12 @@ void THNN_(VolumetricDilatedMaxPooling_updateOutput)(
     dimw++;
   }
 
-  THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH && input->size[dimt] >= kT, 2,
-    "input image smaller than kernel size"
-  );
+  THArgCheck(input->size[dimw] >= kW && input->size[dimh] >= kH
+	     && input->size[dimt] >= kT, 2,
+	     "input image (T: %d H: %d W: %d) smaller than "
+	     "kernel size (kT: %d kH: %d kW: %d)",
+	     input->size[dimt], input->size[dimh], input->size[dimw],
+	     kT, kH, kW);
 
   THArgCheck(kT/2 >= pT && kW/2 >= pW && kH/2 >= pH, 2,
     "pad should be smaller than half of kernel size"
@@ -340,6 +342,7 @@ void THNN_(VolumetricDilatedMaxPooling_updateGradInput)(
   int dimh = 2;
   int dimw = 3;
 
+  // TODO: gradOutput shape check
   /* get contiguous gradOutput */
   gradOutput = THTensor_(newContiguous)(gradOutput);
 

--- a/lib/THNN/generic/VolumetricFullConvolution.c
+++ b/lib/THNN/generic/VolumetricFullConvolution.c
@@ -101,9 +101,9 @@ void THNN_(VolumetricFullConvolution_updateOutput)(
   THTensor *ones    = fgradInput;
 
   // number of input & output planes and kernel size is indirectly defined by the weight tensor
-  THArgCheck(weight->nDimension == 5, 4,
-    "5D weight tensor is expected (nInputPlane x nOutputPlane x kT x kH x kW)"
-  );
+  THNN_ARGCHECK(weight->nDimension == 5, 4, weight,
+		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+		"expected for weight, but got: %s");
 
   const int nInputPlane  = (int)weight->size[0];
   const int nOutputPlane = (int)weight->size[1];
@@ -111,9 +111,8 @@ void THNN_(VolumetricFullConvolution_updateOutput)(
   const int kH           = (int)weight->size[3];
   const int kW           = (int)weight->size[4];
 
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2,
-    "4D or 5D (batch mode) tensor is expected"
-  );
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   int batch = 1;
   if (input->nDimension == 4)
@@ -241,9 +240,9 @@ void THNN_(VolumetricFullConvolution_updateGradInput)(
   THTensor *gradColumns = finput;
 
   // number of input & output planes and kernel size is indirectly defined by the weight tensor
-  THArgCheck(weight->nDimension == 5, 4,
-    "5D weight tensor is expected (nInputPlane x nOutputPlane x kT x kH x kW)"
-  );
+  THNN_ARGCHECK(weight->nDimension == 5, 4, weight,
+		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+		"expected for weight, but got: %s");
 
   const int nInputPlane  = (int)weight->size[0];
   const int nOutputPlane = (int)weight->size[1];
@@ -251,9 +250,8 @@ void THNN_(VolumetricFullConvolution_updateGradInput)(
   const int kH           = (int)weight->size[3];
   const int kW           = (int)weight->size[4];
 
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2,
-    "4D or 5D (batch mode) tensor is expected"
-  );
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   int batch = 1;
   if (input->nDimension == 4)
@@ -349,9 +347,9 @@ void THNN_(VolumetricFullConvolution_accGradParameters)(
   real scale)
 {
   // number of input & output planes and kernel size is indirectly defined by the gradWeight tensor
-  THArgCheck(gradWeight->nDimension == 5, 4,
-    "5D gradWeight tensor is expected (nInputPlane x nOutputPlane x kT x kH x kW)"
-  );
+  THNN_ARGCHECK(gradWeight->nDimension == 5, 4, gradWeight,
+		"5D (nOutputPlane x nInputPlane x kT x kH x kW) tensor "
+		"expected for gradWeight, but got: %s");
 
   int nInputPlane  = (int)gradWeight->size[0];
   int nOutputPlane = (int)gradWeight->size[1];
@@ -362,9 +360,8 @@ void THNN_(VolumetricFullConvolution_accGradParameters)(
   THTensor *columns = finput;
   THTensor *ones = fgradInput;
 
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5, 2,
-    "4D or 5D (batch mode) tensor is expected"
-  );
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   int batch = 1;
   if (input->nDimension == 4)

--- a/lib/THNN/generic/VolumetricMaxUnpooling.c
+++ b/lib/THNN/generic/VolumetricMaxUnpooling.c
@@ -84,9 +84,8 @@ void THNN_(VolumetricMaxUnpooling_updateOutput)(
   real *output_data;
   real *indices_data;
 
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5 , 2,
-    "4D or 5D (batch mode) tensor expected"
-  );
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   if (!THTensor_(isSameSizeAs)(input, indices))
   {
@@ -250,6 +249,7 @@ void THNN_(VolumetricMaxUnpooling_updateGradInput)(
     THError("Invalid input size w.r.t current indices size");
   }
 
+  // TODO: check gradOutput shape
   /* get contiguous gradOutput */
   gradOutput = THTensor_(newContiguous)(gradOutput);
   indices = THTensor_(newContiguous)(indices);

--- a/lib/THNN/generic/VolumetricReplicationPadding.c
+++ b/lib/THNN/generic/VolumetricReplicationPadding.c
@@ -85,8 +85,8 @@ void THNN_(VolumetricReplicationPadding_updateOutput)(THNNState *state,
   real *input_data;
   real *output_data;
 
-  THArgCheck(input->nDimension == 4 || input->nDimension == 5,
-             2, "input must be 4 or 5-dimensional");
+  THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
+		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
   if (input->nDimension == 5)
   {
@@ -106,8 +106,10 @@ void THNN_(VolumetricReplicationPadding_updateOutput)(THNNState *state,
   oheight = iheight + ptop + pbottom;
   owidth  = iwidth + pleft + pright;
 
-  THArgCheck(owidth >= 1 || oheight >= 1 || odepth >= 1 , 2,
-             "input is too small");
+  THArgCheck(owidth >= 1 || oheight >= 1 || odepth >= 1, 2,
+	     "input (D: %d H: %d, W: %d)is too small."
+	     " Calculated output D: %d H: %d W: %d",
+	     idepth, iheight, iwidth, odepth, oheight, owidth);
 
   /* get contiguous input */
   input = THTensor_(newContiguous)(input);
@@ -254,11 +256,15 @@ void THNN_(VolumetricReplicationPadding_updateGradInput)(THNNState *state,
   owidth  = iwidth + pleft + pright;
 
   THArgCheck(owidth == THTensor_(size)(gradOutput, dimw), 3,
-                "gradOutput width unexpected");
+	     "gradOutput width unexpected. Expected: %d, Got: %d",
+	     owidth, THTensor_(size)(gradOutput, dimw));
   THArgCheck(oheight == THTensor_(size)(gradOutput, dimh), 3,
-                "gradOutput height unexpected");
+	     "gradOutput height unexpected. Expected: %d, Got: %d",
+	     oheight, THTensor_(size)(gradOutput, dimh));
   THArgCheck(odepth == THTensor_(size)(gradOutput, dimd), 3,
-                "gradOutput depth unexpected");
+	     "gradOutput depth unexpected. Expected: %d, Got: %d",
+	     odepth, THTensor_(size)(gradOutput, dimd));
+  
 
   /* get contiguous gradOutput */
   gradOutput = THTensor_(newContiguous)(gradOutput);

--- a/lib/THNN/init.c
+++ b/lib/THNN/init.c
@@ -4,6 +4,43 @@
 #define torch_(NAME) TH_CONCAT_3(torch_, Real, NAME)
 #define nn_(NAME) TH_CONCAT_3(nn_, Real, NAME)
 
+#define THNN_CHECK_SHAPE(I1, I2)			\
+  if (I1 != NULL && I2 != NULL && !THTensor_(isSameSizeAs)(I1, I2))	\
+    {							\
+       THDescBuff s1 = THTensor_(sizeDesc)(I1);		\
+       THDescBuff s2 = THTensor_(sizeDesc)(I2);		\
+       THError(#I1 " and " #I2 " shapes do not match: "	\
+	       #I1 " %s, " #I2 " %s", s1.str, s2.str);	\
+    }
+
+#define THNN_CHECK_NELEMENT(I1, I2) \
+  if (I1 != NULL && I2 != NULL ) {					\
+    long n1 = THTensor_(nElement)(I1);					\
+    long n2 = THTensor_(nElement)(I2);	                                \
+    if (n1 != n2)							\
+      {									\
+	THDescBuff s1 = THTensor_(sizeDesc)(I1);			\
+	THDescBuff s2 = THTensor_(sizeDesc)(I2);			\
+	THError(#I1 " and " #I2 " have different number of elements: "	\
+		#I1 "%s has %ld elements, while "			\
+		#I2 "%s has %ld elements", s1.str, n1, s2.str, n2);	\
+      }									\
+  }
+
+#define THNN_CHECK_DIM_SIZE(T, DIM, DIM_SIZE, SIZE)			\
+  if (THTensor_(nDimension)(T) != DIM ||				\
+      THTensor_(size)(T, DIM_SIZE) != SIZE) {				\
+      THDescBuff s1 = THTensor_(sizeDesc)(T);				\
+      THError("Need " #T " of dimension %d and " #T ".size[%d] == %d"	\
+	      " but got " #T " to be of shape: %s", DIM, DIM_SIZE, SIZE, s1.str); \
+  }
+
+#define THNN_ARGCHECK(COND, ARG, T, FORMAT)	\
+  if (!(COND)) {				\
+    THDescBuff s1 = THTensor_(sizeDesc)(T);	\
+    THArgCheck(COND, ARG, FORMAT, s1.str);	\
+  }
+
 #include "generic/Abs.c"
 #include "THGenerateFloatTypes.h"
 


### PR DESCRIPTION
Error messages across board have been largely improved in the C library of THNN.
Now, instead of reporting that a tensor has mismatched shape, or that they have wrong dimension, the error will also report what the expected dimension was, and what the tensor shape is...

For example:
Old message:
```
bad argument #2 to 'v' (3D or 4D (batch mode) tensor expected for input
```
New message:
```
bad argument #2 to 'v' (3D or 4D (batch mode) tensor expected for input, but got: [100 x 100]
```

Some places where error messages weren't there, argchecks have been added. Most critically in SoftMax and LogSoftMax