### PR TITLE
Fix shapeCheck in Spatial Pooling modules

### DIFF
--- a/lib/THNN/generic/SpatialAveragePooling.c
+++ b/lib/THNN/generic/SpatialAveragePooling.c
@@ -52,6 +52,16 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
     outputWidth  = (long)(floor((float)(inputWidth  - kW + 2*padW) / dW)) + 1;
   }
 
+  if (padW || padH)
+  {
+    // ensure that the last pooling starts inside the image
+    // needed to avoid problems in ceil mode
+    if ((outputHeight - 1)*dH >= inputHeight + padH)
+      --outputHeight;
+    if ((outputWidth  - 1)*dW >= inputWidth  + padW)
+      --outputWidth;
+  }
+
   if (outputWidth < 1 || outputHeight < 1)
     THError("Given input size: (%dx%dx%d). "
 	    "Calculated output size: (%dx%dx%d). Output size is too small",

--- a/lib/THNN/generic/SpatialDilatedMaxPooling.c
+++ b/lib/THNN/generic/SpatialDilatedMaxPooling.c
@@ -55,6 +55,16 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
     outputWidth  = (long)(floor((float)(inputWidth  - (dilationW * (kW - 1) + 1) + 2*padW) / dW)) + 1;
   }
 
+  if (padW || padH)
+  {
+    // ensure that the last pooling starts inside the image
+    // needed to avoid problems in ceil mode
+    if ((outputHeight - 1)*dH >= inputHeight + padH)
+      --outputHeight;
+    if ((outputWidth  - 1)*dW >= inputWidth  + padW)
+      --outputWidth;
+  }
+
   if (outputWidth < 1 || outputHeight < 1)
     THError("Given input size: (%dx%dx%d). "
 	    "Calculated output size: (%dx%dx%d). Output size is too small",
@@ -201,6 +211,7 @@ void THNN_(SpatialDilatedMaxPooling_updateOutput)(
   if (padW || padH)
   {
     // ensure that the last pooling starts inside the image
+    // needed to avoid problems in ceil mode
     if ((outputHeight - 1)*dH >= inputHeight + padH)
       --outputHeight;
     if ((outputWidth  - 1)*dW >= inputWidth  + padW)


### PR DESCRIPTION
There was a problem with `shapeCheck` sometimes when `ceil_mode=True`, as [this part was missing from the size estimates](https://github.com/torch/nn/blob/master/lib/THNN/generic/SpatialDilatedMaxPooling.c#L201-L208).
The following snippet didn't work prior to this change.
```lua
m = nn.SpatialMaxPooling(2,2,2,2,1,1):ceil()
m:forward(torch.rand(1,1,5,5))
m:backward(torch.rand(1,1,5,5),torch.rand(1,1,3,3))
```
with error message
```
Need indices of dimension 4 and indices.size[3] == 4 but got indices to be of shape: [1 x 1 x 3 x 3]
```

The same change should be made in `THCUNN`. I'll send a PR later.