### PR TITLE
Add squeeze option to nn.Sum

### DIFF
--- a/Sum.lua
+++ b/Sum.lua
@@ -1,11 +1,17 @@
 local Sum, parent = torch.class('nn.Sum', 'nn.Module')
 
-function Sum:__init(dimension, nInputDims, sizeAverage)
+function Sum:__init(dimension, nInputDims, sizeAverage, squeeze)
    parent.__init(self)
    self.dimension   = dimension or 1
    -- do not assign default value to nInputDims or it will break backward compatibility
    self.nInputDims  = nInputDims
    self.sizeAverage = sizeAverage or false
+   if squeeze ~= nil then
+      assert(type(squeeze) == 'boolean', 'squeeze has to be true/false')
+      self.squeeze = squeeze
+   else
+      self.squeeze = true
+   end
 end
 
 function Sum:_getPositiveDimension(input)
@@ -28,7 +34,7 @@ function Sum:updateOutput(input)
     if self.sizeAverage then
         self.output:div(input:size(dimension))
     end
-    if self.output:nDimension() > 1 then
+    if self.squeeze and self.output:nDimension() > 1 then
         self.output:set(self.output:select(dimension, 1))
     end
     return self.output

--- a/Sum.lua
+++ b/Sum.lua
@@ -15,53 +15,53 @@ function Sum:__init(dimension, nInputDims, sizeAverage, squeeze)
 end
 
 function Sum:_getPositiveDimension(input)
-    local dimension = self.dimension
-    if dimension < 0 then
-        dimension = input:dim() + dimension + 1
-    elseif self.nInputDims and input:dim()==(self.nInputDims+1) then
-        dimension = dimension + 1
-    end
-    assert(input:dim() >= dimension, "dimension exceeds input dimensions")
-    return dimension
+   local dimension = self.dimension
+   if dimension < 0 then
+      dimension = input:dim() + dimension + 1
+   elseif self.nInputDims and input:dim()==(self.nInputDims+1) then
+      dimension = dimension + 1
+   end
+   assert(input:dim() >= dimension, "dimension exceeds input dimensions")
+   return dimension
 end
 
 function Sum:updateOutput(input)
-    local dimension = self:_getPositiveDimension(input)
-    if type(self.output) == 'number' then
-        self.output = input.new()
-    end
-    self.output:sum(input, dimension)
-    if self.sizeAverage then
-        self.output:div(input:size(dimension))
-    end
-    if self.squeeze and self.output:nDimension() > 1 then
-        self.output:set(self.output:select(dimension, 1))
-    end
-    return self.output
+   local dimension = self:_getPositiveDimension(input)
+   if type(self.output) == 'number' then
+      self.output = input.new()
+   end
+   self.output:sum(input, dimension)
+   if self.sizeAverage then
+      self.output:div(input:size(dimension))
+   end
+   if self.squeeze and self.output:nDimension() > 1 then
+      self.output:set(self.output:select(dimension, 1))
+   end
+   return self.output
 end
 
 function Sum:updateGradInput(input, gradOutput)
-    local dimension = self:_getPositiveDimension(input)
-    -- zero-strides don't work with MKL/BLAS, so
-    -- don't set self.gradInput to zero-stride tensor.
-    -- Instead, do a deepcopy
-    local size      = input:size()
-    size[dimension] = 1
-    if not gradOutput:isContiguous() then
-        self._gradOutput = self._gradOutput or gradOutput.new()
-        self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
-        gradOutput = self._gradOutput
-    end
-    gradOutput      = gradOutput:view(size)
-    self.gradInput:resizeAs(input)
-    self.gradInput:copy(gradOutput:expandAs(input))
-    if self.sizeAverage then
-        self.gradInput:div(input:size(dimension))
-    end
-    return self.gradInput
+   local dimension = self:_getPositiveDimension(input)
+   -- zero-strides don't work with MKL/BLAS, so
+   -- don't set self.gradInput to zero-stride tensor.
+   -- Instead, do a deepcopy
+   local size      = input:size()
+   size[dimension] = 1
+   if not gradOutput:isContiguous() then
+      self._gradOutput = self._gradOutput or gradOutput.new()
+      self._gradOutput:resizeAs(gradOutput):copy(gradOutput)
+      gradOutput = self._gradOutput
+   end
+   gradOutput      = gradOutput:view(size)
+   self.gradInput:resizeAs(input)
+   self.gradInput:copy(gradOutput:expandAs(input))
+   if self.sizeAverage then
+      self.gradInput:div(input:size(dimension))
+   end
+   return self.gradInput
 end
 
 function Sum:clearState()
-    nn.utils.clear(self, '_gradOutput')
-    return parent.clearState(self)
+   nn.utils.clear(self, '_gradOutput')
+   return parent.clearState(self)
 end

--- a/doc/simple.md
+++ b/doc/simple.md
@@ -556,11 +556,11 @@ This module is based on [nn.Sum](#nn.Sum).
 ## Sum ##
 
 ```lua
-module = nn.Sum(dimension, nInputDim, sizeAverage)
+module = nn.Sum(dimension, nInputDim, sizeAverage, squeeze)
 ```
 
 Applies a sum operation over dimension `dimension`.
-Hence, if an `nxpxq` Tensor was given as input, and `dimension` = `2` then an `nxq` matrix would be output.
+Hence, if an `nxpxq` Tensor was given as input, and `dimension` = `2` then an `nxq` matrix would be output. If argument `squeeze` is set to `false` then the output would be of size `nx1xq`.
 When `nInputDim` is provided , inputs larger than that value will be considered batches where the actual `dimension` to apply the sum operation will be dimension `dimension + 1`.
 Negative indexing is allowed by providing a negative value to `nInputDim`.
 When `sizeAverage` is provided, the sum is divided by the size of the input in this `dimension`. This is equivalent to the mean operation performed by the [nn.Mean](#nn.Mean) module.

--- a/test.lua
+++ b/test.lua
@@ -4084,6 +4084,32 @@ function nntest.Sum()
    local err       = jac.testJacobian(module, input)
    mytester:assertlt(err,precision, 'error on state ')
 
+   -- squeeze
+   local dimension = 1
+   local module    = nn.Sum(dimension, nil, nil, false)
+   local input     = torch.Tensor({{1, 2, 3},{4, 5, 6}})
+   local expected  = torch.Tensor({5, 7, 9}):view(1, 3)
+   local output    = module:forward(input)
+   
+   mytester:assertlt(torch.norm(output-expected), precision, 'error on forward ')
+   mytester:assert(output:isSameSizeAs(expected), 'sizes mismatch')
+   
+   local err       = jac.testJacobian(module, input)
+   mytester:assertlt(err,precision, 'error on state ')
+
+   -- squeeze + batch
+   local dimension = 1
+   local module    = nn.Sum(dimension, 1, nil, false)
+   local input     = torch.Tensor({{1, 2, 3},{4, 5, 6}})
+   local expected  = torch.Tensor({6, 15}):view(2, 1)
+   local output    = module:forward(input)
+
+   mytester:assertlt(torch.norm(output-expected), precision, 'error on forward ')
+   mytester:assert(output:isSameSizeAs(expected), 'sizes mismatch')
+
+   local err       = jac.testJacobian(module, input)
+   mytester:assertlt(err,precision, 'error on state ')
+
    -- 3D
    local ini = math.random(3,5)
    local inj = math.random(3,5)


### PR DESCRIPTION
It is sometimes inconvenient, that nn.Sum squeezes the dimension it sums over while torch.sum does not. This adds additional option to make nn.Sum not squeeze the output tensor. Squeezed as before by default for compatibility.