### PR TITLE
Revert "Revert "ClassNLLCriterion supports missing targets""

### DIFF
--- a/ClassNLLCriterion.lua
+++ b/ClassNLLCriterion.lua
@@ -1,13 +1,10 @@
 local THNN = require 'nn.THNN'
 local ClassNLLCriterion, parent = torch.class('nn.ClassNLLCriterion', 'nn.Criterion')
 
-function ClassNLLCriterion:__init(weights, sizeAverage)
+function ClassNLLCriterion:__init(weights, sizeAverage, ignoreIndex)
     parent.__init(self)
-    if sizeAverage ~= nil then
-       self.sizeAverage = sizeAverage
-    else
-       self.sizeAverage = true
-    end
+    self.sizeAverage = (sizeAverage == nil) and true or sizeAverage
+    self.ignoreIndex = ignoreIndex or -100 -- this target index will be ignored
     if weights then
        assert(weights:dim() == 1, "weights input should be 1-D Tensor")
        self.weights = weights
@@ -47,7 +44,8 @@ function ClassNLLCriterion:updateOutput(input, target)
       self.output_tensor:cdata(),
       self.sizeAverage,
       THNN.optionalTensor(self.weights),
-      self.total_weight_tensor:cdata()
+      self.total_weight_tensor:cdata(),
+      self.ignoreIndex
    )
    self.output = self.output_tensor[1]
    return self.output, self.total_weight_tensor[1]
@@ -76,7 +74,8 @@ function ClassNLLCriterion:updateGradInput(input, target)
       self.gradInput:cdata(),
       self.sizeAverage,
       THNN.optionalTensor(self.weights),
-      self.total_weight_tensor:cdata()
+      self.total_weight_tensor:cdata(),
+      self.ignoreIndex
    )
 
    return self.gradInput

--- a/doc/criterion.md
+++ b/doc/criterion.md
@@ -95,10 +95,10 @@ criterion.sizeAverage = false
 ## ClassNLLCriterion ##
 
 ```lua
-criterion = nn.ClassNLLCriterion([weights])
+criterion = nn.ClassNLLCriterion([weights, sizeAverage, ignoreIndex])
 ```
 
-The negative log likelihood criterion. It is useful to train a classification problem with `n` classes.
+The negative log likelihood (NLL) criterion. It is useful to train a classification problem with `n` classes.
 If provided, the optional argument `weights` should be a 1D `Tensor` assigning weight to each of the classes.
 This is particularly useful when you have an unbalanced training set.
 
@@ -113,11 +113,21 @@ The loss can be described as:
 loss(x, class) = -x[class]
 ```
 
-or in the case of the `weights` argument it is specified as follows:
+or in the case of the `weights` argument, it is specified as follows:
 ```lua
 loss(x, class) = -weights[class] * x[class]
 ```
-Due to the behaviour of the backend code, it is necessary to set sizeAverage to false when calculating losses *in non-batch mode*.
+
+or in the case of the `ignoreIndex` argument:
+```
+loss(x, class) = class != ignoreIndex ? -weights[class] * x[class] : 0
+```
+
+Indeed, the `ignoreIndex` (defaults to -100) specifies a value for targets to be ignored.
+The commensurate `gradInput` for that target will be zero.
+When `sizeAverage=true` (the default), the `gradInput` and `output` are averaged over non-ignored targets.
+
+Due to the behaviour of the backend code, it is necessary to set `sizeAverage` to false when calculating losses *in non-batch mode*.
 
 The following is a code fragment showing how to make a gradient step given an input `x`, a desired output `y` (an integer `1` to `n`, in this case `n = 2` classes), a network `mlp` and a learning rate `learningRate`:
 
@@ -133,7 +143,7 @@ function gradUpdate(mlp, x, y, learningRate)
 end
 ```
 
-By default, the losses are averaged over observations for each minibatch. However, if the field `sizeAverage` is set to `false`, the losses are instead summed for each minibatch.
+By default, the losses are averaged over observations for each minibatch. However, if the argument `sizeAverage` is set to `false`, the losses are instead summed for each minibatch.
 
 
 <a name="nn.CrossEntropyCriterion"></a>
@@ -758,7 +768,7 @@ Sample example
 
    tripleModel = nn.ParallelTable()
    tripleModel:add(embeddingModel)
-   tripleModel:add(embeddingModel:clone('weight', 'bias', 
+   tripleModel:add(embeddingModel:clone('weight', 'bias',
                                         'gradWeight', 'gradBias'))
    tripleModel:add(embeddingModel:clone('weight', 'bias',
                                         'gradWeight', 'gradBias'))

--- a/lib/THNN/generic/THNN.h
+++ b/lib/THNN/generic/THNN.h
@@ -47,7 +47,8 @@ TH_API void THNN_(ClassNLLCriterion_updateOutput)(
           THTensor *output,            // [OUT] a one-element tensor with loss
           bool sizeAverage,            // if true, the loss will be normalized by batch size and class weights
           THTensor *weights,           // [OPTIONAL] class weights
-          THTensor *total_weight);     // [BUFFER]
+          THTensor *total_weight,      // [BUFFER]
+          long ignore_index);          // target index to ignore (loss = 0, gradInput = 0)
 TH_API void THNN_(ClassNLLCriterion_updateGradInput)(
           THNNState *state,            // library's state
           THTensor *input,             // input tensor (1D/2D)
@@ -55,7 +56,8 @@ TH_API void THNN_(ClassNLLCriterion_updateGradInput)(
           THTensor *gradInput,         // [OUT] gradient w.r.t. input
           bool sizeAverage,            // if true, the loss will be normalized by batch size and class weights
           THTensor *weights,           // [OPTIONAL] class weights
-          THTensor *total_weight);     // [BUFFER]
+          THTensor *total_weight,      // [BUFFER]
+          long ignore_index);          // target index to ignore (loss = 0, gradInput = 0)
 
 TH_API void THNN_(SpatialClassNLLCriterion_updateOutput)(
           THNNState *state,            // library's state

--- a/test.lua
+++ b/test.lua
@@ -2333,19 +2333,45 @@ function nntest.DistKLDivCriterion()
 end
 
 function nntest.ClassNLLCriterion()
+   local batchsize = math.random(2,4)
    local numLabels = math.random(5,10)
-   local input = torch.rand(numLabels)
-   local target = math.random(1,numLabels)
 
-   -- default ClassNLLCriterion
-   local cri = nn.ClassNLLCriterion()
-   criterionJacobianTest(cri, input, target)
+   local function testclassnll(input, target)
+      -- default ClassNLLCriterion
+      local cri = nn.ClassNLLCriterion()
+      criterionJacobianTest(cri, input, target)
 
-   -- ClassNLLCriterion with weights
-   local weights = torch.rand(numLabels)
-   weights = weights / weights:sum()
-   cri = nn.ClassNLLCriterion(weights)
-   criterionJacobianTest(cri, input, target)
+      -- ClassNLLCriterion with weights
+      local weights = torch.rand(numLabels)
+      weights = weights / weights:sum()
+      cri = nn.ClassNLLCriterion(weights)
+      criterionJacobianTest(cri, input, target)
+   end
+
+   -- input/target: 1D/number
+   testclassnll(torch.rand(numLabels), math.random(1,numLabels))
+   -- input/target: 1D/1D
+   testclassnll(torch.rand(numLabels), torch.LongTensor(1):random(1, numLabels))
+   -- input/target: 2D/1D
+   testclassnll(torch.rand(batchsize, numLabels), torch.LongTensor(batchsize):random(1,numLabels))
+   -- test ignoreIndex
+   local ignoreIndex = -1
+   local cri = nn.ClassNLLCriterion(nil, nil, ignoreIndex)
+   local input = torch.randn(numLabels)
+   local target = ignoreIndex
+   mytester:assert(cri:forward(input, target) == 0)
+   mytester:assert(cri:backward(input, target):abs():sum() == 0)
+   local input = torch.randn(batchsize, numLabels)
+   local target = torch.LongTensor(batchsize):random(1,numLabels)
+   target[1] = ignoreIndex
+   local output = cri:forward(input, target)
+   local gradInput = cri:backward(input, target):clone()
+   mytester:assert(gradInput[1]:abs():sum() == 0)
+   local input, target = input:sub(2,batchsize), target:sub(2,batchsize)
+   local output2 = cri:forward(input, target)
+   mytester:assert(math.abs(output2 - output) < 0.0000001)
+   local gradInput2 = cri:backward(input, target)
+   mytester:assertTensorEq(gradInput2, gradInput:sub(2,batchsize), 0.0000001)
 end
 
 function nntest.SpatialClassNLLCriterion()


### PR DESCRIPTION
Reverts torch/nn#1217

Now that https://github.com/torch/cunn/pull/468 is implemented, this can be merged back again