### PR TITLE
Specify output height and width instead of scale

### DIFF
--- a/SpatialUpSamplingBilinear.lua
+++ b/SpatialUpSamplingBilinear.lua
@@ -8,21 +8,28 @@ input planes.
 
 The Y and X dimensions are assumed to be the last 2 tensor dimensions.  For
 instance, if the tensor is 4D, then dim 3 is the y dimension and dim 4 is the x.
-scale_factor is assumed to be a positive integer.
 
+scale_factor is assumed to be a positive integer. 
 owidth  = (width-1)*(scale_factor-1) + width
 oheight  = (height-1)*(scale_factor-1) + height
+
+Alternatively, owidth and oheight can be directly provided as input.
 --]]
 
-function SpatialUpSamplingBilinear:__init(scale_factor)
+function SpatialUpSamplingBilinear:__init(params)
    parent.__init(self)
 
-   self.scale_factor = scale_factor
-   if self.scale_factor < 1 then
-     error('scale_factor must be greater than 1')
-   end
-   if math.floor(self.scale_factor) ~= self.scale_factor then
-     error('scale_factor must be integer')
+   self.owidth, self.oheight, self.scale_factor = nil, nil, nil
+   if torch.type(params) == 'table' then
+      self.owidth, self.oheight = params.owidth, params.oheight
+   else
+      self.scale_factor = params   
+      if self.scale_factor < 1 then
+         error('scale_factor must be greater than 1')
+      end
+      if math.floor(self.scale_factor) ~= self.scale_factor then
+         error('scale_factor must be integer')
+      end
    end
    self.inputSize = torch.LongStorage(4)
    self.outputSize = torch.LongStorage(4)
@@ -46,7 +53,7 @@ end
 
 function SpatialUpSamplingBilinear:updateOutput(input)
    assert(input:dim() == 4 or input:dim()==3,
-            'SpatialUpSamplingBilinear only support 3D or 4D tensors' )
+            'SpatialUpSamplingBilinear only supports 3D or 4D tensors' )
    local inputwas3D = false
    if input:dim() == 3 then
       input=input:view(-1, input:size(1), input:size(2), input:size(3))
@@ -58,13 +65,18 @@ function SpatialUpSamplingBilinear:updateOutput(input)
    local xdim = input:dim()
    local ydim = input:dim() - 1
    for i = 1, input:dim() do
-     self.inputSize[i] = input:size(i)
-     self.outputSize[i] = input:size(i)
+      self.inputSize[i] = input:size(i)
+      self.outputSize[i] = input:size(i)
    end
-   self.outputSize[ydim] = (self.outputSize[ydim]-1) * (self.scale_factor-1)
-                           + self.outputSize[ydim]
-   self.outputSize[xdim] = (self.outputSize[xdim]-1) * (self.scale_factor -1)
-                           + self.outputSize[xdim]
+   if self.scale_factor ~= nil then
+      self.outputSize[ydim] = (self.outputSize[ydim]-1) * (self.scale_factor-1)
+                              + self.outputSize[ydim]
+      self.outputSize[xdim] = (self.outputSize[xdim]-1) * (self.scale_factor -1)
+                              + self.outputSize[xdim]
+   else
+      self.outputSize[ydim] = self.oheight
+      self.outputSize[xdim] = self.owidth
+   end
    -- Resize the output if needed
    self.output:resize(self.outputSize)
    input.THNN.SpatialUpSamplingBilinear_updateOutput(
@@ -105,7 +117,13 @@ function SpatialUpSamplingBilinear:updateGradInput(input, gradOutput)
 end
 
 
-function SpatialUpSamplingBilinear:__tostring__()
-   local s = string.format('%s(%d)', torch.type(self), self.scale_factor)
+function SpatialUp:__tostring__()
+   local s
+   if self.scale_factor ~= nil then
+      s = string.format('%s(%d)', torch.type(self), self.scale_factor)
+   else
+      s = string.format('%s(%d, %d)', 
+         torch.type(self), self.oheight, self.owidth)
+   end
    return s
 end

--- a/SpatialUpSamplingBilinear.lua
+++ b/SpatialUpSamplingBilinear.lua
@@ -117,7 +117,7 @@ function SpatialUpSamplingBilinear:updateGradInput(input, gradOutput)
 end
 
 
-function SpatialUp:__tostring__()
+function SpatialUpSamplingBilinear:__tostring__()
    local s
    if self.scale_factor ~= nil then
       s = string.format('%s(%d)', torch.type(self), self.scale_factor)

--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -757,8 +757,10 @@ Applies a 2D up-sampling over an input image composed of several input planes. T
 
 The parameters are the following:
   * `scale`: The upscale ratio.  Must be a positive integer
+  * Or a table `{oheight=H, owidth=W}`: The required output height and width, should be positive integers.
 
-The up-scaling method is bilinear, and given an input of height iH and width iW, output height and width will be:
+The up-scaling method is bilinear.
+If `scale` is specified, given an input of height iH and width iW, output height and width will be:
 ```lua
 oH = (iH - 1)(scale - 1) + iH
 oW = (iW - 1)(scale - 1) + iW

--- a/doc/convolution.md
+++ b/doc/convolution.md
@@ -750,6 +750,7 @@ Where `u` and `v` are index from 1 (as per lua convention).  There are no learna
 
 ```lua
 module = nn.SpatialUpSamplingBilinear(scale)
+module = nn.SpatialUpSamplingBilinear({oheight=H, owidth=W})
 ```
 
 Applies a 2D up-sampling over an input image composed of several input planes. The `input` tensor in


### PR DESCRIPTION
Optionally pass in a table containing output height and width instead of scale.
This is useful when there is no exact integer scale that can produce the required output size. 

```
module = nn.SpatialUpSamplingBilinear(scale)
or
module = nn.SpatialUpSamplingBilinear({oheight=H, owidth=W})
```