### PR TITLE
Move make contiguous code from lua to C.

### DIFF
--- a/LookupTable.lua
+++ b/LookupTable.lua
@@ -102,12 +102,6 @@ function LookupTable:accGradParameters(input, gradOutput, scale)
       error("input must be a vector or matrix")
    end
 
-   if not gradOutput:isContiguous() then
-      self._gradOutput = self._gradOutput or gradOutput.new()
-      self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
-      gradOutput = self._gradOutput
-   end
-
    self.gradWeight.THNN.LookupTable_accGradParameters(
       input:cdata(),
       gradOutput:cdata(),
@@ -162,7 +156,7 @@ function LookupTable:type(type, tensorCache)
 end
 
 function LookupTable:clearState()
-   nn.utils.clear(self, '_count', '_input', '_gradOutput')
+   nn.utils.clear(self, '_count', '_input')
    return parent.clearState(self)
 end
 

--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -73,26 +73,9 @@ local function backCompatibility(self)
    end
 end
 
-local function makeContiguous(self, input, gradOutput)
-   if not input:isContiguous() then
-      self._input = self._input or input.new()
-      self._input:resizeAs(input):copy(input)
-      input = self._input
-   end
-   if gradOutput then
-      if not gradOutput:isContiguous() then
-	 self._gradOutput = self._gradOutput or gradOutput.new()
-	 self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
-	 gradOutput = self._gradOutput
-      end
-   end
-   return input, gradOutput
-end
-
 function SpatialConvolution:updateOutput(input)
    assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    backCompatibility(self)
-   input = makeContiguous(self, input)
    input.THNN.SpatialConvolutionMM_updateOutput(
       input:cdata(),
       self.output:cdata(),
@@ -111,7 +94,6 @@ function SpatialConvolution:updateGradInput(input, gradOutput)
    assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    if self.gradInput then
       backCompatibility(self)
-      input, gradOutput = makeContiguous(self, input, gradOutput)
       input.THNN.SpatialConvolutionMM_updateGradInput(
          input:cdata(),
          gradOutput:cdata(),
@@ -131,7 +113,6 @@ function SpatialConvolution:accGradParameters(input, gradOutput, scale)
    assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    scale = scale or 1
    backCompatibility(self)
-   input, gradOutput = makeContiguous(self, input, gradOutput)
    input.THNN.SpatialConvolutionMM_accGradParameters(
       input:cdata(),
       gradOutput:cdata(),

--- a/SpatialConvolutionLocal.lua
+++ b/SpatialConvolutionLocal.lua
@@ -48,22 +48,6 @@ function SpatialConvolutionLocal:reset(stdv)
    end
 end
 
-local function makeContiguous(self, input, gradOutput)
-   if not input:isContiguous() then
-      self._input = self._input or input.new()
-      self._input:resizeAs(input):copy(input)
-      input = self._input
-   end
-   if gradOutput then
-      if not gradOutput:isContiguous() then
-	 self._gradOutput = self._gradOutput or gradOutput.new()
-	 self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
-	 gradOutput = self._gradOutput
-      end
-   end
-   return input, gradOutput
-end
-
 local function viewWeight(self)
    self.weight = self.weight:view(self.oH * self.oW, self.nOutputPlane, self.nInputPlane * self.kH * self.kW)
    if self.gradWeight and self.gradWeight:dim() > 0 then
@@ -118,7 +102,6 @@ function SpatialConvolutionLocal:updateOutput(input)
    self.fgradInput = self.fgradInput or input.new()
    checkInputSize(self, input)
    viewWeight(self)
-   input = makeContiguous(self, input)
    input.THNN.SpatialConvolutionLocal_updateOutput(
       input:cdata(),
       self.output:cdata(),
@@ -141,7 +124,6 @@ function SpatialConvolutionLocal:updateGradInput(input, gradOutput)
    checkOutputSize(self, input, gradOutput)
    if self.gradInput then
       viewWeight(self)
-      input, gradOutput = makeContiguous(self, input, gradOutput)
       input.THNN.SpatialConvolutionLocal_updateGradInput(
          input:cdata(),
          gradOutput:cdata(),
@@ -164,7 +146,6 @@ function SpatialConvolutionLocal:accGradParameters(input, gradOutput, scale)
    scale = scale or 1
    checkInputSize(self, input)
    checkOutputSize(self, input, gradOutput)
-   input, gradOutput = makeContiguous(self, input, gradOutput)
    viewWeight(self)
    input.THNN.SpatialConvolutionLocal_accGradParameters(
       input:cdata(),

--- a/SpatialConvolutionMM.lua
+++ b/SpatialConvolutionMM.lua
@@ -50,22 +50,6 @@ function SpatialConvolutionMM:reset(stdv)
    end
 end
 
-local function makeContiguous(self, input, gradOutput)
-   if not input:isContiguous() then
-      self._input = self._input or input.new()
-      self._input:resizeAs(input):copy(input)
-      input = self._input
-   end
-   if gradOutput then
-      if not gradOutput:isContiguous() then
-	 self._gradOutput = self._gradOutput or gradOutput.new()
-	 self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
-	 gradOutput = self._gradOutput
-      end
-   end
-   return input, gradOutput
-end
-
 function SpatialConvolutionMM:updateOutput(input)
    assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    self.finput = self.finput or input.new()
@@ -76,7 +60,6 @@ function SpatialConvolutionMM:updateOutput(input)
       self.padH = self.padding
       self.padding = nil
    end
-   input = makeContiguous(self, input)
    input.THNN.SpatialConvolutionMM_updateOutput(
       input:cdata(),
       self.output:cdata(),
@@ -94,7 +77,6 @@ end
 function SpatialConvolutionMM:updateGradInput(input, gradOutput)
    assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    if self.gradInput then
-      input, gradOutput = makeContiguous(self, input, gradOutput)
       input.THNN.SpatialConvolutionMM_updateGradInput(
          input:cdata(),
          gradOutput:cdata(),
@@ -113,7 +95,6 @@ end
 function SpatialConvolutionMM:accGradParameters(input, gradOutput, scale)
    assert(input.THNN, torch.type(input)..'.THNN backend not imported')
    scale = scale or 1
-   input, gradOutput = makeContiguous(self, input, gradOutput)
    assert((self.bias and self.gradBias) or (self.bias == nil and self.gradBias == nil))
    input.THNN.SpatialConvolutionMM_accGradParameters(
       input:cdata(),

--- a/SpatialDilatedConvolution.lua
+++ b/SpatialDilatedConvolution.lua
@@ -8,26 +8,9 @@ function SpatialDilatedConvolution:__init(nInputPlane, nOutputPlane, kW, kH, dW,
    self.dilationH = dilationH or 1
 end
 
-local function makeContiguous(self, input, gradOutput)
-   if not input:isContiguous() then
-      self._input = self._input or input.new()
-      self._input:resizeAs(input):copy(input)
-      input = self._input
-   end
-   if gradOutput then
-      if not gradOutput:isContiguous() then
-	 self._gradOutput = self._gradOutput or gradOutput.new()
-	 self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
-	 gradOutput = self._gradOutput
-      end
-   end
-   return input, gradOutput
-end
-
 function SpatialDilatedConvolution:updateOutput(input)
    self.finput = self.finput or self.weight.new()
    self.fgradInput = self.fgradInput or self.weight.new()
-   input = makeContiguous(self, input)
    input.THNN.SpatialDilatedConvolution_updateOutput(
       input:cdata(),
       self.output:cdata(),
@@ -45,7 +28,6 @@ end
 
 function SpatialDilatedConvolution:updateGradInput(input, gradOutput)
    if self.gradInput then
-      input, gradOutput = makeContiguous(self, input, gradOutput)
       self.fgradInput = self.fgradInput or self.weight.new()
       input.THNN.SpatialDilatedConvolution_updateGradInput(
          input:cdata(),
@@ -64,7 +46,6 @@ end
 
 function SpatialDilatedConvolution:accGradParameters(input, gradOutput, scale)
    scale = scale or 1
-   input, gradOutput = makeContiguous(self, input, gradOutput)
    self.fgradInput = self.fgradInput or self.weight.new()
    input.THNN.SpatialDilatedConvolution_accGradParameters(
       input:cdata(),

--- a/SpatialFullConvolution.lua
+++ b/SpatialFullConvolution.lua
@@ -55,22 +55,6 @@ function SpatialFullConvolution:reset(stdv)
    end
 end
 
-local function makeContiguous(self, input, gradOutput)
-  if not input:isContiguous() then
-    self._input = self._input or input.new()
-    self._input:resizeAs(input):copy(input)
-    input = self._input
-  end
-  if gradOutput then
-    if not gradOutput:isContiguous() then
-      self._gradOutput = self._gradOutput or gradOutput.new()
-      self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
-      gradOutput = self._gradOutput
-    end
-  end
-  return input, gradOutput
-end
-
 local function calculateAdj(targetSize, ker, pad, stride)
   return (targetSize + 2 * pad - ker) % stride
 end
@@ -103,7 +87,6 @@ function SpatialFullConvolution:updateOutput(input)
     self.fgradInput = self.fgradInput or input.new()
   end
 
-  inputTensor = makeContiguous(self, inputTensor)
   inputTensor.THNN.SpatialFullConvolution_updateOutput(
     inputTensor:cdata(),
     self.output:cdata(),
@@ -144,7 +127,6 @@ function SpatialFullConvolution:updateGradInput(input, gradOutput)
       end
     end
 
-    inputTensor, gradOutput = makeContiguous(self, inputTensor, gradOutput)
     inputTensor.THNN.SpatialFullConvolution_updateGradInput(
       inputTensor:cdata(),
       gradOutput:cdata(),
@@ -190,7 +172,6 @@ function SpatialFullConvolution:accGradParameters(input, gradOutput, scale)
     adjH = calculateAdj(tH, self.kH, self.padH, self.dH)
   end
 
-  inputTensor, gradOutput = makeContiguous(self, inputTensor, gradOutput)
   inputTensor.THNN.SpatialFullConvolution_accGradParameters(
     inputTensor:cdata(),
     gradOutput:cdata(),

--- a/VolumetricDilatedConvolution.lua
+++ b/VolumetricDilatedConvolution.lua
@@ -9,26 +9,9 @@ function VolumetricDilatedConvolution:__init(nInputPlane, nOutputPlane, kT, kW, 
    self.dilationH = dilationH or 1
 end
 
-local function makeContiguous(self, input, gradOutput)
-   if not input:isContiguous() then
-      self._input = self._input or input.new()
-      self._input:resizeAs(input):copy(input)
-      input = self._input
-   end
-   if gradOutput then
-      if not gradOutput:isContiguous() then
-	 self._gradOutput = self._gradOutput or gradOutput.new()
-	 self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
-	 gradOutput = self._gradOutput
-      end
-   end
-   return input, gradOutput
-end
-
 function VolumetricDilatedConvolution:updateOutput(input)
    self.finput = self.finput or self.weight.new()
    self.fgradInput = self.fgradInput or self.weight.new()
-   input = makeContiguous(self, input)
    input.THNN.VolumetricDilatedConvolution_updateOutput(
       input:cdata(),
       self.output:cdata(),
@@ -46,7 +29,6 @@ end
 
 function VolumetricDilatedConvolution:updateGradInput(input, gradOutput)
    if self.gradInput then
-      input, gradOutput = makeContiguous(self, input, gradOutput)
       self.fgradInput = self.fgradInput or self.weight.new()
       input.THNN.VolumetricDilatedConvolution_updateGradInput(
          input:cdata(),
@@ -65,7 +47,6 @@ end
 
 function VolumetricDilatedConvolution:accGradParameters(input, gradOutput, scale)
    scale = scale or 1
-   input, gradOutput = makeContiguous(self, input, gradOutput)
    self.fgradInput = self.fgradInput or self.weight.new()
    input.THNN.VolumetricDilatedConvolution_accGradParameters(
       input:cdata(),

--- a/VolumetricFullConvolution.lua
+++ b/VolumetricFullConvolution.lua
@@ -57,22 +57,6 @@ function VolumetricFullConvolution:reset(stdv)
    self.bias:uniform(-stdv, stdv)
 end
 
-local function makeContiguous(self, input, gradOutput)
-   if not input:isContiguous() then
-      self._input = self._input or input.new()
-      self._input:resizeAs(input):copy(input)
-      input = self._input
-   end
-   if gradOutput then
-      if not gradOutput:isContiguous() then
-         self._gradOutput = self._gradOutput or gradOutput.new()
-         self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
-         gradOutput = self._gradOutput
-     end
-   end
-   return input, gradOutput
-end
-
 local function calculateAdj(targetSize, ker, pad, stride)
   return (targetSize + 2 * pad - ker) % stride
 end
@@ -113,7 +97,6 @@ function VolumetricFullConvolution:updateOutput(input)
     adjH = calculateAdj(tH, self.kH, self.padH, self.dH)
   end
 
-   inputTensor = makeContiguous(self, inputTensor)
    inputTensor.THNN.VolumetricFullConvolution_updateOutput(
       inputTensor:cdata(),
       self.output:cdata(),
@@ -153,7 +136,6 @@ function VolumetricFullConvolution:updateGradInput(input, gradOutput)
       end
     end
 
-   inputTensor, gradOutput = makeContiguous(self, inputTensor, gradOutput)
    inputTensor.THNN.VolumetricFullConvolution_updateGradInput(
       inputTensor:cdata(),
       gradOutput:cdata(),
@@ -199,7 +181,6 @@ function VolumetricFullConvolution:accGradParameters(input, gradOutput, scale)
     adjH = calculateAdj(tH, self.kH, self.padH, self.dH)
   end
 
-   inputTensor, gradOutput = makeContiguous(self, inputTensor, gradOutput)
    inputTensor.THNN.VolumetricFullConvolution_accGradParameters(
       inputTensor:cdata(),
       gradOutput:cdata(),

--- a/lib/THNN/generic/SpatialConvolutionLocal.c
+++ b/lib/THNN/generic/SpatialConvolutionLocal.c
@@ -224,6 +224,7 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
      inputHeight, inputWidth, outputHeight, outputWidth);
 
   input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
   long nInputPlane = THTensor_(size)(weight,2)/(kW*kH);
   long nOutputPlane = THTensor_(size)(weight,1);
 
@@ -266,6 +267,7 @@ void THNN_(SpatialConvolutionLocal_updateGradInput)(
   THTensor_(transpose)(weight, weight, 1, 2);
 
   THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
   if (freeWeight)
     THTensor_(free)(weight);
 

--- a/lib/THNN/generic/SpatialConvolutionMM.c
+++ b/lib/THNN/generic/SpatialConvolutionMM.c
@@ -124,6 +124,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
   THNN_(SpatialConvolutionMM_shapeCheck)
     (input, NULL, weight, bias, kH, kW, dH, dW, padH, padW);
 
+  input = THTensor_(newContiguous)(input);
   int ndim = input->nDimension;
   int dimf = 0;
   int dimh = 1;
@@ -180,6 +181,7 @@ void THNN_(SpatialConvolutionMM_updateOutput)(
     }
   }
 
+  THTensor_(free)(input);
   if (freeWeight)
     THTensor_(free)(weight);
 }
@@ -239,6 +241,9 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
   THNN_(SpatialConvolutionMM_shapeCheck)
     (input, gradOutput, weight, NULL, kH, kW, dH, dW, padH, padW);
 
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
+
   THTensor_(resizeAs)(gradInput, input);
   THTensor_(resizeAs)(fgradInput, finput);
 
@@ -279,6 +284,8 @@ void THNN_(SpatialConvolutionMM_updateGradInput)(
 
   THTensor_(transpose)(weight, weight, 0, 1);
 
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
   if (freeWeight)
     THTensor_(free)(weight);
 }
@@ -345,6 +352,9 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
   THNN_(SpatialConvolutionMM_shapeCheck)
     (input, gradOutput, gradWeight, gradBias, kH, kW, dH, dW, padH, padW);
 
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
+
   if(input->nDimension == 3)
   {
     THNN_(SpatialConvolutionMM_accGradParameters_frame)(gradOutput, gradWeight,
@@ -367,6 +377,9 @@ void THNN_(SpatialConvolutionMM_accGradParameters)(
       THTensor_(free)(finput_t);
     }
   }
+
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
   if (freeWeight)
     THTensor_(free)(gradWeight);
 }

--- a/lib/THNN/generic/SpatialDilatedConvolution.c
+++ b/lib/THNN/generic/SpatialDilatedConvolution.c
@@ -80,6 +80,7 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
   int nInputPlane = weight->size[1];
   int nOutputPlane = weight->size[0];
 
+  input = THTensor_(newContiguous)(input);
   int batch = 1;
   if (input->nDimension == 3) {
     // Force batch
@@ -175,6 +176,8 @@ void THNN_(SpatialDilatedConvolution_updateOutput)(
     THTensor_(resize3d)(output, nOutputPlane, outputHeight, outputWidth);
     THTensor_(resize3d)(input, nInputPlane, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
 }
 
 void THNN_(SpatialDilatedConvolution_updateGradInput)(
@@ -197,6 +200,8 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
   int nInputPlane = weight->size[1];
   int nOutputPlane = weight->size[0];
 
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
   int batch = 1;
   if (input->nDimension == 3) {
     // Force batch
@@ -266,6 +271,9 @@ void THNN_(SpatialDilatedConvolution_updateGradInput)(
     THTensor_(resize3d)(input, nInputPlane, inputHeight, inputWidth);
     THTensor_(resize3d)(gradInput, nInputPlane, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
 }
 
 
@@ -291,6 +299,8 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
   int nInputPlane = gradWeight->size[1];
   int nOutputPlane = gradWeight->size[0];
 
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
   int batch = 1;
   if (input->nDimension == 3) {
     // Force batch
@@ -380,6 +390,9 @@ void THNN_(SpatialDilatedConvolution_accGradParameters)(
     THTensor_(resize3d)(gradOutput, nOutputPlane, outputHeight, outputWidth);
     THTensor_(resize3d)(input, nInputPlane, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
 }
 
 #endif

--- a/lib/THNN/generic/SpatialFullConvolution.c
+++ b/lib/THNN/generic/SpatialFullConvolution.c
@@ -127,6 +127,7 @@ void THNN_(SpatialFullConvolution_updateOutput)(
   int nInputPlane = THTensor_(size)(weight,0);
   int nOutputPlane = THTensor_(size)(weight,1);
 
+  input = THTensor_(newContiguous)(input);
   int batch = 1;
   if (input->nDimension == 3) {
     // Force batch
@@ -224,6 +225,8 @@ void THNN_(SpatialFullConvolution_updateOutput)(
     THTensor_(resize3d)(output, nOutputPlane, outputHeight, outputWidth);
     THTensor_(resize3d)(input, nInputPlane, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
 }
 
 void THNN_(SpatialFullConvolution_updateGradInput)(
@@ -244,6 +247,8 @@ void THNN_(SpatialFullConvolution_updateGradInput)(
   int nInputPlane = THTensor_(size)(weight,0);
   int nOutputPlane = THTensor_(size)(weight,1);
 
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
   int batch = 1;
   if (input->nDimension == 3) {
     // Force batch
@@ -316,6 +321,9 @@ void THNN_(SpatialFullConvolution_updateGradInput)(
     THTensor_(resize3d)(input, nInputPlane, inputHeight, inputWidth);
     THTensor_(resize3d)(gradInput, nInputPlane, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
 }
 
 
@@ -339,6 +347,8 @@ void THNN_(SpatialFullConvolution_accGradParameters)(
   int nInputPlane = THTensor_(size)(gradWeight,0);
   int nOutputPlane = THTensor_(size)(gradWeight,1);
 
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
   int batch = 1;
   if (input->nDimension == 3) {
     // Force batch
@@ -431,6 +441,9 @@ void THNN_(SpatialFullConvolution_accGradParameters)(
     THTensor_(resize3d)(gradOutput, nOutputPlane, outputHeight, outputWidth);
     THTensor_(resize3d)(input, nInputPlane, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
 }
 
 #endif

--- a/lib/THNN/generic/VolumetricDilatedConvolution.c
+++ b/lib/THNN/generic/VolumetricDilatedConvolution.c
@@ -29,6 +29,7 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
   int nInputPlane = weight->size[1];
   int nOutputPlane = weight->size[0];
 
+  input = THTensor_(newContiguous)(input);
   int batch = 1;
   if (input->nDimension == 4) {
     THArgCheck(input->size[0] == nInputPlane, 2, "input channels and nInputPlane dont match. Expected: %d, got %d", nInputPlane, input->size[0]);
@@ -136,6 +137,8 @@ void THNN_(VolumetricDilatedConvolution_updateOutput)(
     THTensor_(resize4d)(output, nOutputPlane, outputDepth, outputHeight, outputWidth);
     THTensor_(resize4d)(input, nInputPlane, inputDepth, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
 }
 
 void THNN_(VolumetricDilatedConvolution_updateGradInput)(
@@ -165,6 +168,8 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
   int nInputPlane = weight->size[1];
   int nOutputPlane = weight->size[0];
 
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
   int batch = 1;
   if (input->nDimension == 4) {
     THArgCheck(input->size[0] == nInputPlane, 2, "input channels and nInputPlane dont match");
@@ -239,6 +244,9 @@ void THNN_(VolumetricDilatedConvolution_updateGradInput)(
     THTensor_(resize4d)(input, nInputPlane, inputDepth, inputHeight, inputWidth);
     THTensor_(resize4d)(gradInput, nInputPlane, inputDepth, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
 }
 
 void THNN_(VolumetricDilatedConvolution_accGradParameters)(
@@ -271,6 +279,8 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
   int nInputPlane = gradWeight->size[1];
   int nOutputPlane = gradWeight->size[0];
 
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
   int batch = 1;
   if (input->nDimension == 4) {
     THArgCheck(input->size[0] == nInputPlane, 2, "input channels and nInputPlane dont match");
@@ -365,6 +375,9 @@ void THNN_(VolumetricDilatedConvolution_accGradParameters)(
     THTensor_(resize4d)(gradOutput, nOutputPlane, outputDepth, outputHeight, outputWidth);
     THTensor_(resize4d)(input, nInputPlane, inputDepth, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
 }
 
 #endif

--- a/lib/THNN/generic/VolumetricFullConvolution.c
+++ b/lib/THNN/generic/VolumetricFullConvolution.c
@@ -114,6 +114,7 @@ void THNN_(VolumetricFullConvolution_updateOutput)(
   THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
 		"4D or 5D (batch mode) tensor expected for input, but got: %s");
 
+  input = THTensor_(newContiguous)(input);
   int batch = 1;
   if (input->nDimension == 4)
   {
@@ -223,6 +224,8 @@ void THNN_(VolumetricFullConvolution_updateOutput)(
     THTensor_(resize4d)(output, nOutputPlane, outputDepth, outputHeight, outputWidth);
     THTensor_(resize4d)(input, nInputPlane, inputDepth, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
 }
 
 void THNN_(VolumetricFullConvolution_updateGradInput)(
@@ -252,6 +255,9 @@ void THNN_(VolumetricFullConvolution_updateGradInput)(
 
   THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
 		"4D or 5D (batch mode) tensor expected for input, but got: %s");
+
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
 
   int batch = 1;
   if (input->nDimension == 4)
@@ -331,6 +337,9 @@ void THNN_(VolumetricFullConvolution_updateGradInput)(
     THTensor_(resize4d)(input, nInputPlane, inputDepth, inputHeight, inputWidth);
     THTensor_(resize4d)(gradInput, nInputPlane, inputDepth, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
 }
 
 void THNN_(VolumetricFullConvolution_accGradParameters)(
@@ -362,6 +371,9 @@ void THNN_(VolumetricFullConvolution_accGradParameters)(
 
   THNN_ARGCHECK(input->nDimension == 4 || input->nDimension == 5, 2, input,
 		"4D or 5D (batch mode) tensor expected for input, but got: %s");
+
+  input = THTensor_(newContiguous)(input);
+  gradOutput = THTensor_(newContiguous)(gradOutput);
 
   int batch = 1;
   if (input->nDimension == 4)
@@ -461,6 +473,9 @@ void THNN_(VolumetricFullConvolution_accGradParameters)(
     THTensor_(resize4d)(gradOutput, nOutputPlane, outputDepth, outputHeight, outputWidth);
     THTensor_(resize4d)(input, nInputPlane, inputDepth, inputHeight, inputWidth);
   }
+
+  THTensor_(free)(input);
+  THTensor_(free)(gradOutput);
 }
 
 #endif


### PR DESCRIPTION
Exceptions are:
1) SparseLinear
requires additional parameters to be passed in (e.g. nbatches),
so it's not clear it's worth moving to C since it won't really simplify the binding
code logic.

2) BatchNormalization
requires "makeBatch", which isn't a trivial translation to C.

3) LookupTable
requires "view" in C, which is already a TODO

4) SpatialUpSamplingBilinear
requires "view" in C, which is already TODO