### PR TITLE
Avoid function serialization when sharing parameters

### DIFF
--- a/Bilinear.lua
+++ b/Bilinear.lua
@@ -142,8 +142,10 @@ function Bilinear:accGradParameters(input, gradOutput, scale)
    if self.bias then self.gradBias:add(scale, gradOutput:sum(1)) end
 end
 
--- we do not need to accumulate parameters when sharing:
-Bilinear.sharedAccUpdateGradParameters = Bilinear.accUpdateGradParameters
+function Bilinear:sharedAccUpdateGradParameters(input, gradOutput, lr)
+   -- we do not need to accumulate parameters when sharing:
+   self:defaultAccUpdateGradParameters(input, gradOutput, lr)
+end
 
 function Bilinear:__tostring__()
   return torch.type(self) ..

--- a/Linear.lua
+++ b/Linear.lua
@@ -105,8 +105,10 @@ function Linear:accGradParameters(input, gradOutput, scale)
    end
 end
 
--- we do not need to accumulate parameters when sharing
-Linear.sharedAccUpdateGradParameters = Linear.accUpdateGradParameters
+function Linear:sharedAccUpdateGradParameters(input, gradOutput, lr)
+   -- we do not need to accumulate parameters when sharing:
+   self:defaultAccUpdateGradParameters(input, gradOutput, lr)
+end
 
 function Linear:clearState()
    if self.addBuffer then self.addBuffer:set() end

--- a/LookupTable.lua
+++ b/LookupTable.lua
@@ -160,5 +160,7 @@ function LookupTable:clearState()
    return parent.clearState(self)
 end
 
--- we do not need to accumulate parameters when sharing
-LookupTable.sharedAccUpdateGradParameters = LookupTable.accUpdateGradParameters
+function LookupTable:sharedAccUpdateGradParameters(input, gradOutput, lr)
+   -- we do not need to accumulate parameters when sharing:
+   self:defaultAccUpdateGradParameters(input, gradOutput, lr)
+end

--- a/Module.lua
+++ b/Module.lua
@@ -50,14 +50,18 @@ function Module:accUpdateGradParameters(input, gradOutput, lr)
    if self.shared then
       self:sharedAccUpdateGradParameters(input, gradOutput, lr)
    else
-      local gradWeight = self.gradWeight
-      local gradBias = self.gradBias
-      self.gradWeight = self.weight
-      self.gradBias = self.bias
-      self:accGradParameters(input, gradOutput, -lr)
-      self.gradWeight = gradWeight
-      self.gradBias = gradBias
+      self:defaultAccUpdateGradParameters(input, gradOutput, lr)
    end
+end
+
+function Module:defaultAccUpdateGradParameters(input, gradOutput, lr)
+   local gradWeight = self.gradWeight
+   local gradBias = self.gradBias
+   self.gradWeight = self.weight
+   self.gradBias = self.bias
+   self:accGradParameters(input, gradOutput, -lr)
+   self.gradWeight = gradWeight
+   self.gradBias = gradBias
 end
 
 function Module:sharedAccUpdateGradParameters(input, gradOutput, lr)

--- a/Module.lua
+++ b/Module.lua
@@ -47,13 +47,17 @@ function Module:accGradParameters(input, gradOutput, scale)
 end
 
 function Module:accUpdateGradParameters(input, gradOutput, lr)
-   local gradWeight = self.gradWeight
-   local gradBias = self.gradBias
-   self.gradWeight = self.weight
-   self.gradBias = self.bias
-   self:accGradParameters(input, gradOutput, -lr)
-   self.gradWeight = gradWeight
-   self.gradBias = gradBias
+   if self.shared then
+      self:sharedAccUpdateGradParameters(input, gradOutput, lr)
+   else
+      local gradWeight = self.gradWeight
+      local gradBias = self.gradBias
+      self.gradWeight = self.weight
+      self.gradBias = self.bias
+      self:accGradParameters(input, gradOutput, -lr)
+      self.gradWeight = gradWeight
+      self.gradBias = gradBias
+   end
 end
 
 function Module:sharedAccUpdateGradParameters(input, gradOutput, lr)
@@ -95,8 +99,8 @@ function Module:share(mlp, ...)
    for i,v in ipairs(arg) do
       if self[v] ~= nil then
          self[v]:set(mlp[v])
-         self.accUpdateGradParameters = self.sharedAccUpdateGradParameters
-         mlp.accUpdateGradParameters = mlp.sharedAccUpdateGradParameters
+         self.shared = true
+         mlp.shared = true
       end
    end
    return self

--- a/PartialLinear.lua
+++ b/PartialLinear.lua
@@ -102,9 +102,10 @@ function PartialLinear:updateParameters(learningRate)
    self.bias:add(-learningRate, self.gradBias)
 end
 
--- we do not need to accumulate parameters when sharing
-PartialLinear.sharedAccUpdateGradParameters =
-   PartialLinear.accUpdateGradParameters
+function PartialLinear:sharedAccUpdateGradParameters(input, gradOutput, lr)
+   -- we do not need to accumulate parameters when sharing:
+   self:defaultAccUpdateGradParameters(input, gradOutput, lr)
+end
 
 function PartialLinear:__tostring__()
    return torch.type(self) ..

--- a/TemporalConvolution.lua
+++ b/TemporalConvolution.lua
@@ -67,5 +67,7 @@ function TemporalConvolution:accGradParameters(input, gradOutput, scale)
    )
 end
 
--- we do not need to accumulate parameters when sharing
-TemporalConvolution.sharedAccUpdateGradParameters = TemporalConvolution.accUpdateGradParameters
+function TemporalConvolution:sharedAccUpdateGradParameters(input, gradOutput, lr)
+   -- we do not need to accumulate parameters when sharing:
+   self:defaultAccUpdateGradParameters(input, gradOutput, lr)
+end

--- a/test/LinearTHNN.lua
+++ b/test/LinearTHNN.lua
@@ -79,8 +79,10 @@ function LinearTHNN:accGradParameters(input, gradOutput, scale)
    return self.gradWeight
 end
 
--- we do not need to accumulate parameters when sharing
-LinearTHNN.sharedAccUpdateGradParameters = LinearTHNN.accUpdateGradParameters
+function LinearTHNN:sharedAccUpdateGradParameters(input, gradOutput, lr)
+   -- we do not need to accumulate parameters when sharing:
+   self:defaultAccUpdateGradParameters(input, gradOutput, lr)
+end
 
 function LinearTHNN:clearState()
    if self.addBuffer then self.addBuffer:set() end


### PR DESCRIPTION
Overwriting the `accUpdateGradParameters` field exposed the function to serialization and made the saved object incompatible with other Lua versions.

This could be avoided with a simple conditional branching to call the shared version of this function.