### PR TITLE
Remove resizing of output in lua.

### DIFF
--- a/BatchNormalization.lua
+++ b/BatchNormalization.lua
@@ -116,7 +116,6 @@ function BN:updateOutput(input)
    input = makeContiguous(self, input)
    input = makeBatch(self, input)
 
-   self.output:resizeAs(input)
    self.save_mean = self.save_mean or input.new()
    self.save_mean:resizeAs(self.running_mean)
    self.save_std = self.save_std or input.new()

--- a/SpatialUpSamplingBilinear.lua
+++ b/SpatialUpSamplingBilinear.lua
@@ -79,7 +79,6 @@ function SpatialUpSamplingBilinear:updateOutput(input)
    local xdim = input:dim()
    local ydim = xdim - 1
    self:setSize(input)
-   self.output:resize(self.outputSize)
    input.THNN.SpatialUpSamplingBilinear_updateOutput(
       input:cdata(),
       self.output:cdata(),

--- a/SpatialUpSamplingNearest.lua
+++ b/SpatialUpSamplingNearest.lua
@@ -39,13 +39,6 @@ function SpatialUpSamplingNearest:updateOutput(input)
    end
    self.outputSize[ydim] = self.outputSize[ydim] * self.scale_factor
    self.outputSize[xdim] = self.outputSize[xdim] * self.scale_factor
-   -- Resize the output if needed
-   if input:dim() == 3 then
-     self.output:resize(self.outputSize[1], self.outputSize[2],
-       self.outputSize[3])
-   else
-     self.output:resize(self.outputSize)
-   end
    input.THNN.SpatialUpSamplingNearest_updateOutput(
       input:cdata(),
       self.output:cdata(),


### PR DESCRIPTION
These resizes have already been moved to C code in nn/cunn, so are safe to remove.