### PR TITLE
Fix Bilinear crash when backward is called after clearState.

### DIFF
--- a/Bilinear.lua
+++ b/Bilinear.lua
@@ -86,7 +86,8 @@ function Bilinear:updateGradInput(input, gradOutput)
       self:__assertInputGradOutput(input, gradOutput)
 
       if #self.gradInput == 0 then
-          for i = 1, 2 do self.gradInput[i] = input[1].new() end                                                                                                                                               end
+          for i = 1, 2 do self.gradInput[i] = input[1].new() end
+      end
 
       -- compute d output / d input:
       self.gradInput[1]:resizeAs(input[1]):fill(0)

--- a/Bilinear.lua
+++ b/Bilinear.lua
@@ -84,6 +84,10 @@ function Bilinear:updateGradInput(input, gradOutput)
    assert(self)
    if self.gradInput then
       self:__assertInputGradOutput(input, gradOutput)
+
+      if #self.gradInput == 0 then
+          for i = 1, 2 do self.gradInput[i] = input[1].new() end                                                                                                                                               end
+
       -- compute d output / d input:
       self.gradInput[1]:resizeAs(input[1]):fill(0)
       self.gradInput[2]:resizeAs(input[2]):fill(0)


### PR DESCRIPTION
[This MWE](https://gist.github.com/adityaramesh/e31f9bafee2a85243f1d4714fd3cb1ff) shows that Bilinear module crashes when `backward` is called after `clearState`. I modified `updateGradInput` in `Bilinear.lua` to repopulate `self.gradInput` after it is emptied by `clearState`. This fixes the crash.