### PR TITLE
ClassNLLCriterion broken for cunn1.0-0

### DIFF
--- a/ClassNLLCriterion.lua
+++ b/ClassNLLCriterion.lua
@@ -29,13 +29,13 @@ end
 function ClassNLLCriterion:updateOutput(input, target)
    if type(target) == 'number' then
       if input:type() == 'torch.CudaTensor' then
-          self.target = self.target:cudaLong()
+          self.target = torch.cudaLong and self.target:cudaLong() or self.target:cuda()
       else
           self.target = self.target:long()
       end
       self.target[1] = target
    elseif target:type() == 'torch.CudaTensor' then
-      self.target = target:cudaLong()
+      self.target = torch.cudaLong and target:cudaLong() or target
    else
       self.target = target:long()
    end
@@ -55,13 +55,13 @@ end
 function ClassNLLCriterion:updateGradInput(input, target)
    if type(target) == 'number' then
       if input:type() == 'torch.CudaTensor' then
-          self.target = self.target:cudaLong()
+          self.target = torch.cudaLong and self.target:cudaLong() or self.target:cuda()
       else
           self.target = self.target:long()
       end
       self.target[1] = target
    elseif target:type() == 'torch.CudaTensor' then
-      self.target = target:cudaLong()
+      self.target = torch.cudaLong and target:cudaLong() or target
    else
       self.target = target:long()
    end

--- a/SpatialClassNLLCriterion.lua
+++ b/SpatialClassNLLCriterion.lua
@@ -29,13 +29,13 @@ end
 function SpatialClassNLLCriterion:updateOutput(input, target)
    if type(target) == 'number' then
       if input:type() == 'torch.CudaTensor' then
-          self.target = self.target:cudaLong()
+          self.target = torch.cudaLong and self.target:cudaLong() or self.target:cuda()
       else
           self.target = self.target:long()
       end
       self.target[1] = target
    elseif target:type() == 'torch.CudaTensor' then
-      self.target = target:cudaLong()
+      self.target = torch.cudaLong and target:cudaLong() or target
    else
       self.target = target:long()
    end
@@ -55,13 +55,13 @@ end
 function SpatialClassNLLCriterion:updateGradInput(input, target)
    if type(target) == 'number' then
       if input:type() == 'torch.CudaTensor' then
-          self.target = self.target:cudaLong()
+          self.target = torch.cudaLong and self.target:cudaLong() or self.target:cuda()
       else
           self.target = self.target:long()
       end
       self.target[1] = target
    elseif target:type() == 'torch.CudaTensor' then
-      self.target = target:cudaLong()
+      self.target = torch.cudaLong and target:cudaLong() or target
    else
       self.target = target:long()
    end


### PR DESCRIPTION
The changes introduced in commit #979 have broken cutorch/cunn 1.0-0 because there is no `cudaLong` there.  This fix makes the conversion conditional.
An alternative would be to remove the ugly type castings completely, they are not used e.g. in `MultiMarginCriterion` either.