### PR TITLE
Bottle handling gradInput = nil

### DIFF
--- a/Bottle.lua
+++ b/Bottle.lua
@@ -49,9 +49,17 @@ function Bottle:updateGradInput(input, gradOutput)
       local input_ = input:view(unpack(self.inShape:totable()))
       local gradOutput_ = gradOutput:view(unpack(self.outShape:totable()))
       self.modules[1]:updateGradInput(input_, gradOutput_)
-      self.gradInput:set(self.modules[1].gradInput:viewAs(input))
+      if self.modules[1].gradInput then
+         self.gradInput:set(self.modules[1].gradInput:viewAs(input))
+      else
+         self.gradInput = nil
+      end
    else
-      self.gradInput:set(self.modules[1]:updateGradInput(input))
+      if self.modules[1].gradInput then
+         self.gradInput:set(self.modules[1]:updateGradInput(input))
+      else
+         self.gradInput = nil
+      end
    end
    return self.gradInput
 end


### PR DESCRIPTION
gradInput is sometimes nil for saving computation (like [this](https://github.com/facebook/fb.resnet.torch/blob/master/models/resnet.lua#L202)). This PR handles this case to avoid error in Bottle. 