### PR TITLE
MixtureTable - variable length bugfix

### DIFF
--- a/MixtureTable.lua
+++ b/MixtureTable.lua
@@ -84,6 +84,13 @@ function MixtureTable:updateGradInput(input, gradOutput)
       end
       gaterGradInput:resizeAs(gaterInput)
       
+      -- Clear invalid gradients
+      if #expertGradInputs > #expertInputs then 
+         for i=#expertInputs+1, #expertGradInputs do
+            expertGradInputs[i] = nil
+         end
+      end
+      
       -- like CMulTable, but with broadcasting
       for i,expertGradInput in ipairs(expertGradInputs) do
          -- gater updateGradInput


### PR DESCRIPTION
If batch size between two successive inputs of variable lengths was the same, self.size was not recomputed. I removed all batch size checks to make sure self.size is recomputed every time.