### PR TITLE
Add SpatialAutoCropMSECriterion

### DIFF
--- a/SpatialAutoCropMSECriterion.lua
+++ b/SpatialAutoCropMSECriterion.lua
@@ -1,0 +1,74 @@
+--[[
+   SpatialAutoCropMSECriterion.
+   Implements the MSECriterion when the spatial resolution of the input is less than
+   or equal to the spatial resolution of the target. It achieves this center-cropping
+   the target to the same spatial resolution of the input and the MSE is then
+   calculated between these cropped inputs
+]]
+local SpatialAutoCropMSECriterion, parent = torch.class('nn.SpatialAutoCropMSECriterion', 'nn.MSECriterion')
+
+function SpatialAutoCropMSECriterion:__init(sizeAverage)
+    parent.__init(self, sizeAverage)
+end
+
+local function centerCrop(input, cropSize)
+   assert(input:dim() == 3 or input:dim() == 4, "input should be a 3D or  4D tensor")
+   assert(#cropSize == 2, "cropSize should have two elements only")
+   local _input = input
+   if input:dim() == 3 then
+      _input = input:view(1, input:size(1), input:size(2), input:size(3))
+   end
+   assert(cropSize[1] > 0 and cropSize[1] <= _input:size(3),
+         "0 < cropSize[1] <= input:size(3) not satisfied")
+   assert(cropSize[2] > 0 and cropSize[2] <= _input:size(4),
+        "0 < cropSize[1] <= input:size(3) not satisfied")
+
+   local inputHeight = _input:size(3)
+   local inputWidth = _input:size(4)
+
+   local rowStart = 1 + math.floor((inputHeight - cropSize[1])/2.0)
+   local rowEnd = rowStart + cropSize[1] - 1
+   local colStart = 1 +  math.floor((inputWidth - cropSize[2])/2.0)
+   local colEnd = colStart + cropSize[2] - 1
+   if input:dim() == 3 then
+      return input[{{}, {rowStart, rowEnd}, {colStart, colEnd}}]
+   else
+      return input[{{}, {}, {rowStart, rowEnd}, {colStart, colEnd}}]
+   end
+end
+
+local function getTensorHeightAndWidth(tensor)
+   heightIdx = 2
+   widthIdx = 3
+   if tensor:dim() == 4 then
+      heightIdx = 3
+      widthIdx = 4
+   end
+   return tensor:size(heightIdx), tensor:size(widthIdx)
+end
+
+local function inputResolutionIsSmallerThanTargetResolution(input, target)
+   inputHeight, inputWidth = getTensorHeightAndWidth(input)
+   targetHeight, targetWidth = getTensorHeightAndWidth(target)
+   return inputHeight <= targetHeight and inputWidth <= targetWidth
+end
+
+function SpatialAutoCropMSECriterion:updateOutput(input, target)
+   assert(input:dim() == target:dim(), "input and target should have the same number of dimensions")
+   assert(input:dim() == 4 or input:dim() == 3, "input and target must have 3 or 4 dimensions")
+   assert(inputResolutionIsSmallerThanTargetResolution(input, target),
+   "Spatial resolution of input should be less than or equal to the spatial resolution of the target")
+
+   inputHeight, inputWidth = getTensorHeightAndWidth(input)
+   local targetCropped = centerCrop(target, {inputHeight, inputWidth})
+   return parent.updateOutput(self, input, targetCropped)
+end
+
+
+function SpatialAutoCropMSECriterion:updateGradInput(input, gradOutput)
+   assert(input:dim() == gradOutput:dim(), "input and gradOutput should have the same number of dimensions")
+   assert(input:dim() == 4 or input:dim() == 3, "input and gradOutput must have 3 or 4 dimensions")
+   assert(input:isSameSizeAs(gradOutput), "gradOutput and input must have the same size")
+
+   return parent.updateGradInput(self, input, gradOutput)
+end

--- a/doc/criterion.md
+++ b/doc/criterion.md
@@ -18,6 +18,7 @@ target, they compute a gradient according to a given loss function.
     * [`AbsCriterion`](#nn.AbsCriterion): measures the mean absolute value of the element-wise difference between input;
     * [`SmoothL1Criterion`](#nn.SmoothL1Criterion): a smooth version of the AbsCriterion;
     * [`MSECriterion`](#nn.MSECriterion): mean square error (a classic);
+    * [`SpatialAutoCropMSECriterion`](#nn.SpatialAutoCropMSECriterion): Spatial mean square error when the input is spatially smaller than the target, by only comparing their spatial overlap;
     * [`DistKLDivCriterion`](#nn.DistKLDivCriterion): Kullback–Leibler divergence (for fitting continuous probability distributions);
   * Embedding criterions (measuring whether two inputs are similar or dissimilar):
     * [`HingeEmbeddingCriterion`](#nn.HingeEmbeddingCriterion): takes a distance as input;
@@ -500,6 +501,25 @@ criterion.sizeAverage = false
 ```
 
 By default, the losses are averaged over observations for each minibatch. However, if the field `sizeAverage` is set to `false`, the losses are instead summed.
+
+
+<a name="nn.SpatialAutoCropMSECriterion"></a>
+## SpatialAutoCropMSECriterion ##
+
+```lua
+criterion = nn.SpatialAutoCropMSECriterion()
+```
+
+Creates a criterion that measures the mean squared error between the input and target, even if the target is spatially larger than the input. It achieves this by center-cropping the target to the same spatial resolution as the input, the mean squared error is then calculated between the input and this cropped target.
+
+If the input and cropped target tensors are `d`-dimensional `Tensor`s with a total of `n` elements, the sum operation operates over all the elements, and divides by `n`.
+
+The division by `n` can be avoided if one sets the internal variable `sizeAverage` to `false`:
+
+```lua
+criterion = nn.SpatialAutoCropMSECriterion()
+criterion.sizeAverage = false
+```
 
 
 <a name="nn.MultiCriterion"></a>

--- a/init.lua
+++ b/init.lua
@@ -152,6 +152,7 @@ require('nn.MapTable')
 
 require('nn.Criterion')
 require('nn.MSECriterion')
+require('nn.SpatialAutoCropMSECriterion')
 require('nn.SmoothL1Criterion')
 require('nn.MarginCriterion')
 require('nn.SoftMarginCriterion')

--- a/test.lua
+++ b/test.lua
@@ -1577,6 +1577,114 @@ function nntest.MSECriterion()
    criterionJacobianTest(cri, input, target)
 end
 
+function nntest.SpatialAutoCropMSECriterion()
+   -- Tests the assumptions on input and target dimensions for the
+   -- nn.SpatialAutoCropMSECriterion criterion
+   local function testInputBounds()
+      for _, average in pairs({true, false}) do
+         local sMSE = nn.SpatialAutoCropMSECriterion(average)
+
+         input = torch.Tensor(3, 3, 3)
+         target = torch.Tensor(4, 3, 3)
+         mytester:assertError(function() sMSE:forward(input, target) end,
+                          "Target and input must have same number of channels")
+
+         input = torch.Tensor(2, 4, 3, 3)
+         target = torch.Tensor(2, 3, 3, 3)
+         mytester:assertError(function() sMSE:forward(input, target) end,
+                        "Target and input must have same number of channels")
+
+         input = torch.Tensor(2, 3, 3, 3)
+         target = torch.Tensor(1, 3, 3, 3)
+         mytester:assertError(function() sMSE:forward(input, target) end,
+                         "Target and input must have same batch size")
+
+         input = torch.Tensor(2, 5, 5)
+         target = torch.Tensor(2, 5, 4)
+         mytester:assertError(function() sMSE:forward(input, target) end,
+                         "input resolution must be smaller or equal to the spatial resolution of the target")
+
+         input = torch.Tensor(1, 2, 5, 5)
+         target = torch.Tensor(1, 2, 4, 5)
+         mytester:assertError(function() sMSE:forward(input, target) end,
+                         "input resolution must be smaller or equal to the spatial resolution of the target")
+      end
+   end
+
+   -- Tests that the forward pass of nn.SpatialAutoCropMSECriterion
+   -- is equivalent to the forward pass of nn.MSECriterion with a pre-cropped target
+   function testSpatialAutoCropMSECriterionBatched()
+      for _, average in pairs({true, false}) do
+         local sMSE = nn.SpatialAutoCropMSECriterion(average)
+         local MSE = nn.MSECriterion(average)
+
+         local batchSize = math.random(1,10)
+         local channels = math.random(1,10)
+         local inputHeight = math.random(1, 50)
+         local inputWidth = math.random(1, 50)
+         local targetHeight = inputHeight + math.random(0,5)
+         local targetWidth = inputWidth + math.random(0,5)
+
+         local input = torch.Tensor(batchSize, channels, inputHeight, inputWidth):uniform()
+         local target = torch.Tensor(batchSize, channels, targetHeight, targetWidth):uniform()
+
+         local heightStartIdx = 1 + math.floor((targetHeight - inputHeight)/2.0)
+         local heightEndIdx = heightStartIdx + inputHeight - 1
+         local widthStartIdx = 1 +  math.floor((targetWidth - inputWidth)/2.0)
+         local widthEndIdx = widthStartIdx + inputWidth - 1
+
+         local croppedTarget = target[{{}, {}, {heightStartIdx, heightEndIdx}, {widthStartIdx, widthEndIdx}}]
+
+         local sMSEOut = nn.SpatialAutoCropMSECriterion(average):forward(input, target)
+         local MSEOut = MSE:forward(input, croppedTarget)
+         mytester:asserteq(sMSEOut, MSEOut)
+
+         local gradOutput = torch.Tensor():resizeAs(croppedTarget):uniform()
+         local sMSEGradInput = sMSE:backward(input, gradOutput)
+         local MSEGradInput = MSE:backward(input, gradOutput)
+         mytester:assertTensorEq(sMSEGradInput, MSEGradInput, 1e-7)
+         criterionJacobianTest(sMSE, input, gradOutput)
+      end
+   end
+
+   function testSpatialAutoCropMSECriterionNonBatched()
+      for _, average in pairs({true, false}) do
+         local sMSE = nn.SpatialAutoCropMSECriterion(average)
+         local MSE = nn.MSECriterion(average)
+
+         local channels = math.random(1,10)
+         local inputHeight = math.random(1, 50)
+         local inputWidth = math.random(1, 50)
+         local targetHeight = inputHeight + math.random(0,5)
+         local targetWidth = inputWidth + math.random(0,5)
+
+         local input = torch.Tensor(channels, inputHeight, inputWidth):uniform()
+         local target = torch.Tensor(channels, targetHeight, targetWidth):uniform()
+
+         local heightStartIdx = 1 + math.floor((targetHeight - inputHeight)/2.0)
+         local heightEndIdx = heightStartIdx + inputHeight - 1
+         local widthStartIdx = 1 +  math.floor((targetWidth - inputWidth)/2.0)
+         local widthEndIdx = widthStartIdx + inputWidth - 1
+
+         local croppedTarget = target[{{}, {heightStartIdx, heightEndIdx}, {widthStartIdx, widthEndIdx}}]
+
+         local sMSEOut = nn.SpatialAutoCropMSECriterion(average):forward(input, target)
+         local MSEOut = MSE:forward(input, croppedTarget)
+         mytester:asserteq(sMSEOut, MSEOut)
+
+         local gradOutput = torch.Tensor():resizeAs(croppedTarget):uniform()
+         local sMSEGradInput = sMSE:backward(input, gradOutput)
+         local MSEGradInput = MSE:backward(input, gradOutput)
+         mytester:assertTensorEq(sMSEGradInput, MSEGradInput, 1e-7)
+         criterionJacobianTest(sMSE, input, gradOutput)
+      end
+   end
+
+   testInputBounds()
+   testSpatialAutoCropMSECriterionBatched()
+   testSpatialAutoCropMSECriterionNonBatched()
+end
+
 function nntest.ClassSimplexCriterion()
    local nClasses = torch.random(3,15)
    local input = torch.rand(nClasses)


### PR DESCRIPTION
Added the `SpatialAutoCropMSECriterion` which performs MSECriterion even if the input has a smaller spatial resolution than the target. This is achieved by cropping the target to the same size as the input tensor.

This is useful for image regression tasks, such as super resolution in which non-padded convolutions reduce the output resolution from your network. This layer allows you to still perform MSE with the center of the target image