### PR TITLE
Support Tensor constant

### DIFF
--- a/AddConstant.lua
+++ b/AddConstant.lua
@@ -3,7 +3,7 @@ local AddConstant, parent = torch.class('nn.AddConstant', 'nn.Module')
 function AddConstant:__init(constant_scalar,ip)
    parent.__init(self)
    self.constant_scalar = constant_scalar
-   if type(self.constant_scalar) == 'userdata' then
+   if torch.isTensor(self.constant_scalar) then
       self.tmp = constant_scalar.new()
    end
 

--- a/AddConstant.lua
+++ b/AddConstant.lua
@@ -1,10 +1,12 @@
 local AddConstant, parent = torch.class('nn.AddConstant', 'nn.Module')
 
 function AddConstant:__init(constant_scalar,ip)
-  parent.__init(self)
-  assert(type(constant_scalar) == 'number', 'input is not scalar!')
-  self.constant_scalar = constant_scalar
-  
+   parent.__init(self)
+   self.constant_scalar = constant_scalar
+   if type(self.constant_scalar) == 'userdata' then
+      self.tmp = torch.Tensor()
+   end
+
   -- default for inplace is false
    self.inplace = ip or false
    if (ip and type(ip) ~= 'boolean') then
@@ -13,25 +15,37 @@ function AddConstant:__init(constant_scalar,ip)
 end
 
 function AddConstant:updateOutput(input)
-  if self.inplace then
-    input:add(self.constant_scalar)
-    self.output:set(input)
-  else
-    self.output:resizeAs(input)
-    self.output:copy(input)
-    self.output:add(self.constant_scalar)
-  end
-  return self.output
-end 
+   assert(type(self.constant_scalar) == 'number' or
+      (type(self.constant_scalar) == 'userdata' and input:nDimension() <= 2 and
+      input:size(input:nDimension()) == self.constant_scalar:size(1)),
+      'input is not scalar or doesn\'t match with the dimension of constant!')
+   if type(self.constant_scalar) == 'userdata' and input:nDimension() == 2 then
+      local nOutput = self.constant_scalar:size(1)
+      self.tmp:resize(1,nOutput)
+      self.tmp:copy(self.constant_scalar)
+      self.tmp = self.tmp:expand(input:size(1),nOutput)
+   else
+      self.tmp = self.constant_scalar
+   end
+   if self.inplace then
+      input:add(self.tmp)
+      self.output:set(input)
+   else
+      self.output:resizeAs(input)
+      self.output:copy(input)
+      self.output:add(self.tmp)
+   end
+   return self.output
+end
 
 function AddConstant:updateGradInput(input, gradOutput)
-  if self.inplace then
-    self.gradInput:set(gradOutput)
-    -- restore previous input value
-    input:add(-self.constant_scalar)
-  else
-    self.gradInput:resizeAs(gradOutput)
-    self.gradInput:copy(gradOutput)
-  end
-  return self.gradInput
+   if self.inplace then
+      self.gradInput:set(gradOutput)
+      -- restore previous input value
+      input:add(-self.constant_scalar)
+   else
+      self.gradInput:resizeAs(gradOutput)
+      self.gradInput:copy(gradOutput)
+   end
+   return self.gradInput
 end

--- a/AddConstant.lua
+++ b/AddConstant.lua
@@ -4,7 +4,7 @@ function AddConstant:__init(constant_scalar,ip)
    parent.__init(self)
    self.constant_scalar = constant_scalar
    if type(self.constant_scalar) == 'userdata' then
-      self.tmp = torch.Tensor()
+      self.tmp = constant_scalar.new()
    end
 
   -- default for inplace is false
@@ -16,7 +16,7 @@ end
 
 function AddConstant:updateOutput(input)
    assert(type(self.constant_scalar) == 'number' or
-      (type(self.constant_scalar) == 'userdata' and input:nDimension() <= 2 and
+      (torch.isTensor(self.constant_scalar) and input:nDimension() <= 2 and
       input:size(input:nDimension()) == self.constant_scalar:size(1)),
       'input is not scalar or doesn\'t match with the dimension of constant!')
    if type(self.constant_scalar) == 'userdata' and input:nDimension() == 2 then

--- a/test.lua
+++ b/test.lua
@@ -5585,6 +5585,15 @@ function nntest.AddConstant()
   local err = (input1-input2):abs():max()
   mytester:asserteq(err, 0, torch.typename(module1) ..
                           ' - inplace input change err ')
+
+  local module3 = nn.AddConstant(torch.Tensor{1,2,3})
+  local out3 = module3:forward(torch.Tensor{-1,-2,-3})
+  mytester:asserteq(0, out3:abs():max(), torch.typename(module3) ..
+                      ' - tensor constant forward err ')
+  local module4 = nn.AddConstant(torch.Tensor{1,2,3})
+  local out4 = module3:forward(torch.Tensor{{-1,-2,-3},{-1,-2,-3}})
+  mytester:asserteq(0, out4:abs():max(), torch.typename(module4) ..
+                      ' - batch tensor constant forward err ') 
 end
 
 function nntest.MulConstant()


### PR DESCRIPTION
Now, `constant_scalar` in `nn.AddConstant` can be a 1-D tensor. It is useful when a fixed bias is needed. And, polished indents.