### PR TITLE
Allow SelectTable to accept non-tensor table content.

### DIFF
--- a/SelectTable.lua
+++ b/SelectTable.lua
@@ -24,13 +24,15 @@ local function zeroTableCopy(t1, t2)
    for k, v in pairs(t2) do
       if (torch.type(v) == "table") then
          t1[k] = zeroTableCopy(t1[k] or {}, t2[k])
-      else
+      elseif torch.isTensor(v) then
          if not t1[k] then
             t1[k] = v:clone():zero()
          else
             t1[k]:resizeAs(v)
             t1[k]:zero()
          end
+      else
+        t1[k] = nil
       end
    end
    for k, v in pairs(t1) do


### PR DESCRIPTION
At present, SelectTable assumes that the tables will contain only tensors. Sometimes it is convenient in NLP work to pass around tables that some tensors and some other other data, such as strings. This fix allows for that, albeit with the caveat that those components of the table will not back-progagate gradients. 