### PR TITLE
Masking feature for nn.Linear and nn.SpatialConvolution

### DIFF
--- a/Linear.lua
+++ b/Linear.lua
@@ -1,4 +1,5 @@
 local Linear, parent = torch.class('nn.Linear', 'nn.Module')
+
 function Linear:__init(inputSize, outputSize, bias)
    parent.__init(self)
    local bias = ((bias == nil) and true) or bias

--- a/SpatialConvolution.lua
+++ b/SpatialConvolution.lua
@@ -31,6 +31,20 @@ function SpatialConvolution:noBias()
    return self
 end
 
+function SpatialConvolution:setMask(mask)
+   if self.weight:isSameSizeAs(mask) then
+      self.mask = mask
+      self.weight:cmul(self.mask)
+   else
+      error('Size of Mask must be same as the weight tensor')
+   end
+end
+
+function SpatialConvolution:removeMask(mask)
+      self.mask = nil
+end
+
+
 function SpatialConvolution:reset(stdv)
    if stdv then
       stdv = stdv * math.sqrt(3)
@@ -125,6 +139,9 @@ function SpatialConvolution:accGradParameters(input, gradOutput, scale)
       self.padW, self.padH,
       scale
    )
+   if self.mask ~= nil then
+      self.gradWeight:cmul(self.mask)
+   end
 end
 
 function SpatialConvolution:type(type,tensorCache)


### PR DESCRIPTION
I am implementing network pruning/compression from the `Learning both Weights and Connections for Efficient Neural Networks` paper as my final project. I would like to add pruning feature to those layers by setting a mask for each of those layers. 

There was couple of ideas in my mind. I first try those by adding a hook on training and saw that it works. Then there was two easy options;

- Implement it as a separate module `nn.PrunedLinear`. 
- Modify individual layers by adding the necessary lines.

I chose the second one to enable training first with all parameters, then iterating between pruning and retraining straightforward.

If the mask is same size as the weight tensor, then it is applied. Gradients are correctly calculated with pruned(zero-set) weights. Then right after accumulating the grad for all weights, the masked applied to the gradients to prevent grad update on pruned connections. I hope in future this can be implemented with sparse-tensors and 