### PR TITLE
Support index parameters with Cuda*Tensor.

### DIFF
--- a/Max.lua
+++ b/Max.lua
@@ -21,7 +21,7 @@ end
 function Max:_lazyInit()
    self._output = self._output or self.output.new()
    if not self._indices then
-      if torch.type(self.output) == 'torch.CudaTensor' then
+      if torch.typename(self.output):find('torch%.Cuda.*Tensor') then
          self._indices = torch.CudaLongTensor and torch.CudaLongTensor() or torch.CudaTensor()
       else
          self._indices = torch.LongTensor()

--- a/Min.lua
+++ b/Min.lua
@@ -21,7 +21,7 @@ end
 function Min:_lazyInit()
    self._output = self._output or self.output.new()
    if not self._indices then
-      if torch.type(self.output) == 'torch.CudaTensor' then
+      if torch.typename(self.output):find('torch%.Cuda.*Tensor') then
          self._indices = torch.CudaLongTensor and torch.CudaLongTensor() or torch.CudaTensor()
       else
          self._indices = torch.LongTensor()

--- a/Normalize.lua
+++ b/Normalize.lua
@@ -24,7 +24,7 @@ function Normalize:updateOutput(input)
   if self.p == math.huge then
     -- specialization for the infinity norm
     if not self._indices then
-      if torch.type(self.output) == 'torch.CudaTensor' then
+      if torch.typename(self.output):find('torch%.Cuda.*Tensor') then
         self._indices = torch.CudaLongTensor and torch.CudaLongTensor() or torch.CudaTensor()
       else
         self._indices = torch.LongTensor()


### PR DESCRIPTION
These modules check the type explicitly for CudaTensor
rather than the regular expression.  There are other
modules that have this identical check, but do operations
on the resulting type which may or may not be supported
(i.e. require more checking), so I didn't change them.
These should be safe because the index type is independent
of the type being checking.