### PR TITLE
Fix backward compatibility with serialized nn.Sum modules

### DIFF
--- a/Sum.lua
+++ b/Sum.lua
@@ -34,7 +34,7 @@ function Sum:updateOutput(input)
    if self.sizeAverage then
       self.output:div(input:size(dimension))
    end
-   if self.squeeze and self.output:nDimension() > 1 then
+   if (self.squeeze == nil or self.squeeze) and self.output:nDimension() > 1 then
       self.output:set(self.output:select(dimension, 1))
    end
    return self.output


### PR DESCRIPTION
44a15a1 introduced the `squeeze` option for nn.Sum but did not correctly handle the case of serialized nn.Sum modules in which undefined `self.squeeze` means `self.squeeze = true`.