### PR TITLE
MapTable: 'zeroGradParameters' and 'updateParameters' bugfix

### DIFF
--- a/MapTable.lua
+++ b/MapTable.lua
@@ -16,7 +16,7 @@ function MapTable:_extend(n)
          if shared then
            self.modules[i] = self.module:clone(table.unpack(self.sharedparams))
          else
-           self.modules[i] = self.module:clone(table.unpack(self.sharedparams))
+           self.modules[i] = self.module:clone()
          end
       end
    end

--- a/MapTable.lua
+++ b/MapTable.lua
@@ -2,7 +2,7 @@ local MapTable, parent = torch.class('nn.MapTable', 'nn.Container')
 
 function MapTable:__init(module, shared)
    parent.__init(self)
-   self.shared = shared or true
+   if shared ~= nil then self.shared = shared else self.shared = true end
    self.sharedparams = {'weight', 'bias', 'gradWeight', 'gradBias'}
    self.output = {}
    self.gradInput = {}

--- a/MapTable.lua
+++ b/MapTable.lua
@@ -2,7 +2,8 @@ local MapTable, parent = torch.class('nn.MapTable', 'nn.Container')
 
 function MapTable:__init(module, shared)
    parent.__init(self)
-   self.shared = shared or {'weight', 'bias', 'gradWeight', 'gradBias'}
+   self.shared = shared or true
+   self.sharedparams = {'weight', 'bias', 'gradWeight', 'gradBias'}
    self.output = {}
    self.gradInput = {}
    self:add(module)
@@ -12,7 +13,11 @@ function MapTable:_extend(n)
    self.modules[1] = self.module
    for i = 2, n do
       if not self.modules[i] then
-         self.modules[i] = self.module:clone(table.unpack(self.shared))
+         if shared then
+           self.modules[i] = self.module:clone(table.unpack(self.sharedparams))
+         else
+           self.modules[i] = self.module:clone(table.unpack(self.sharedparams))
+         end
       end
    end
 end

--- a/MapTable.lua
+++ b/MapTable.lua
@@ -75,13 +75,21 @@ end
 
 function MapTable:zeroGradParameters()
     if self.module then
-        self.module:zeroGradParameters()
+        if self.shared then
+          self.module:zeroGradParameters()
+        else
+          parent.zeroGradParameters(self)
+        end
     end
 end
 
 function MapTable:updateParameters(learningRate)
     if self.module then
-        self.module:updateParameters(learningRate)
+        if self.shared then
+          self.module:updateParameters(learningRate)
+        else
+          parent.updateParameters(self, learningRate)
+        end
     end
 end
 

--- a/MapTable.lua
+++ b/MapTable.lua
@@ -2,7 +2,7 @@ local MapTable, parent = torch.class('nn.MapTable', 'nn.Container')
 
 function MapTable:__init(module, shared)
    parent.__init(self)
-   if shared ~= nil then self.shared = shared else self.shared = true end
+   self.shared = (shared == nil) and true or shared
    self.sharedparams = {'weight', 'bias', 'gradWeight', 'gradBias'}
    self.output = {}
    self.gradInput = {}

--- a/MapTable.lua
+++ b/MapTable.lua
@@ -13,7 +13,7 @@ function MapTable:_extend(n)
    self.modules[1] = self.module
    for i = 2, n do
       if not self.modules[i] then
-         if shared then
+         if self.shared then
            self.modules[i] = self.module:clone(table.unpack(self.sharedparams))
          else
            self.modules[i] = self.module:clone()

--- a/doc/table.md
+++ b/doc/table.md
@@ -177,7 +177,7 @@ module = nn.MapTable(m, share)
 
 `MapTable` is a container for a single module which will be applied to all input elements. The member module is cloned as necessary to process all input elements. Call `resize(n)` to set the number of clones manually or call `clearState()` to discard all clones.
 
-Optionally, the module can be initialized with the contained module and with a list of parameters that are shared across all clones. By default, these parameters are `weight`, `bias`, `gradWeight` and `gradBias`.
+Optionally, the module can be initialized with the contained module and a boolean `share`. It indicates whether parameters are shared across all clones or not. By default it is set to true. The shared parameters are `weight`, `bias`, `gradWeight` and `gradBias`.
 
 ```
 +----------+         +-----------+

--- a/test.lua
+++ b/test.lua
@@ -6646,6 +6646,24 @@ function nntest.MapTable()
       == torch.pointer(map:get(1).weight:storage()))
    map:clearState()
    mytester:assert(map:size() == 1)
+
+  -- check if gradients are correctly reset
+  -- share weights and gradients
+  map = nn.MapTable(nn.Linear(10,5))
+  map:forward(input)
+  _, gradParams = map:getParameters()
+  gradParams:uniform()
+  map:zeroGradParameters()
+  mytester:assertlt(gradParams:sum(),precision)
+
+  -- check if gradients are correctly reset
+  -- do not share weights and gradients
+  map = nn.MapTable(nn.Linear(10,5),false)
+  map:forward(input)
+  _, gradParams = map:getParameters()
+  gradParams:uniform()
+  map:zeroGradParameters()
+  mytester:assertlt(gradParams:sum(),precision)
 end
 
 function nntest.FlattenTable()


### PR DESCRIPTION
These two commits fix a bug in MapTable layer. 
zeroGradParameters only works when parameters are shared among layers. If they are not shared, the call to module:zeroGradParameters() is effective only on the first module. Instead, by calling the parent function, it is effective on the whole set of modules. The same applies for updateParameters.
Since managing a list of shared/not shared parameters is tricky and involves more lines of code, I opted for the simplest solution: a boolean variable that indicates if the whole set of parameters is shared or not. The default behavior remains the same as before. 

