### PR TITLE
Preserve old behavior of setting nll.sizeAverage in CrossEntropyCriterion.

### DIFF
--- a/CrossEntropyCriterion.lua
+++ b/CrossEntropyCriterion.lua
@@ -5,15 +5,21 @@ function CrossEntropyCriterion:__init(weights, sizeAverage)
    self.lsm = nn.LogSoftMax()
    self.nll = nn.ClassNLLCriterion(weights, sizeAverage)
    self.sizeAverage = self.nll.sizeAverage
+   self.oldSizeAverage = self.sizeAverage
 end
 
 function CrossEntropyCriterion:updateOutput(input, target)
    input = input:squeeze()
    target = type(target) == 'number' and target or target:squeeze()
-   self.nll.sizeAverage = self.sizeAverage
+   -- only propagate if value has changed to preserve old behavior
+   -- of setting nll.sizeAverage directly
+   if self.sizeAverage ~= self.oldSizeAverage then
+      self.nll.sizeAverage = self.sizeAverage
+   end
    self.lsm:updateOutput(input)
    self.nll:updateOutput(self.lsm.output, target)
    self.output = self.nll.output
+   self.oldSizeAverage = self.sizeAverage
    return self.output
 end
 
@@ -21,10 +27,15 @@ function CrossEntropyCriterion:updateGradInput(input, target)
    local size = input:size()
    input = input:squeeze()
    target = type(target) == 'number' and target or target:squeeze()
-   self.nll.sizeAverage = self.sizeAverage
+   -- only propagate if  value has changed to preserve old behavior
+   -- of setting nll.sizeAverage directly
+   if self.sizeAverage ~= self.oldSizeAverage then
+      self.nll.sizeAverage = self.sizeAverage
+   end
    self.nll:updateGradInput(self.lsm.output, target)
    self.lsm:updateGradInput(input, self.nll.gradInput)
    self.gradInput:view(self.lsm.gradInput, size)
+   self.oldSizeAverage = self.sizeAverage
    return self.gradInput
 end
 

--- a/test.lua
+++ b/test.lua
@@ -2116,6 +2116,20 @@ function nntest.CrossEntropyCriterion()
    weights = weights / weights:sum()
    cri = nn.CrossEntropyCriterion(weights)
    criterionJacobianTest(cri, input, target)
+
+   -- verify nll.sizeAverage preservation
+   cri = nn.CrossEntropyCriterion(weights)
+   cri.nll.sizeAverage = false
+   criterionJacobianTest(cri, input, target)
+   mytester:eq(cri.nll.sizeAverage, false,
+      "ClassNLLCriterion.sizeAverage overwritten")
+
+   -- verify nll.sizeAverage propagation
+   cri = nn.CrossEntropyCriterion(weights)
+   cri.sizeAverage = false
+   criterionJacobianTest(cri, input, target)
+   mytester:eq(cri.nll.sizeAverage, false,
+      "ClassNLLCriterion.sizeAverage not propagated")
 end
 
 function nntest.LogSigmoid()


### PR DESCRIPTION
Old behavior to get sizeAverage == false was:
local cri = nn.CrossEntropyCriterion(weights)
cri.nll.sizeAverage = false
which no longer works as nll.sizeAverage is overwritten.  Only overwriting when the value has actually changed preserves the old behavior.