### PR TITLE
Fixed signs for MultiMarginCriterion

### DIFF
--- a/doc/criterion.md
+++ b/doc/criterion.md
@@ -419,7 +419,7 @@ Optionally, you can give non-equal weighting on the classes by passing a 1D `wei
 The loss function then becomes:
 
 ```lua
-loss(x, y) = sum_i(max(0, w[y] * (margin - x[y] - x[i]))^p) / x:size(1)
+loss(x, y) = sum_i(max(0, w[y] * (margin - x[y] + x[i]))^p) / x:size(1)
 ```
 
 This criterion is especially useful for classification when used in conjunction with a module ending in the following output layer:


### PR DESCRIPTION
The loss for `MultiMarginCriterion` with weights (line 422) was `(margin - x[y] - x[i])` instead of `(margin - x[y] + x[i])`. Changed the sign before x[i] to `+`.