### PR TITLE
Remove accreal typedef because it is defined multiple times

### DIFF
--- a/THNN.lua
+++ b/THNN.lua
@@ -55,7 +55,7 @@ local replacements =
 {
    {
       ['TYPE'] = 'Double',
-      ['real'] = 'double',
+      ['accreal'] = 'double',
       ['THTensor'] = 'THDoubleTensor',
       ['THIndexTensor'] = 'THLongTensor',
       ['THIntegerTensor'] = 'THIntTensor',
@@ -64,7 +64,7 @@ local replacements =
    },
    {
       ['TYPE'] = 'Float',
-      ['real'] = 'float',
+      ['accreal'] = 'double',
       ['THTensor'] = 'THFloatTensor',
       ['THIndexTensor'] = 'THLongTensor',
       ['THIntegerTensor'] = 'THIntTensor',
@@ -72,13 +72,6 @@ local replacements =
       ['THInteger_t'] = 'int'
     }
 }
-
--- gsub(s, 'real', 'float') changes accreal to accfloat.
--- typedef accfloat ahead of time.
-ffi.cdef("typedef double accfloat;")
--- gsub(s, 'real', 'double') changes accreal to accfloat.
--- typedef accdouble ahead of time
-ffi.cdef("typedef double accdouble;")
 
 for i=1,#replacements do
    local r = replacements[i]


### PR DESCRIPTION
when THCUNN is loaded.

Both THNN and THCUNN define the accfloat/accdouble typedef via ffi.  The behavior of this seems to be lua version/luajit version dependent (saw test failures with luajit) and it's probably a good idea to get rid of it (as C doesn't let you redefine a typedef in any case).

Since we no longer support 'real' in the header declaration, it makes sense to just define the gsub on accreal; if we want to add back real support we'll have to do something more complicated.