### PR TITLE
Contiguous checking

### DIFF
--- a/SpatialUpSamplingBilinear.lua
+++ b/SpatialUpSamplingBilinear.lua
@@ -70,12 +70,12 @@ end
 function SpatialUpSamplingBilinear:updateOutput(input)
    assert(input:dim() == 4 or input:dim()==3,
             'SpatialUpSamplingBilinear only supports 3D or 4D tensors' )
+   input = makeContiguous(self, input)
    local inputwas3D = false
    if input:dim() == 3 then
       input=input:view(-1, input:size(1), input:size(2), input:size(3))
       inputwas3D = true
    end
-   input = makeContiguous(self, input)
    local xdim = input:dim()
    local ydim = xdim - 1
    self:setSize(input)
@@ -98,6 +98,7 @@ function SpatialUpSamplingBilinear:updateGradInput(input, gradOutput)
             'SpatialUpSamplingBilinear only support 3D or 4D tensors' )
    assert(input:dim() == gradOutput:dim(),
 	  'Input and gradOutput should be of same dimension' )
+   input, gradOutput = makeContiguous(self, input, gradOutput)
    local inputwas3D = false
    if input:dim() == 3 then
       input = input:view(-1, input:size(1), input:size(2), input:size(3))

--- a/VolumetricConvolution.lua
+++ b/VolumetricConvolution.lua
@@ -45,22 +45,6 @@ function VolumetricConvolution:reset(stdv)
    end
 end
 
-local function makeContiguous(self, input, gradOutput)
-   if not input:isContiguous() then
-      self._input = self._input or input.new()
-      self._input:resizeAs(input):copy(input)
-      input = self._input
-   end
-   if gradOutput then
-      if not gradOutput:isContiguous() then
-         self._gradOutput = self._gradOutput or gradOutput.new()
-         self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
-         gradOutput = self._gradOutput
-      end
-   end
-   return input, gradOutput
-end
-
 function VolumetricConvolution:updateOutput(input)
    self.finput = self.finput or input.new()
    self.fgradInput = self.fgradInput or input.new()
@@ -76,7 +60,6 @@ function VolumetricConvolution:updateOutput(input)
         self.padT, self.padW, self.padH
       )
    else
-      input = makeContiguous(self, input)
       input.THNN.VolumetricConvolutionMM_updateOutput(
          input:cdata(),
          self.output:cdata(),
@@ -105,7 +88,6 @@ function VolumetricConvolution:updateGradInput(input, gradOutput)
       return self.gradInput
    else
       if self.gradInput then
-         input, gradOutput = makeContiguous(self, input, gradOutput)
          input.THNN.VolumetricConvolutionMM_updateGradInput(
             input:cdata(),
             gradOutput:cdata(),
@@ -136,7 +118,6 @@ function VolumetricConvolution:accGradParameters(input, gradOutput, scale)
          scale or 1
       )
    else
-      input, gradOutput = makeContiguous(self, input, gradOutput)
       input.THNN.VolumetricConvolutionMM_accGradParameters(
          input:cdata(),
          gradOutput:cdata(),

--- a/lib/THNN/generic/PReLU.c
+++ b/lib/THNN/generic/PReLU.c
@@ -2,6 +2,16 @@
 #define TH_GENERIC_FILE "generic/PReLU.c"
 #else
 
+static inline void THNN_(PReLU_shapeCheck)(
+                         THNNState *state,
+                         THTensor *input,
+                         THTensor *gradOutput) {
+  THArgCheck(THTensor_(isContiguous)(input), 2, "input must be contiguous");
+  if (gradOutput != NULL) {
+    THArgCheck(THTensor_(isContiguous)(gradOutput), 2, "gradOuput must be contiguous");
+  }
+}
+
 void THNN_(PReLU_updateOutput)(
           THNNState *state,
           THTensor *input,
@@ -9,6 +19,7 @@ void THNN_(PReLU_updateOutput)(
           THTensor *weight,
           THIndex_t nOutputPlane)
 {
+  THNN_(PReLU_shapeCheck)(state, input, NULL);
   THTensor_(resizeAs)(output, input);
 
   if (nOutputPlane == 0)
@@ -76,6 +87,7 @@ void THNN_(PReLU_updateGradInput)(
           THTensor *weight,
           THIndex_t nOutputPlane)
 {
+  THNN_(PReLU_shapeCheck)(state, input, gradOutput);
   THNN_CHECK_NELEMENT(input, gradOutput);
   THTensor_(resizeAs)(gradInput, input);
 
@@ -161,7 +173,8 @@ void THNN_(PReLU_accGradParameters)(
           THIndex_t nOutputPlane,
           real scale)
 {
-  THNN_CHECK_NELEMENT(input, gradOutput);  
+  THNN_(PReLU_shapeCheck)(state, input, gradOutput);
+  THNN_CHECK_NELEMENT(input, gradOutput);
   real *gradWeight_data = THTensor_(data)(gradWeight);
 
   if (nOutputPlane == 0)

--- a/lib/THNN/generic/TemporalConvolution.c
+++ b/lib/THNN/generic/TemporalConvolution.c
@@ -163,6 +163,9 @@ void THNN_(TemporalConvolution_updateGradInput)(
   nInputFrame = input->size[dimS];
   nOutputFrame = gradOutput->size[dimS];
 
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
+
   gradOutputWindow = THTensor_(new)();
   gradInputWindow = THTensor_(new)();
 
@@ -231,6 +234,8 @@ void THNN_(TemporalConvolution_updateGradInput)(
 
   THTensor_(free)(gradOutputWindow);
   THTensor_(free)(gradInputWindow);
+  THTensor_(free)(gradOutput);
+  THTensor_(free)(input);
 
 }
 
@@ -264,6 +269,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
   nOutputFrame = gradOutput->size[dimS];
 
   input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
   gradOutputWindow = THTensor_(new)();
   inputWindow = THTensor_(new)();
   
@@ -347,6 +353,7 @@ void THNN_(TemporalConvolution_accGradParameters)(
 
   THTensor_(free)(gradOutputWindow);
   THTensor_(free)(inputWindow);
+  THTensor_(free)(gradOutput);
   THTensor_(free)(input);
 
 }

--- a/lib/THNN/generic/VolumetricConvolutionMM.c
+++ b/lib/THNN/generic/VolumetricConvolutionMM.c
@@ -270,6 +270,7 @@ void THNN_(VolumetricConvolutionMM_updateOutput)(
 
   THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
 		"4D or 5D (batch mode) tensor expected for input, but got: %s");
+  input = THTensor_(newContiguous)(input);
 
   if (input->nDimension == 5)
   {
@@ -343,6 +344,7 @@ void THNN_(VolumetricConvolutionMM_updateOutput)(
     }
   }
 
+  THTensor_(free)(input);
   if (freeWeight)
     THTensor_(free)(weight);
 }
@@ -406,6 +408,8 @@ void THNN_(VolumetricConvolutionMM_updateGradInput)(
   THArgCheck(nOutputPlane == gradOutput->size[input->nDimension == 5 ? 1 : 0], 1,
     "Number of output features is not equal to nOutputPlane"
   );
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
 
   int freeWeight = THNN_(view_weight)(&weight);
 
@@ -453,6 +457,8 @@ void THNN_(VolumetricConvolutionMM_updateGradInput)(
 
   THTensor_(transpose)(weight, weight, 0, 1);
 
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
   if (freeWeight)
     THTensor_(free)(weight);
 }
@@ -508,6 +514,8 @@ void THNN_(VolumetricConvolutionMM_accGradParameters)(
   THArgCheck(nOutputPlane == gradOutput->size[input->nDimension == 5 ? 1 : 0], 3,
     "Number of output features is not equal to nOutputPlane"
   );
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
 
   freeWeight = THNN_(view_weight)(&gradWeight);
 
@@ -532,6 +540,8 @@ void THNN_(VolumetricConvolutionMM_accGradParameters)(
     }
   }
 
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
   if (freeWeight)
     THTensor_(free)(gradWeight);
 }


### PR DESCRIPTION
Adds contiguous checking / auto make contiguous code for tests that failed cunn test checking when all parameter tensors were made contiguous.

In some cases we add checking, in some cases we make the tensor contiguous; I did this based on if other tensors in the module were already being made contiguous.