### PR TITLE
more improvments on error messages and shape checks

### DIFF
--- a/SpatialUpSamplingNearest.lua
+++ b/SpatialUpSamplingNearest.lua
@@ -24,7 +24,6 @@ function SpatialUpSamplingNearest:__init(scale)
    end
    self.inputSize = torch.LongStorage(4)
    self.outputSize = torch.LongStorage(4)
-   self.usage = nil
 end
 
 function SpatialUpSamplingNearest:updateOutput(input)

--- a/lib/THNN/generic/SpatialDilatedConvolution.c
+++ b/lib/THNN/generic/SpatialDilatedConvolution.c
@@ -2,6 +2,61 @@
 #define TH_GENERIC_FILE "generic/SpatialDilatedConvolution.c"
 #else
 
+static inline void THNN_(SpatialDilatedConvolution_shapeCheck)(
+	THTensor *input, THTensor *gradOutput,
+	THTensor *weight, THTensor *bias, 
+	int kH, int kW, int dH, int dW, int padH, int padW,
+	int dilationH, int dilationW) {
+
+  THNN_ARGCHECK(weight->nDimension == 4, 4, weight,
+		"4D weight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
+		"but got: %s");
+  THArgCheck(kW > 0 && kH > 0, 9,
+	       "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
+  THArgCheck(dW > 0 && dH > 0, 11,
+	     "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
+  THNN_ARGCHECK(weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
+		"2D or 4D weight tensor expected, but got: %s");
+
+  if (bias != NULL) {
+    THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[0]);
+  }
+
+  int ndim = input->nDimension;
+  int dimf = 0;
+  int dimh = 1;
+  int dimw = 2;
+
+  if (ndim == 4) {
+    dimf++;
+    dimh++;
+    dimw++;
+  }
+
+  THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
+		"3D or 4D input tensor expected but got: %s");
+
+  long nInputPlane  = weight->size[1];
+  long inputHeight  = input->size[dimh];
+  long inputWidth   = input->size[dimw];
+  long nOutputPlane = weight->size[0];
+  long outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
+  long outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
+
+  if (outputWidth < 1 || outputHeight < 1)
+    THError("Given input size: (%ld x %ld x %ld). "
+	    "Calculated output size: (%ld x %ld x %ld). Output size is too small",
+	    nInputPlane,inputHeight,inputWidth,nOutputPlane,outputHeight,outputWidth);
+
+  THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
+  
+  if (gradOutput != NULL) {
+    THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
+    THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimh, outputHeight);
+    THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimw, outputWidth);
+  }
+}
+
 void THNN_(SpatialDilatedConvolution_updateOutput)(
     THNNState *state,
     THTensor *input,
@@ -15,17 +70,10 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
     int padW, int padH,
     int dilationW, int dilationH)
 {
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
-		"3D or 4D (batch mode) tensor expected for input, but got: %s");
-  THNN_ARGCHECK(weight->nDimension == 4, 4, weight,
-		"4D weight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
-		"but got: %s");
-  THArgCheck(!bias || weight->size[0] == bias->size[0], 4,
-	     "nOutputPlane mismatch in weight and bias");
-  THArgCheck(kW > 0 && kH > 0, 8,
-	       "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
-  THArgCheck(dW > 0 && dH > 0, 10,
-	     "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
+
+  THNN_(SpatialDilatedConvolution_shapeCheck)
+    (input, NULL, weight, bias, kH, kW, dH, dW, padH, padW,
+     dilationH, dilationW);
 
   // Params:
   int nInputPlane = weight->size[1];
@@ -33,27 +81,14 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
 
   int batch = 1;
   if (input->nDimension == 3) {
-    THArgCheck(input->size[0] == nInputPlane, 2,
-	       "input channels %d and nInputPlane %d dont match.",
-	       input->size[0], nInputPlane);
     // Force batch
     batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
-  } else {
-    THArgCheck(input->size[1] == nInputPlane, 2,
-	       "input channels %d and nInputPlane %d dont match",
-	       input->size[1], nInputPlane);
   }
-
   long inputWidth   = input->size[3];
   long inputHeight  = input->size[2];
   long outputWidth  = (inputWidth + 2*padW - (dilationW * (kW - 1) + 1)) / dW + 1;
   long outputHeight = (inputHeight + 2*padH - (dilationH * (kH - 1) + 1)) / dH + 1;
-
-  if (outputWidth < 1 || outputHeight < 1)
-    THError("Given input size: (%dx%dx%d). "
-	    "Calculated output size: (%dx%dx%d). Output size is too small",
-            nInputPlane,inputHeight,inputWidth,nOutputPlane,outputHeight,outputWidth);
 
   // Batch size + input planes
   long batchSize = input->size[0];
@@ -153,15 +188,9 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
     int padW, int padH,
     int dilationW, int dilationH)
 {
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
-		"3D or 4D (batch mode) tensor expected for input, but got: %s");
-  THNN_ARGCHECK(weight->nDimension == 4, 4, weight,
-		"4D weight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
-		"but got: %s");
-  THArgCheck(kW > 0 && kH > 0, 9,
-	       "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
-  THArgCheck(dW > 0 && dH > 0, 11,
-	     "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
+  THNN_(SpatialDilatedConvolution_shapeCheck)
+    (input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW,
+     dilationH, dilationW);
 
   // Params
   int nInputPlane = weight->size[1];
@@ -253,17 +282,9 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
     int dilationW, int dilationH,
     real scale)
 {
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
-		"3D or 4D (batch mode) tensor expected for input, but got: %s");
-  THNN_ARGCHECK(gradWeight->nDimension == 4, 4, gradWeight,
-		"4D gradWeight tensor (nOutputPlane,nInputPlane,kH,kW) expected, "
-		"but got: %s");
-  THArgCheck(!gradBias || gradWeight->size[0] == gradBias->size[0], 4,
-	     "nOutputPlane mismatch in gradWeight and gradBias");
-  THArgCheck(kW > 0 && kH > 0, 8,
-	       "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
-  THArgCheck(dW > 0 && dH > 0, 10,
-	     "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
+  THNN_(SpatialDilatedConvolution_shapeCheck)
+    (input, gradOutput, gradWeight, gradBias, kH, kW, dH, dW, padH, padW,
+     dilationH, dilationW);
 
   // Params
   int nInputPlane = gradWeight->size[1];

--- a/lib/THNN/generic/SpatialFullConvolution.c
+++ b/lib/THNN/generic/SpatialFullConvolution.c
@@ -57,6 +57,57 @@ static void THNN_(col2im)(const real* data_col, const int channels,
   }
 }
 
+static inline void THNN_(SpatialFullConvolution_shapeCheck)(
+	THTensor *input, THTensor *gradOutput,
+	THTensor *weight, THTensor *bias, 
+	int kH, int kW, int dH, int dW, int padH, int padW, int adjH, int adjW) {
+
+  THArgCheck(kW > 0 && kH > 0, 9,
+	       "kernel size should be greater than zero, but got kH: %d kW: %d", kH, kW);
+  THArgCheck(dW > 0 && dH > 0, 11,
+	     "stride should be greater than zero, but got dH: %d dW: %d", dH, dW);
+  THNN_ARGCHECK(weight->nDimension == 2 || weight->nDimension == 4, 5, weight,
+		"2D or 4D weight tensor expected, but got: %s");
+
+  if (bias != NULL) {
+    THNN_CHECK_DIM_SIZE(bias, 1, 0, weight->size[1]);
+  }
+
+  int ndim = input->nDimension;
+  int dimf = 0;
+  int dimh = 1;
+  int dimw = 2;
+
+  if (ndim == 4) {
+    dimf++;
+    dimh++;
+    dimw++;
+  }
+
+  THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
+		"3D or 4D input tensor expected but got: %s");
+
+  long nInputPlane  = weight->size[0];
+  long inputHeight  = input->size[dimh];
+  long inputWidth   = input->size[dimw];
+  long nOutputPlane = weight->size[1];
+  long outputHeight = (inputHeight - 1) * dH - 2*padH + kH + adjH;
+  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW + adjW;
+
+  if (outputWidth < 1 || outputHeight < 1)
+    THError("Given input size: (%d x %d x %d). "
+	    "Calculated output size: (%d x %d x %d). Output size is too small",
+	    nInputPlane,inputHeight,inputWidth,nOutputPlane,outputHeight,outputWidth);
+
+  THNN_CHECK_DIM_SIZE(input, ndim, dimf, nInputPlane);
+  
+  if (gradOutput != NULL) {
+    THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimf, nOutputPlane);
+    THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimh, outputHeight);
+    THNN_CHECK_DIM_SIZE(gradOutput, ndim, dimw, outputWidth);
+  }
+}
+
 void THNN_(SpatialFullConvolution_updateOutput)(
     THNNState *state,
     THTensor *input,
@@ -70,30 +121,23 @@ void THNN_(SpatialFullConvolution_updateOutput)(
     int padW, int padH,
     int adjW, int adjH)
 {
+  THNN_(SpatialFullConvolution_shapeCheck)
+    (input, NULL, weight, bias, kH, kW, dH, dW, padH, padW, adjH, adjW);
+
   int nInputPlane = THTensor_(size)(weight,0);
   int nOutputPlane = THTensor_(size)(weight,1);
 
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
-		"3D or 4D (batch mode) tensor expected for input, but got: %s")
-
   int batch = 1;
   if (input->nDimension == 3) {
-    THArgCheck(input->size[0] == nInputPlane, 2,
-	       "input channels (%d) and nInputPlane (%d) dont match",
-	       input->size[0], nInputPlane);
     // Force batch
     batch = 0;
     THTensor_(resize4d)(input, 1, input->size[0], input->size[1], input->size[2]);
-  } else {
-    THArgCheck(input->size[1] == nInputPlane, 2,
-	       "input channels (%d) and nInputPlane (%d) dont match",
-	       input->size[1], nInputPlane);
   }
 
-  long inputWidth   = input->size[3];
   long inputHeight  = input->size[2];
-  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW + adjW;
+  long inputWidth   = input->size[3];
   long outputHeight = (inputHeight - 1) * dH - 2*padH + kH + adjH;
+  long outputWidth  = (inputWidth - 1) * dW - 2*padW + kW + adjW;
 
   // Batch size + input planes
   long batchSize = input->size[0];
@@ -194,12 +238,11 @@ void THNN_(SpatialFullConvolution_updateGradInput)(
     int padW, int padH,
     int adjW, int adjH)
 {
-  // TODO: check gradOutput shape
+  THNN_(SpatialFullConvolution_shapeCheck)
+    (input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW, adjH, adjW);
+
   int nInputPlane = THTensor_(size)(weight,0);
   int nOutputPlane = THTensor_(size)(weight,1);
-
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
-		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   int batch = 1;
   if (input->nDimension == 3) {
@@ -290,11 +333,11 @@ void THNN_(SpatialFullConvolution_accGradParameters)(
     int adjW, int adjH,
     real scale)
 {
+  THNN_(SpatialFullConvolution_shapeCheck)
+    (input, gradOutput, gradWeight, gradBias, kH, kW, dH, dW, padH, padW, adjH, adjW);
+
   int nInputPlane = THTensor_(size)(gradWeight,0);
   int nOutputPlane = THTensor_(size)(gradWeight,1);
-
-  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
-		"3D or 4D (batch mode) tensor expected for input, but got: %s");
 
   int batch = 1;
   if (input->nDimension == 3) {

--- a/lib/THNN/generic/SpatialUpSamplingBilinear.c
+++ b/lib/THNN/generic/SpatialUpSamplingBilinear.c
@@ -5,125 +5,170 @@
 #define TH_GENERIC_FILE "generic/SpatialUpSamplingBilinear.c"
 #else
 
+static inline void THNN_(SpatialUpSamplingBilinear_shapeCheck)
+     (THTensor *input, THTensor *gradOutput,
+      int nBatch, int nChannels,
+      int inputHeight, int inputWidth,
+      int outputHeight, int outputWidth) {
+  THArgCheck(inputHeight > 0 && inputWidth > 0
+	     && outputHeight > 0 && outputWidth > 0, 2,
+	     "input and output sizes should be greater than 0,"
+	     " but got input (H: %d, W: %d) output (H: %d, W: %d)",
+	     inputHeight, inputWidth, outputHeight, outputWidth);
+  if (input != NULL) {
+    THNN_ARGCHECK(input->nDimension == 4, 2, input,
+		  "4D input tensor expected but got: %s");
+  }
+
+  if (gradOutput != NULL) {
+    THNN_CHECK_DIM_SIZE(gradOutput, 4, 0, nBatch);
+    THNN_CHECK_DIM_SIZE(gradOutput, 4, 1, nChannels);
+    THNN_CHECK_DIM_SIZE(gradOutput, 4, 2, outputHeight);
+    THNN_CHECK_DIM_SIZE(gradOutput, 4, 3, outputWidth);
+  }
+}
+
 void THNN_(SpatialUpSamplingBilinear_updateOutput)(
     THNNState *state,
     THTensor *input,
-    THTensor *output){
-  // TODO: check argument shapes
+    THTensor *output,
+    int outputHeight,
+    int outputWidth){
+
+  int nbatch = THTensor_(size)(input, 0);
+  int channels = THTensor_(size)(input, 1);
+  int inputHeight = THTensor_(size)(input, 2);
+  int inputWidth = THTensor_(size)(input, 3);
+
+  THNN_(SpatialUpSamplingBilinear_shapeCheck)
+    (input, NULL,
+     nbatch, channels,
+     inputHeight, inputWidth,
+     outputHeight, outputWidth);
+
   input = THTensor_(newContiguous)(input);
-  output = THTensor_(newContiguous)(output);
+  THTensor_(resize4d)(output, 
+		      THTensor_(size)(input, 0), 
+		      THTensor_(size)(input, 1), 
+		      outputHeight, outputWidth);
   THTensor_(zero)(output);
   real *idata = THTensor_(data)(input);
   real *odata = THTensor_(data)(output);
-  int channels = THTensor_(size)(input, 0) * THTensor_(size)(input, 1);
-  int height1 = THTensor_(size)(input, 2);
-  int width1 = THTensor_(size)(input, 3);
-  int height2 = THTensor_(size)(output, 2);
-  int width2 = THTensor_(size)(output, 3);
-  THAssert(height1 > 0 && width1 > 0 && height2 > 0 && width2 > 0);
+  channels = nbatch * channels;
+  THAssert(inputHeight > 0 && inputWidth > 0 && outputHeight > 0 && outputWidth > 0);
   // special case: just copy
-  if (height1 == height2 && width1 == width2) {
-    for (int h2 = 0; h2 < height2; ++h2) {
+  if (inputHeight == outputHeight && inputWidth == outputWidth) {
+    for (int h2 = 0; h2 < outputHeight; ++h2) {
       const int h1 = h2;
-      for (int w2 = 0; w2 < width2; ++w2) {
+      for (int w2 = 0; w2 < outputWidth; ++w2) {
         const int w1 = w2;
-        const real* pos1 = &idata[h1 * width1 + w1];
-        real* pos2 = &odata[h2 * width2 + w2];
+        const real* pos1 = &idata[h1 * inputWidth + w1];
+        real* pos2 = &odata[h2 * outputWidth + w2];
         for (int c = 0; c < channels; ++c) {
           pos2[0] = pos1[0];
-          pos1 += width1 * height1;
-          pos2 += width2 * height2;
+          pos1 += inputWidth * inputHeight;
+          pos2 += outputWidth * outputHeight;
         }
       }
     }
     return;
   }
-  const float rheight =(height2 > 1) ? (float)(height1 - 1)/(height2 - 1) : 0.f;
-  const float rwidth = (width2 > 1) ? (float)(width1 - 1) / (width2 - 1) : 0.f;
-  for (int h2 = 0; h2 < height2; ++h2) {
+  const float rheight =(outputHeight > 1) ? (float)(inputHeight - 1)/(outputHeight - 1) : 0.f;
+  const float rwidth = (outputWidth > 1) ? (float)(inputWidth - 1) / (outputWidth - 1) : 0.f;
+  for (int h2 = 0; h2 < outputHeight; ++h2) {
     const float h1r = rheight * h2;
     const int h1 = h1r;
-    const int h1p = (h1 < height1 - 1) ? 1 : 0;
+    const int h1p = (h1 < inputHeight - 1) ? 1 : 0;
     const real h1lambda = h1r - h1;
     const real h0lambda = (real)1. - h1lambda;
-    for (int w2 = 0; w2 < width2; ++w2) {
+    for (int w2 = 0; w2 < outputWidth; ++w2) {
       const float w1r = rwidth * w2;
       const int w1 = w1r;
-      const int w1p = (w1 < width1 - 1) ? 1 : 0;
+      const int w1p = (w1 < inputWidth - 1) ? 1 : 0;
       const real w1lambda = w1r - w1;
       const real w0lambda = (real)1. - w1lambda;
-      const real* pos1 = &idata[h1 * width1 + w1];
-      real* pos2 = &odata[h2 * width2 + w2];
+      const real* pos1 = &idata[h1 * inputWidth + w1];
+      real* pos2 = &odata[h2 * outputWidth + w2];
       for (int c = 0; c < channels; ++c) {
         pos2[0] = h0lambda * (w0lambda * pos1[0]+ w1lambda * pos1[w1p])
-                  + h1lambda * (w0lambda * pos1[h1p * width1]
-                  + w1lambda * pos1[h1p * width1 + w1p]);
-        pos1 += width1 * height1;
-        pos2 += width2 * height2;
+                  + h1lambda * (w0lambda * pos1[h1p * inputWidth]
+                  + w1lambda * pos1[h1p * inputWidth + w1p]);
+        pos1 += inputWidth * inputHeight;
+        pos2 += outputWidth * outputHeight;
       }
     }
   }
+  THTensor_(free)(input);
 }
 
 void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
     THNNState *state,
     THTensor *gradOutput,
-    THTensor *gradInput){
-  // TODO: check argument shapes  
-  gradInput = THTensor_(newContiguous)(gradInput);
-  gradOutput = THTensor_(newContiguous)(gradOutput);
+    THTensor *gradInput,
+    int nbatch,
+    int channels,
+    int inputHeight,
+    int inputWidth,
+    int outputHeight,
+    int outputWidth){
+
+  THNN_(SpatialUpSamplingBilinear_shapeCheck)
+    (NULL, gradOutput,
+     nbatch, channels,
+     inputHeight, inputWidth,
+     outputHeight, outputWidth);
+
+  THTensor_(resize4d)(gradInput, nbatch, channels, inputHeight, inputWidth);
   THTensor_(zero)(gradInput);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
   real *data1 = THTensor_(data)(gradInput);
   real *data2 = THTensor_(data)(gradOutput);
-  int channels = THTensor_(size)(gradInput, 0) * THTensor_(size)(gradInput, 1);
-  int height1 = THTensor_(size)(gradInput, 2);
-  int width1 = THTensor_(size)(gradInput, 3);
-  int height2 = THTensor_(size)(gradOutput, 2);
-  int width2 = THTensor_(size)(gradOutput, 3);
-  THAssert(height1 > 0 && width1 > 0 && height2 > 0 && width2 > 0);
+  channels = nbatch * channels;
+
   // special case: same-size matching grids
-  if (height1 == height2 && width1 == width2) {
-    for (int h2 = 0; h2 < height2; ++h2) {
+  if (inputHeight == outputHeight && inputWidth == outputWidth) {
+    for (int h2 = 0; h2 < outputHeight; ++h2) {
       const int h1 = h2;
-      for (int w2 = 0; w2 < width2; ++w2) {
+      for (int w2 = 0; w2 < outputWidth; ++w2) {
         const int w1 = w2;
-        real* pos1 = &data1[h1 * width1 + w1];
-        const real* pos2 = &data2[h2 * width2 + w2];
+        real* pos1 = &data1[h1 * inputWidth + w1];
+        const real* pos2 = &data2[h2 * outputWidth + w2];
         for (int c = 0; c < channels; ++c) {
           pos1[0] += pos2[0];
-          pos1 += width1 * height1;
-          pos2 += width2 * height2;
+          pos1 += inputWidth * inputHeight;
+          pos2 += outputWidth * outputHeight;
         }
       }
     }
     return;
   }
-  const float rheight =(height2 > 1) ? (float)(height1 - 1)/(height2 - 1) : 0.f;
-  const float rwidth = (width2 > 1) ? (float)(width1 - 1)/(width2 - 1) : 0.f;
-  for (int h2 = 0; h2 < height2; ++h2) {
+  const float rheight =(outputHeight > 1) ? (float)(inputHeight - 1)/(outputHeight - 1) : 0.f;
+  const float rwidth = (outputWidth > 1) ? (float)(inputWidth - 1)/(outputWidth - 1) : 0.f;
+  for (int h2 = 0; h2 < outputHeight; ++h2) {
     const float h1r = rheight * h2;
     const int h1 = h1r;
-    const int h1p = (h1 < height1 - 1) ? 1 : 0;
+    const int h1p = (h1 < inputHeight - 1) ? 1 : 0;
     const real h1lambda = h1r - h1;
     const real h0lambda = (real)1. - h1lambda;
-    for (int w2 = 0; w2 < width2; ++w2) {
+    for (int w2 = 0; w2 < outputWidth; ++w2) {
       const float w1r = rwidth * w2;
       const int w1 = w1r;
-      const int w1p = (w1 < width1 - 1) ? 1 : 0;
+      const int w1p = (w1 < inputWidth - 1) ? 1 : 0;
       const real w1lambda = w1r - w1;
       const real w0lambda = (real)1. - w1lambda;
-      real* pos1 = &data1[h1 * width1 + w1];
-      const real* pos2 = &data2[h2 * width2 + w2];
+      real* pos1 = &data1[h1 * inputWidth + w1];
+      const real* pos2 = &data2[h2 * outputWidth + w2];
       for (int c = 0; c < channels; ++c) {
         pos1[0] += h0lambda * w0lambda * pos2[0];
         pos1[w1p] += h0lambda * w1lambda * pos2[0];
-        pos1[h1p * width1] += h1lambda * w0lambda * pos2[0];
-        pos1[h1p * width1 + w1p] += h1lambda * w1lambda * pos2[0];
-        pos1 += width1 * height1;
-        pos2 += width2 * height2;
+        pos1[h1p * inputWidth] += h1lambda * w0lambda * pos2[0];
+        pos1[h1p * inputWidth + w1p] += h1lambda * w1lambda * pos2[0];
+        pos1 += inputWidth * inputHeight;
+        pos2 += outputWidth * outputHeight;
       }
     }
   }
+  THTensor_(free)(gradOutput);
 }
 
 #endif

--- a/lib/THNN/generic/SpatialUpSamplingNearest.c
+++ b/lib/THNN/generic/SpatialUpSamplingNearest.c
@@ -2,24 +2,76 @@
 #define TH_GENERIC_FILE "generic/SpatialUpSamplingNearest.c"
 #else
 
+
+static inline void THNN_(SpatialUpSamplingNearest_shapeCheck)
+     (THTensor *input, THTensor *gradOutput,
+      int scale_factor) {
+  THArgCheck(input != NULL, 2, "4D input tensor expected but got NULL");
+  THArgCheck(scale_factor > 1, 4,
+	     "scale_factor must be greater than 1, but got: %d", scale_factor);
+  THNN_ARGCHECK(input->nDimension == 3 || input->nDimension == 4, 2, input,
+		"3D or 4D input tensor expected but got: %s");
+  if (input->nDimension == 3) {
+    int nChannels    = THTensor_(size)(input, 0);
+    int inputHeight  = THTensor_(size)(input, 1);
+    int inputWidth   = THTensor_(size)(input, 2);
+    int outputHeight = inputHeight * scale_factor;
+    int outputWidth  = inputWidth  * scale_factor;
+    if (gradOutput != NULL) {
+      THNN_CHECK_DIM_SIZE(gradOutput, 3, 0, nChannels);
+      THNN_CHECK_DIM_SIZE(gradOutput, 3, 1, outputHeight);
+      THNN_CHECK_DIM_SIZE(gradOutput, 3, 2, outputWidth);
+    }
+  } else {
+    int nBatch       = THTensor_(size)(input, 0);
+    int nChannels    = THTensor_(size)(input, 1);
+    int inputHeight  = THTensor_(size)(input, 2);
+    int inputWidth   = THTensor_(size)(input, 3);  
+    int outputHeight = inputHeight * scale_factor;
+    int outputWidth  = inputWidth  * scale_factor;
+    if (gradOutput != NULL) {
+      THNN_CHECK_DIM_SIZE(gradOutput, 4, 0, nBatch);
+      THNN_CHECK_DIM_SIZE(gradOutput, 4, 1, nChannels);
+      THNN_CHECK_DIM_SIZE(gradOutput, 4, 2, outputHeight);
+      THNN_CHECK_DIM_SIZE(gradOutput, 4, 3, outputWidth);
+    }
+  }
+}
+
 void THNN_(SpatialUpSamplingNearest_updateOutput)(
     THNNState *state,
     THTensor *input,
     THTensor *output,
     int scale_factor)
 {
-  // TODO: check argument shapes  
+  THNN_(SpatialUpSamplingNearest_shapeCheck)(input, NULL, scale_factor);
+  int inputHeight = THTensor_(size)(input, input->nDimension-2);
+  int inputWidth  = THTensor_(size)(input,  input->nDimension-1);
+  int outputHeight = inputHeight * scale_factor;
+  int outputWidth = inputWidth * scale_factor;
+
+  if (input->nDimension == 3) {
+    THTensor_(resize3d)(output,
+			THTensor_(size)(input, 0),
+			outputHeight, outputWidth);    
+  } else {
+    THTensor_(resize4d)(output,
+			THTensor_(size)(input, 0),
+			THTensor_(size)(input, 1),
+			outputHeight, outputWidth);
+  }
+
   int dW = scale_factor;
   int dH = scale_factor;
   int xDim = input->nDimension-2;
   int yDim = input->nDimension-1;
 
   // dims
-  int idim = input->nDimension;  // Guaranteed to be between 3 and 5
+  int idim = input->nDimension;
   int osz0 = output->size[0];
   int osz1 = output->size[1];
   int osz2 = output->size[2];
-  int osz3 = 1;
+  int osz3 = 1;  
   if (idim > 3) {
     osz3 = output->size[3];
   }
@@ -75,7 +127,9 @@ void THNN_(SpatialUpSamplingNearest_updateGradInput)(
     THTensor *gradInput,
     int scale_factor)
 {
-  // TODO: check argument shapes  
+  THNN_(SpatialUpSamplingNearest_shapeCheck)(input, gradOutput, scale_factor);
+  THTensor_(resizeAs)(gradInput, input);
+
   int dW = scale_factor;
   int dH = scale_factor;
   int xDim = gradInput->nDimension-2;

--- a/lib/THNN/generic/THNN.h
+++ b/lib/THNN/generic/THNN.h
@@ -945,11 +945,19 @@ TH_API void THNN_(SpatialUpSamplingNearest_updateGradInput)(
 TH_API void THNN_(SpatialUpSamplingBilinear_updateOutput)(
           THNNState *state,
           THTensor *input,
-          THTensor *output);
+          THTensor *output,
+	  int outputHeight,
+          int outputWidth);
 TH_API void THNN_(SpatialUpSamplingBilinear_updateGradInput)(
           THNNState *state,
           THTensor *gradOutput,
-          THTensor *gradInput);
+          THTensor *gradInput,
+          int nbatch,
+          int nchannels,
+          int inputHeight,
+          int inputWidth,
+          int outputHeight,
+          int outputWidth);
 
 TH_API void THNN_(unfolded_acc)(
           THTensor *finput,

--- a/test.lua
+++ b/test.lua
@@ -2288,10 +2288,6 @@ function nntest.SpatialConvolution()
       module = nn.SpatialConvolution(from, to, ki, kj, si, sj)
       input = torch.Tensor(batch,from,inj,ini):zero()
 
-      --    print(from, to, ki, kj, si, sj, batch, ini, inj)
-      --    print(module.weight:size())
-      --    print(module.gradWeight:size())
-
       local err = jac.testJacobian(module, input)
       mytester:assertlt(err, precision, 'batch error on state ')
 
@@ -2515,11 +2511,7 @@ function nntest.SpatialConvolutionLocal()
    ini = (outi-1)*si+ki
    inj = (outj-1)*sj+kj
    module = nn.SpatialConvolutionLocal(from, to, ini, inj, ki, kj, si, sj)
-   input = torch.Tensor(batch,from,inj,ini):zero()
-
---    print(from, to, ki, kj, si, sj, batch, ini, inj)
---    print(module.weight:size())
---    print(module.gradWeight:size())
+   input = torch.Tensor(batch, from, inj, ini):zero()
 
    local err = jac.testJacobian(module, input)
    mytester:assertlt(err, precision, 'batch error on state ')
@@ -2561,14 +2553,13 @@ function nntest.SpatialConvolutionLocal()
 
    -- check against nn.SpatialConvolution
    local conv = nn.SpatialConvolution(from, to, ki, kj, si, sj)
-   torch.repeatTensor(module.bias, conv.bias:view(to, 1, 1), 1, outi, outj)
+   torch.repeatTensor(module.bias, conv.bias:view(to, 1, 1), 1, outj, outi)
    torch.repeatTensor(module.weight, conv.weight:view(1, 1, from, to, ki, kj), outi, outj, 1, 1, 1, 1)
    local input = torch.rand(batch, from, inj, ini)
    local output = module:forward(input)
    local outputConv = conv:forward(input)
    local err = torch.dist(output, outputConv)
    mytester:assertlt(err, precision, 'error checking against nn.SpatialConvolution')
-
 end
 
 function nntest.SpatialFullConvolution()


### PR DESCRIPTION
This refactors error checking in all Spatial* modules and adds many more needed shape checks with better error messages.

Found bugs in SpatialUpSamplingBilinear as a result and fixed.


Depends on https://github.com/torch/cunn/pull/353