### PR TITLE
Add clearState in VolumetricFullConvolution.lua

### DIFF
--- a/VolumetricFullConvolution.lua
+++ b/VolumetricFullConvolution.lua
@@ -223,3 +223,8 @@ function VolumetricFullConvolution:__tostring__()
    end
    return s .. ')'
 end
+
+function VolumetricFullConvolution:clearState()
+   nn.utils.clear(self, 'finput', 'fgradInput', '_input', '_gradOutput')
+   return parent.clearState(self)
+end


### PR DESCRIPTION
This adds the clearState method in VolumetricFullConvolution.lua. The code is a copy from SpatialFullConvolution.lua. Also would it be safe to remove the  gradBias,gradWeight buffers? 