### PR TITLE
Added sharedparams default values in MapTable so that it is backwards…

### DIFF
--- a/MapTable.lua
+++ b/MapTable.lua
@@ -10,6 +10,7 @@ function MapTable:__init(module, shared)
 end
 
 function MapTable:_extend(n)
+   self.sharedparams = self.sharedparams or {'weight', 'bias', 'gradWeight', 'gradBias'}
    self.modules[1] = self.module
    for i = 2, n do
       if not self.modules[i] then


### PR DESCRIPTION
Models Serialized before commit `179133fb499483555074eaff2ea875e975508df1` no longer work as the `sharedparams` is null. 
This pull requests makes MapTable compatible with already serialized models.