### PR TITLE
Only update addBuffer when bias is used

### DIFF
--- a/Linear.lua
+++ b/Linear.lua
@@ -62,9 +62,12 @@ function Linear:updateOutput(input)
       if self.output:nElement() ~= nElement then
          self.output:zero()
       end
-      self:updateAddBuffer(input)
       self.output:addmm(0, self.output, 1, input, self.weight:t())
-      if self.bias then self.output:addr(1, self.addBuffer, self.bias) end
+      if self.bias then
+         -- only update buffer if bias
+         self:updateAddBuffer(input)
+         self.output:addr(1, self.addBuffer, self.bias)
+      end
    else
       error('input must be vector or matrix')
    end


### PR DESCRIPTION
This should save ns and memory when the `bias` parameter is not used. When the `input` size is large, there would be a difference in memory footprint, but that's it.