### PR TITLE
BN supports batchsize=1

### DIFF
--- a/BatchNormalization.lua
+++ b/BatchNormalization.lua
@@ -130,7 +130,7 @@ function BN:updateOutput(input)
       self.running_var:cdata(),
       self.save_mean:cdata(),
       self.save_std:cdata(),
-      self.train,
+      self.train and (input:size(1) > 1), -- don't update running_[var,mean] when batchsize = 1
       self.momentum,
       self.eps)
 
@@ -162,7 +162,7 @@ local function backward(self, input, gradOutput, scale, gradInput, gradWeight, g
       self.running_var:cdata(),
       self.save_mean:cdata(),
       self.save_std:cdata(),
-      self.train,
+      self.train and (input:size(1) > 1), -- don't update running_[var,mean] when batchsize = 1
       scale,
       self.eps)
 

--- a/test.lua
+++ b/test.lua
@@ -7609,9 +7609,9 @@ function nntest.Replicate()
    mytester:assertTensorEq(vOutput2, expected2, precision, 'Wrong tiling of data when replicating batch vector.')
 end
 
-local function testBatchNormalization(moduleName, dim, k)
+local function testBatchNormalization(moduleName, dim, k, batchsize)
    local planes = torch.random(1,k)
-   local size = { torch.random(2, k), planes }
+   local size = { batchsize or torch.random(2, k), planes }
    for i=1,dim do
       table.insert(size, torch.random(1,k))
    end
@@ -7670,6 +7670,7 @@ end
 
 function nntest.BatchNormalization()
    testBatchNormalization('BatchNormalization', 0, 20)
+   testBatchNormalization('BatchNormalization', 0, 20, 1) -- test batchsize=1
 end
 
 function nntest.SpatialBatchNormalization()


### PR DESCRIPTION
This fixes a bug where samples of batchsize 1 would introduce a NaN in BatchNormalization.running_var (see C code where `accreal unbiased_var = sum / (n - 1);`). 
Of course, ideally, we wouldn't need to support a batchsize (that is, n) of 1.
But while iterating a dataset of, say, 101 samples in batch sizes of 10 or less, the last batch will have one sample. This use case break BatchNormalization by introducing a NaN in the running_var.