### PR TITLE
Improve fix/shape checks for Temporal and Spatial modules

### DIFF
--- a/lib/THNN/generic/SpatialAveragePooling.c
+++ b/lib/THNN/generic/SpatialAveragePooling.c
@@ -26,10 +26,6 @@ static inline void THNN_(SpatialAveragePooling_shapeCheck)(
   THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
 		"3D or 4D input tensor expected but got: %s");
 
-  THArgCheck(input->size[dimw] >= kW - padW && input->size[dimh] >= kH - padH, 2,
-	     "input image (H: %d, W: %d) smaller than kernel "
-	     "size - padding( kH: %d padH: %d kW: %d padW: %d",
-	     input->size[dimh], input->size[dimw], kH, padH, kW, padW);
   THArgCheck(kW/2 >= padW && kH/2 >= padH, 2,
 	     "pad should be smaller than half of kernel size, but got "
 	     "padW = %d, padH = %d, kW = %d, kH = %d",

--- a/lib/THNN/generic/SpatialDilatedMaxPooling.c
+++ b/lib/THNN/generic/SpatialDilatedMaxPooling.c
@@ -29,10 +29,6 @@ static inline void THNN_(SpatialDilatedMaxPooling_shapeCheck)(
   THNN_ARGCHECK(ndim == 3 || ndim == 4, 2, input,
 		"3D or 4D input tensor expected but got: %s");
 
-  THArgCheck(input->size[dimw] >= kW - padW && input->size[dimh] >= kH - padH, 2,
-	     "input image (H: %d, W: %d) smaller than kernel "
-	     "size - padding( kH: %d padH: %d kW: %d padW: %d",
-	     input->size[dimh], input->size[dimw], kH, padH, kW, padW);
   THArgCheck(kW/2 >= padW && kH/2 >= padH, 2,
 	     "pad should be smaller than half of kernel size, but got "
 	     "padW = %d, padH = %d, kW = %d, kH = %d",

--- a/lib/THNN/generic/TemporalConvolution.c
+++ b/lib/THNN/generic/TemporalConvolution.c
@@ -2,6 +2,38 @@
 #define TH_GENERIC_FILE "generic/TemporalConvolution.c"
 #else
 
+static inline void THNN_(TemporalConvolution_shapeCheck)(
+                         THNNState *state,
+                         THTensor *input,
+                         int kW,
+                         int dW,
+                         int *inputFrameSize) {
+
+  THArgCheck(kW > 0, 9,
+             "kernel size should be greater than zero, but got kW: %d", kW);
+  THArgCheck(dW > 0, 11,
+             "stride should be greater than zero, but got dW: %d", dW);
+
+  int dimS = 0; // sequence dimension
+  int dimF = 1; // feature dimension
+
+  if (input->nDimension == 3)
+  {
+    dimS = 1;
+    dimF = 2;
+  }
+  THNN_ARGCHECK(input->nDimension == 2 || input->nDimension == 3, 2, input,
+                  "2D or 3D (batch mode) tensor expected for input, but got: %s");
+  if (inputFrameSize != NULL) {
+    THArgCheck(input->size[dimF] == *inputFrameSize, 2,
+               "invalid input frame size. Got: %d, Expected: %d",
+               input->size[dimF], *inputFrameSize);
+  }
+  THArgCheck(input->size[dimS] >= kW, 2,
+             "input sequence smaller than kernel size. Got: %d, Expected: %d",
+             input->size[dimS], kW);
+}
+
 void THNN_(TemporalConvolution_updateOutput)(
           THNNState *state,
           THTensor *input,
@@ -20,21 +52,14 @@ void THNN_(TemporalConvolution_updateOutput)(
   int dimS = 0; // sequence dimension
   int dimF = 1; // feature dimension
   
-  THNN_ARGCHECK(input->nDimension == 2 || input->nDimension == 3, 2, input,
-		"2D or 3D (batch mode) tensor expected for input, but got: %s");
-  
   if (input->nDimension == 3) 
   {
     dimS = 1;
     dimF = 2;
   }
-  THArgCheck(input->size[dimF] == inputFrameSize, 2,
-	     "invalid input frame size. Got: %d, Expected: %d",
-	     input->size[dimF], inputFrameSize);
-  THArgCheck(input->size[dimS] >= kW, 2,
-	     "input sequence smaller than kernel size. Got: %d, Expected: %d",
-	     input->size[dimS], kW);
 
+  THNN_(TemporalConvolution_shapeCheck)
+       (state, input, kW, dW, &inputFrameSize);
   input = THTensor_(newContiguous)(input);
   outputWindow = THTensor_(new)();
   inputWindow = THTensor_(new)();
@@ -159,7 +184,9 @@ void THNN_(TemporalConvolution_updateGradInput)(
     dimS = 1;
     dimF = 2;
   }
-  
+
+  THNN_(TemporalConvolution_shapeCheck)(
+        state, input, kW, dW, NULL);
   nInputFrame = input->size[dimS];
   nOutputFrame = gradOutput->size[dimS];
 
@@ -264,7 +291,9 @@ void THNN_(TemporalConvolution_accGradParameters)(
     dimS = 1;
     dimF = 2;
   }
-  
+
+  THNN_(TemporalConvolution_shapeCheck)(
+        state, input, kW, dW, NULL);
   nInputFrame = input->size[dimS];
   nOutputFrame = gradOutput->size[dimS];
 

--- a/lib/THNN/generic/TemporalSubSampling.c
+++ b/lib/THNN/generic/TemporalSubSampling.c
@@ -5,9 +5,12 @@
 static inline void THNN_(TemporalSubSampling_shapeCheck)(
                          THNNState *state,
                          THTensor *input,
+                         THTensor *gradOutput,
                          int kW,
                          int dW,
                          int *inputFrameSize) {
+  int nInputFrame, nOutputFrame;
+
   THArgCheck(kW > 0, 6,
              "kernel size should be greater than zero, but got kW: %d", kW);
   THArgCheck(dW > 0, 7,
@@ -23,6 +26,16 @@ static inline void THNN_(TemporalSubSampling_shapeCheck)(
   THArgCheck( input->size[0] >= kW, 2,
               "input sequence smaller than kernel size.  Got %d, Expected: %d",
               input->size[0], kW);
+
+  nInputFrame = input->size[0];
+  nOutputFrame = (nInputFrame - kW) / dW + 1;
+
+  if (gradOutput != NULL) {
+    THNN_CHECK_DIM_SIZE(gradOutput, input->nDimension, 0, nOutputFrame);
+    if (inputFrameSize != NULL) {
+      THNN_CHECK_DIM_SIZE(gradOutput, input->nDimension, 1, *inputFrameSize);
+    }
+  }
 }
 
 void THNN_(TemporalSubSampling_updateOutput)(
@@ -39,7 +52,7 @@ void THNN_(TemporalSubSampling_updateOutput)(
   int nInputFrame, nOutputFrame;
   long k;
   
-  THNN_(TemporalSubSampling_shapeCheck)(state, input, kW, dW, &inputFrameSize);
+  THNN_(TemporalSubSampling_shapeCheck)(state, input, NULL, kW, dW, &inputFrameSize);
 
   outputFrame = THTensor_(new)();
   inputWindow = THTensor_(new)();
@@ -78,7 +91,7 @@ void THNN_(TemporalSubSampling_updateGradInput)(
   THTensor *gradInputWindow, *buffer, *kwunit;
   long k;
 
-  THNN_(TemporalSubSampling_shapeCheck)(state, input, kW, dW, NULL);
+  THNN_(TemporalSubSampling_shapeCheck)(state, input, gradOutput, kW, dW, NULL);
 
   gradOutputFrame = THTensor_(new)();
   gradInputWindow = THTensor_(new)();
@@ -117,7 +130,7 @@ void THNN_(TemporalSubSampling_accGradParameters)(
   THTensor *inputWindow, *buffer;
   long k;
 
-  THNN_(TemporalSubSampling_shapeCheck)(state, input, kW, dW, NULL);
+  THNN_(TemporalSubSampling_shapeCheck)(state, input, gradOutput, kW, dW, NULL);
   gradOutputFrame = THTensor_(new)();
   inputWindow = THTensor_(new)();
   buffer = THTensor_(new)();


### PR DESCRIPTION
1) Adds shape checking for Temporal Convolution (this already exists in cunn, but was skipped in nn).
2) Adds gradOutput shape checks for temporal modules
3) Removes unnecessary (too restrictive and/or redundant) shape checks in Spatial Pooling modules.